### PR TITLE
Create Renderer class

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ exports.Component = Component;
 exports.h = h;
 exports.Indent = Indent;
 exports.Text = Text;
+exports.Renderer = Renderer;
 
 const noop = () => {};
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const {EventEmitter} = require('events');
+const renderToString = require('./render-to-string');
+const diff = require('./diff');
+
+const noop = () => {};
+
+const build = (nextTree, prevTree, onUpdate = noop, context = {}) => {
+	return diff(prevTree, nextTree, onUpdate, context);
+};
+
+class Renderer extends EventEmitter {
+	constructor(tree) {
+		super();
+
+		this.tree = tree;
+		this.context = {};
+		this.isUnmounted = false;
+		this.update = this.update.bind(this);
+		this.onUpdate = this.onUpdate.bind(this);
+	}
+
+	update() {
+		const nextTree = build(this.tree, this.currentTree, this.onUpdate, this.context);
+
+		this.emit('update', renderToString(nextTree));
+		this.currentTree = nextTree;
+	}
+
+	onUpdate() {
+		if (!this.isUnmounted) {
+			this.update();
+		}
+	}
+
+	unmount() {
+		if (!this.isUnmounted) {
+			this.isUnmounted = true;
+
+			build(null, this.currentTree);
+		}
+	}
+}
+
+module.exports = Renderer;


### PR DESCRIPTION
Fixes #61

the `Renderer` class takes a tree as an argument when constructed (`new Renderer(tree)`). It implements `EventEmitter` and emits an `update` event every time the tree updates. 

This makes creates an easy way to render a component with its lifecycle and get updates without involving stdin/stdout. 

The classic render method is re-written using this class, and calls the log-update's `log` with the updated component on `update`. 