### PR TITLE
Support JSX fragments

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const Underline = require('./lib/components/underline');
 exports.StringComponent = StringComponent;
 exports.Component = Component;
 exports.h = h;
+exports.Fragment = h.Fragment;
 exports.Indent = Indent;
 exports.Color = Color;
 exports.Underline = Underline;

--- a/lib/h.js
+++ b/lib/h.js
@@ -3,7 +3,7 @@
 const flatten = require('lodash.flattendeep');
 const VNode = require('./vnode');
 
-module.exports = (component, props, ...children) => {
+const h = (component, props, ...children) => {
 	if (typeof component !== 'function' && typeof component !== 'string') {
 		throw new TypeError(`Expected component to be a function, but received ${typeof component}. You may have forgotten to export a component.`);
 	}
@@ -40,3 +40,7 @@ module.exports = (component, props, ...children) => {
 
 	return new VNode(component, props);
 };
+
+h.Fragment = ({children}) => children;
+
+module.exports = h;

--- a/package.json
+++ b/package.json
@@ -48,13 +48,14 @@
 		"@babel/plugin-transform-react-jsx": "^7.0.0-beta.44",
 		"@babel/register": "^7.0.0-beta.44",
 		"ansi-styles": "^3.1.0",
+		"ava": "^1.0.0-beta.3",
+		"babel-eslint": "^8.2.2",
 		"eslint-config-xo-react": "^0.13.0",
 		"eslint-plugin-react": "^7.1.0",
 		"sinon": "^2.3.4",
 		"strip-ansi": "^4.0.0",
 		"svg-term-cli": "^2.1.1",
-		"xo": "^0.18.2",
-		"ava": "^1.0.0-beta.3"
+		"xo": "^0.18.2"
 	},
 	"ava": {
 		"require": [
@@ -87,12 +88,13 @@
 				"pragmaFrag": "h.Fragment"
 			}
 		},
-		"ignores": ["test/components.js"],
+		"parser": "babel-eslint",
 		"overrides": [
 			{
 				"files": "test/*.js",
 				"rules": {
-					"react/prop-types": 0
+					"react/prop-types": 0,
+					"quotes": 0
 				}
 			}
 		]

--- a/package.json
+++ b/package.json
@@ -44,33 +44,37 @@
 		"prop-types": "^15.5.10"
 	},
 	"devDependencies": {
+		"@babel/core": "^7.0.0-beta.44",
+		"@babel/plugin-transform-react-jsx": "^7.0.0-beta.44",
+		"@babel/register": "^7.0.0-beta.44",
 		"ansi-styles": "^3.1.0",
-		"ava": "^0.21.0",
-		"babel-plugin-transform-react-jsx": "^6.24.1",
-		"babel-register": "^6.24.1",
 		"eslint-config-xo-react": "^0.13.0",
 		"eslint-plugin-react": "^7.1.0",
 		"sinon": "^2.3.4",
 		"strip-ansi": "^4.0.0",
 		"svg-term-cli": "^2.1.1",
-		"xo": "^0.18.2"
+		"xo": "^0.18.2",
+		"ava": "^1.0.0-beta.3"
 	},
 	"ava": {
 		"require": [
-			"babel-register"
+			"@babel/register"
 		],
 		"babel": {
-			"presets": [
-				"@ava/stage-4"
-			],
-			"plugins": [
-				[
-					"transform-react-jsx",
-					{
-						"pragma": "h"
-					}
+			"testOptions": {
+				"presets": [
+					"@ava/stage-4"
+				],
+				"plugins": [
+					[
+						"@babel/plugin-transform-react-jsx",
+						{
+							"pragma": "h",
+							"pragmaFrag": "h.Fragment"
+						}
+					]
 				]
-			]
+			}
 		}
 	},
 	"xo": {
@@ -79,9 +83,11 @@
 		],
 		"settings": {
 			"react": {
-				"pragma": "h"
+				"pragma": "h",
+				"pragmaFrag": "h.Fragment"
 			}
 		},
+		"ignores": ["test/components.js"],
 		"overrides": [
 			{
 				"files": "test/*.js",

--- a/readme.md
+++ b/readme.md
@@ -534,9 +534,9 @@ const {h, Fragment} = require('ink');
 
 render(
 	<Fragment>
-		<A />
-		<B />
-		<C />
+		<A/>
+		<B/>
+		<C/>
 	</Fragment>
 );
 ```

--- a/readme.md
+++ b/readme.md
@@ -530,8 +530,6 @@ Ink also supports Fragments for returning multiple children from a component's r
 ```jsx
 const {h, Fragment} = require('ink');
 
-// ...
-
 render(
 	<Fragment>
 		<A/>
@@ -545,8 +543,6 @@ Or using the shorthand syntax:
 
 ```jsx
 const {h} = require('ink');
-
-// ...
 
 render(
 	<>

--- a/readme.md
+++ b/readme.md
@@ -528,18 +528,26 @@ const Demo = (
 Ink also supports Fragments for returning multiple children from a component's render method.
 
 ```jsx
+const {h, Fragment} = require('ink');
+
+// ...
+
 render(
-	<h.Fragment>
-		<A/>
-		<B/>
-		<C/>
-	</h.Fragment>
+	<Fragment>
+		<A />
+		<B />
+		<C />
+	</Fragment>
 );
 ```
 
 Or using the shorthand syntax:
 
 ```jsx
+const {h} = require('ink');
+
+// ...
+
 render(
 	<>
 		<A/>

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ render(<Counter/>);
 ```
 
 <p align="center">
-  <img src="media/demo.svg" width="600">
+	<img src="media/demo.svg" width="600">
 </p>
 
 ## Useful Components
@@ -114,7 +114,7 @@ To ensure all examples work and you can begin your adventure with Ink, make sure
 			[
 				"transform-react-jsx",
 				{
-				  "pragma": "h"
+					"pragma": "h"
 				}
 			]
 		]
@@ -498,20 +498,8 @@ As you may have noticed, stateless function components still get access to props
 #### Built-in Components
 
 Surprise, surprise, our favorite `<div>` and `<span>` can be used in Ink components!
-They are useful for grouping elements, since JSX doesn't allow multiple elements without a parent.
+They are useful for grouping elements
 The only difference between `<div>` and `<span>` is that `<div>` inserts a newline after children.
-
-This won't work:
-
-```jsx
-const Demo = (
-	<A/>
-	<B/>
-	<C/>
-);
-```
-
-This will:
 
 ```jsx
 const Demo = (
@@ -534,6 +522,51 @@ const Demo = (
 	</div>
 );
 ```
+
+Ink also supports Fragments for returning multiple children from a component's render method.
+
+```jsx
+render(
+	<h.Fragment>
+		<A />
+		<B />
+		<C />
+	</h.Fragment>
+);
+```
+
+Or using the shorthand syntax:
+
+```jsx
+render(
+	<>
+		<A />
+		<B />
+		<C />
+	</>
+);
+```
+
+To use the Fragments make sure you have `pragmaFrag` in your configuration:
+
+```json
+{
+	"babel": {
+		"plugins": [
+			[
+				"@babel/plugin-transform-react-jsx",
+				{
+					"pragma": "h",
+					"pragmaFrag": "h.Fragment"
+				}
+			]
+		]
+	}
+}
+```
+
+You will also need [Babel v7.0.0-beta.31](https://github.com/babel/babel/releases/tag/v7.0.0-beta.31) or above, which means you will also need to upgrade any other tools that use babel to their compatible versions like [@babel/plugin-transform-react-jsx](https://www.npmjs.com/package/@babel/plugin-transform-react-jsx) and [@babel/core](https://www.npmjs.com/package/@babel/core).
+
 
 The `<Text>` compoment is a simple wrapper around [the `chalk` API](https://github.com/chalk/chalk#api) it supports all of the chalk methods as `props`.
 

--- a/readme.md
+++ b/readme.md
@@ -528,9 +528,9 @@ Ink also supports Fragments for returning multiple children from a component's r
 ```jsx
 render(
 	<h.Fragment>
-		<A />
-		<B />
-		<C />
+		<A/>
+		<B/>
+		<C/>
 	</h.Fragment>
 );
 ```
@@ -540,9 +540,9 @@ Or using the shorthand syntax:
 ```jsx
 render(
 	<>
-		<A />
-		<B />
-		<C />
+		<A/>
+		<B/>
+		<C/>
 	</>
 );
 ```
@@ -565,7 +565,7 @@ To use the Fragments make sure you have `pragmaFrag` in your configuration:
 }
 ```
 
-You will also need [Babel v7.0.0-beta.31](https://github.com/babel/babel/releases/tag/v7.0.0-beta.31) or above, which means you will also need to upgrade any other tools that use babel to their compatible versions like [@babel/plugin-transform-react-jsx](https://www.npmjs.com/package/@babel/plugin-transform-react-jsx) and [@babel/core](https://www.npmjs.com/package/@babel/core).
+You will also need [Babel v7.0.0-beta.31](https://github.com/babel/babel/releases/tag/v7.0.0-beta.31) or above, which means you will also need to upgrade any other tools that use Babel to their compatible versions, like [@babel/plugin-transform-react-jsx](https://www.npmjs.com/package/@babel/plugin-transform-react-jsx) and [@babel/core](https://www.npmjs.com/package/@babel/core).
 
 
 The `<Text>` compoment is a simple wrapper around [the `chalk` API](https://github.com/chalk/chalk#api) it supports all of the chalk methods as `props`.

--- a/test/components.js
+++ b/test/components.js
@@ -666,3 +666,13 @@ test('indent text', t => {
 	t.is(renderToString(build(<Indent size={2}>Test</Indent>)), '  Test');
 	t.is(renderToString(build(<Indent size={2} indent="_">Test</Indent>)), '__Test');
 });
+
+test('render fragments', t => {
+	t.is(renderToString(build(
+		<>
+			<span>one</span>
+			<span>two</span>
+			<span>three</span>
+		</>
+	)), 'onetwothree');
+});


### PR DESCRIPTION
Fixes #46

This adds support for using the new React Fragments `<></>`. 
However: `plugin-transform-react-jsx` only supports them from babel v7 and on, which has no moved to `@babel/plugin-transform-react-jsx`, which requires `@babel/core`, which would mean `@babel/register` should be used instead of `babel-register`. Again, in order to use babel 7, ava had to be bumped to use the new `1.0.0-beta` versions. 

Coulnd't get xo to play nice with the fragments. I kept getting this error:
```
test/components.js:672:6
  ✖  672:6  Parsing error: Unexpected token >  
```
Maybe @sindresorhus can help me figure out how to get xo to recognize them.

This would also mean that every package that uses ink, should also upgrade to the new babel versions. 

A less invasive way of introducing fragments would be to ommit the shorthand `<></>` syntax and jsut add a `<Fragment></Fragment>` component which would basically be a `span`. That wouldn't require any new package versions.