### PR TITLE
Disable input in a non-tty environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,10 @@ exports.render = (tree, options) => {
 	let currentTree;
 
 	readline.emitKeypressEvents(stdin);
-	stdin.setRawMode(true);
+
+	if (stdin.isTTY) {
+		stdin.setRawMode(true);
+	}
 
 	const update = () => {
 		const nextTree = build(tree, currentTree, onUpdate, context, false); // eslint-disable-line no-use-before-define
@@ -85,8 +88,10 @@ exports.render = (tree, options) => {
 		}
 	};
 
-	stdin.on('keypress', onKeyPress);
-	stdout.on('resize', update);
+	if (stdin.isTTY) {
+		stdin.on('keypress', onKeyPress);
+		stdout.on('resize', update);
+	}
 
 	const consoleMethods = ['dir', 'log', 'info', 'warn', 'error'];
 
@@ -110,10 +115,12 @@ exports.render = (tree, options) => {
 			return;
 		}
 
-		stdin.setRawMode(false);
-		stdin.removeListener('keypress', onKeyPress);
-		stdin.pause();
-		stdout.removeListener('resize', update);
+		if (stdin.isTTY) {
+			stdin.setRawMode(false);
+			stdin.removeListener('keypress', onKeyPress);
+			stdin.pause();
+			stdout.removeListener('resize', update);
+		}
 
 		isUnmounted = true;
 		unmount(currentTree);

--- a/test/render.js
+++ b/test/render.js
@@ -11,6 +11,7 @@ const createStdin = () => {
 	const stdin = new EventEmitter();
 	stdin.setRawMode = spy();
 	stdin.pause = spy();
+	stdin.isTTY = spy();
 
 	return stdin;
 };


### PR DESCRIPTION
Hello, 

This pull request closes issue #40. It check if the current env is TTY then attach `stdin` / `stdout` events and settings.

Here's what I did to test these changes : 

```
# Launching a script normally
node index.js

# Launching a script in a non-TTY env.
node index.js | cat
```

Both are printing and exiting the script successfully.

Side note, I tried to launch tests but it failed because of a "loose" option with babel. Just ask me if I should create an issue about this or if I just miss something.