### PR TITLE
context passed in contructor

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -29,7 +29,7 @@ const mount = (vnode, context, onUpdate) => {
 	checkPropTypes(vnode.component, props);
 
 	if (isClassComponent(vnode.component)) {
-		vnode.createInstance(props);
+		vnode.createInstance(props, context);
 		vnode.instance._onUpdate = onUpdate;
 		vnode.instance.context = Object.assign(context, vnode.instance.getChildContext());
 		vnode.instance.componentWillMount();

--- a/lib/vnode.js
+++ b/lib/vnode.js
@@ -47,9 +47,9 @@ class VNode {
 		return this._children;
 	}
 
-	createInstance(props) {
+	createInstance(props, context = {}) {
 		if (isClassComponent(this.component)) {
-			this.instance = new this.component(props, {}); // eslint-disable-line new-cap
+			this.instance = new this.component(props, context); // eslint-disable-line new-cap
 		}
 	}
 }

--- a/test/context.js
+++ b/test/context.js
@@ -128,3 +128,31 @@ test('receive context in a functional component', t => {
 
 	t.is(renderToString(<Outer/>), 'Phoebe');
 });
+
+test('receive context in constructor arguments', t => {
+	class Outer extends Component {
+		render() {
+			return <Inner/>;
+		}
+
+		getChildContext() {
+			return {
+				name: 'Joey'
+			};
+		}
+	}
+
+	class Inner extends Component {
+		constructor(...args) {
+			super(...args);
+
+			this.name = this.context.name;
+		}
+
+		render() {
+			return this.name;
+		}
+	}
+
+	t.is(renderToString(<Outer/>), 'Joey');
+});


### PR DESCRIPTION
This is bug fix PR.

``` js
class Outer extends Component {
  getChildContext () {
    return { name: 'Joey' };
  }

  render () {
    return <Inner />
  }
}

class Inner extends Component {
  constructor (...args) {
    super(...args);
    
    console.log(this.context.name) // FIX: undefined => 'Joey'
  }

  render () {
    render this.context.name;
  } 
}
```