### PR TITLE
add docs example for setting JSX pragma to `h`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,18 +89,20 @@ The key difference you have to remember is that the rendering result isn't a DOM
 
 ### Getting Started
 
-To ensure all examples work and you can begin your adventure with Ink, make sure to set up a JSX transpiler and set JSX pragma to `h`. You can use [`babel-plugin-transform-react-jsx`](https://babeljs.io/docs/plugins/transform-react-jsx/) to do this. For example, in `.babelrc`:
+To ensure all examples work and you can begin your adventure with Ink, make sure to set up a JSX transpiler and set JSX pragma to `h`. You can use [`babel-plugin-transform-react-jsx`](https://babeljs.io/docs/plugins/transform-react-jsx/) to do this. For example, in `package.json`:
 
 ```json
 {
-  "plugins": [
-    [
-      "transform-react-jsx",
-      {
-        "pragma": "h"
-      }
-    ]
-  ]
+	"babel": {
+		"plugins": [
+			[
+				"transform-react-jsx",
+				{
+				  "pragma": "h"
+				}
+			]
+		]
+	}
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,22 @@ The key difference you have to remember is that the rendering result isn't a DOM
 
 ### Getting Started
 
-To ensure all examples work and you can begin your adventure with Ink, make sure to set up a JSX transpiler and set JSX pragma to `h`. Don't forget to import `h` into every file that contains JSX.
+To ensure all examples work and you can begin your adventure with Ink, make sure to set up a JSX transpiler and set JSX pragma to `h`. You can use [`babel-plugin-transform-react-jsx`](https://babeljs.io/docs/plugins/transform-react-jsx/) to do this. For example, in `.babelrc`:
+
+```json
+{
+  "plugins": [
+    [
+      "transform-react-jsx",
+      {
+        "pragma": "h"
+      }
+    ]
+  ]
+}
+```
+
+Don't forget to import `h` into every file that contains JSX:
 
 ```jsx
 const {h} = require('ink');


### PR DESCRIPTION
Show an example `.babelrc` for setting JSX pragma to `h`, and specify the necessary babel plugin.