### PR TITLE
fix indent in README Usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ $ npm install ink
 ## Usage
 
 ```jsx
-const {h, render, Component, Color } = require('ink');
+const {h, render, Component, Color} = require('ink');
 
 class Counter extends Component {
 	constructor() {


### PR DESCRIPTION
I fixed indent different from other lines in README Usage.
I unified it in the same format because parentheses were closed in other lines.
```diff
- const {h, render, Component, Color } = require('ink');
+ const {h, render, Component, Color} = require('ink');
```
