### PR TITLE
Fix tabs in README.md 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,33 +24,33 @@ $ npm install --save ink
 const {h, mount, Component, Text} = require('ink');
 
 class Counter extends Component {
-	constructor() {
-		super();
+  constructor() {
+    super();
 
-		this.state = {
-			i: 0
-		};
-	}
+    this.state = {
+      i: 0
+    };
+  }
 
-	render() {
-		return (
-			<Text green>
-				{this.state.i} tests passed
-			</Text>
-		);
-	}
+  render() {
+    return (
+      <Text green>
+        {this.state.i} tests passed
+      </Text>
+    );
+  }
 
-	componentDidMount() {
-		this.timer = setInterval(() => {
-			this.setState({
-				i: this.state.i + 1
-			});
-		}, 100);
-	}
+  componentDidMount() {
+    this.timer = setInterval(() => {
+      this.setState({
+        i: this.state.i + 1
+      });
+    }, 100);
+  }
 
-	componentWillUnmount() {
-		clearInterval(this.timer);
-	}
+  componentWillUnmount() {
+    clearInterval(this.timer);
+  }
 }
 
 mount(<Counter/>, process.stdout);
@@ -114,36 +114,36 @@ Default: `process.stdout`
 const {h, mount, Component} = require('ink');
 
 class Counter extends Component {
-	constructor() {
-		super();
+  constructor() {
+    super();
 
-		this.state = {
-			i: 0
-		};
-	}
+    this.state = {
+      i: 0
+    };
+  }
 
-	render(props, state) {
-		return `Iteration #${state.i}`;
-	}
+  render(props, state) {
+    return `Iteration #${state.i}`;
+  }
 
-	componentDidMount() {
-		this.timer = setInterval(() => {
-			this.setState({
-				i: this.state.i + 1
-			});
-		}, 100);
-	}
+  componentDidMount() {
+    this.timer = setInterval(() => {
+      this.setState({
+        i: this.state.i + 1
+      });
+    }, 100);
+  }
 
-	componentWillUnmount() {
-		clearInterval(this.timer);
-	}
+  componentWillUnmount() {
+    clearInterval(this.timer);
+  }
 }
 
 const unmount = mount(<Counter/>);
 
 setTimeout(() => {
-	// enough counting
-	unmount();
+  // enough counting
+  unmount();
 }, 1000);
 ```
 
@@ -173,13 +173,13 @@ Unlike stateless function components, they have access to state, context, lifecy
 
 ```js
 class Demo extends Component {
-	render(props, state, context) {
-		// props === this.props
-		// state === this.state
-		// context === this.context
+  render(props, state, context) {
+    // props === this.props
+    // state === this.state
+    // context === this.context
 
-		return 'Hello World';
-	}
+    return 'Hello World';
+  }
 }
 ```
 
@@ -187,13 +187,13 @@ If you need to extend the constructor to set the initial state or for other purp
 
 ```js
 constructor(props, context) {
-	super(props, context);
+  super(props, context);
 
-	this.state = {
-		i: 0
-	};
+  this.state = {
+    i: 0
+  };
 
-	// other initialization
+  // other initialization
 }
 ```
 
@@ -204,17 +204,17 @@ Every parent component can pass props to their children.
 
 ```jsx
 class Child extends Component {
-	render(props) {
-		// props === this.props
+  render(props) {
+    // props === this.props
 
-		return `Hello, ${props.name}`;
-	}
+    return `Hello, ${props.name}`;
+  }
 }
 
 class Parent extends Component {
-	render() {
-		return <Child name="Joe"/>;
-	}
+  render() {
+    return <Child name="Joe"/>;
+  }
 }
 ```
 
@@ -264,17 +264,17 @@ Anywhere in the component state is accessible via `this.state`, and it's also pa
 
 ```js
 class Demo extends Component {
-	constructor(props, context) {
-		super(props, context);
+  constructor(props, context) {
+    super(props, context);
 
-		this.state = {
-			i: 0
-		}
-	}
+    this.state = {
+      i: 0
+    }
+  }
 
-	render(props, state) {
-		return `Iteration ${state.i}`;
-	}
+  render(props, state) {
+    return `Iteration ${state.i}`;
+  }
 }
 ```
 
@@ -291,23 +291,23 @@ Set a new state and update the output.
 
 ```js
 class Demo extends Component {
-	constructor(props, context) {
-		super(props, context);
+  constructor(props, context) {
+    super(props, context);
 
-		this.state = {
-			i: 0
-		}
-	}
+    this.state = {
+      i: 0
+    }
+  }
 
-	render(props, state) {
-		return `Iteration ${state.i}`;
-	}
+  render(props, state) {
+    return `Iteration ${state.i}`;
+  }
 
-	componentDidMount() {
-		this.setState({
-			i: this.state.i + 1
-		});
-	}
+  componentDidMount() {
+    this.setState({
+      i: this.state.i + 1
+    });
+  }
 }
 ```
 
@@ -318,9 +318,9 @@ The same effect of incrementing `i` could be achieved in a following way:
 
 ```js
 this.setState(state => {
-	return {
-		i: state.i + 1
-	}
+  return {
+    i: state.i + 1
+  }
 });
 ```
 
@@ -338,43 +338,43 @@ Prop's value must be a function, which receives a reference to a component as an
 
 ```jsx
 class Child extends Component {
-	render() {
-		return null;
-	}
+  render() {
+    return null;
+  }
 
-	hello() {
-		return 'Hello World';
-	}
+  hello() {
+    return 'Hello World';
+  }
 }
 
 class Parent extends Component {
-	constructor(props, context) {
-		super(props, context);
+  constructor(props, context) {
+    super(props, context);
 
-		this.state = {
-			message: 'Ink is awesome'
-		};
-	}
+    this.state = {
+      message: 'Ink is awesome'
+    };
+  }
 
-	render(props, state) {
-		const setChildRef = ref => {
-			this.childRef = ref;
-		};
+  render(props, state) {
+    const setChildRef = ref => {
+      this.childRef = ref;
+    };
 
-		return (
-			<div>
-				{message}
+    return (
+      <div>
+        {message}
 
-				<Child ref={setChildRef}/>
-			</div>
-		)
-	}
+        <Child ref={setChildRef}/>
+      </div>
+    )
+  }
 
-	componentDidMount() {
-		this.setState({
-			message: this.childRef.hello()
-		});
-	}
+  componentDidMount() {
+    this.setState({
+      message: this.childRef.hello()
+    });
+  }
 }
 ```
 
@@ -385,7 +385,7 @@ Every component can access context either via `this.context` or inside `render()
 
 ```js
 render(props, state, context) {
-	// context === this.context
+  // context === this.context
 }
 ```
 
