### PR TITLE
Add 'ink-text-animation' to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,7 @@ render(<Counter/>);
 - [ink-link](https://github.com/sindresorhus/ink-link) - Link component.
 - [ink-select](https://github.com/karaggeorge/ink-select) - Select component.
 - [ink-scrollbar](https://github.com/karaggeorge/ink-scrollbar) - Scrollbar component.
+- [ink-text-animation](https://github.com/yardnsm/ink-text-animation) - A text animation component.
 
 ## Built with Ink
 

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ render(<Counter/>);
 - [ink-link](https://github.com/sindresorhus/ink-link) - Link component.
 - [ink-select](https://github.com/karaggeorge/ink-select) - Select component.
 - [ink-scrollbar](https://github.com/karaggeorge/ink-scrollbar) - Scrollbar component.
-- [ink-text-animation](https://github.com/yardnsm/ink-text-animation) - A text animation component.
+- [ink-text-animation](https://github.com/yardnsm/ink-text-animation) - Text animation component.
 
 ## Built with Ink
 


### PR DESCRIPTION
I created a small component that can animate text, which uses [chalk-animation](https://github.com/bokub/chalk-animation) under the hood. This PR adds a link to the project in the README.