@@ -393,21 +393,21 @@ To add new entries to context, add `getChildContext()` method to your component:
 
 ```js
 class Child extends Component {
-	render() {
-		return this.context.message;
-	}
+  render() {
+    return this.context.message;
+  }
 }
 
 class Parent extends Component {
-	getChildContext() {
-		return {
-			message: 'Hello World'
-		};
-	}
+  getChildContext() {
+    return {
+      message: 'Hello World'
+    };
+  }
 
-	render() {
-		return <Child/>;
-	}
+  render() {
+    return <Child/>;
+  }
 }
 ```
 
@@ -419,9 +419,9 @@ Using stateful components:
 
 ```js
 class Demo extends Component {
-	render(props, state, context) {
-		return 'Hello World';
-	}
+  render(props, state, context) {
+    return 'Hello World';
+  }
 }
 ```
 
@@ -442,9 +442,9 @@ This won't work:
 
 ```jsx
 const Demo = (
-	<A/>
-	<B/>
-	<C/>
+  <A/>
+  <B/>
+  <C/>
 );
 ```
 
@@ -452,11 +452,11 @@ This will:
 
 ```jsx
 const Demo = (
-	<div>
-		<A/>
-		<B/>
-		<C/>
-	</div>
+  <div>
+    <A/>
+    <B/>
+    <C/>
+  </div>
 );
 ```
 
@@ -464,11 +464,11 @@ There's also `<br/>`, which serves the same purpose as on the web - a newline.
 
 ```jsx
 const Demo = (
-	<div>
-		Line 1
-		<br/>
-		Line 2
-	</div>
+  <div>
+    Line 1
+    <br/>
+    Line 2
+  </div>
 );
 ```
 


### PR DESCRIPTION
This PR fixes some of the display issues that come with tabs and GitHub so that the README is more readable:

Before: 

<img width="420" alt="screen shot 2017-07-09 at 4 28 55 pm" src="https://user-images.githubusercontent.com/236943/27998429-baa438c0-64c3-11e7-9be7-37e5f708b03b.png">


After: 

<img width="259" alt="screen shot 2017-07-09 at 4 26 59 pm" src="https://user-images.githubusercontent.com/236943/27998419-a5abfd4a-64c3-11e7-9fc9-349c899eb779.png">
