### PR TITLE
Next: Use reconciler api to create text nodes

### DIFF
--- a/src/create-reconciler.js
+++ b/src/create-reconciler.js
@@ -10,14 +10,7 @@ import {
 
 const applyProps = (node, props) => {
 	for (const [key, value] of Object.entries(props)) {
-		if (key === 'children') {
-			if (typeof value === 'string' || typeof value === 'number') {
-				// Text node must be wrapped in another node, so that text can be aligned within container
-				const textElement = createNode('span');
-				textElement.textContent = value;
-				appendChildNode(node, textElement);
-			}
-		} else if (key === 'style') {
+		if (key === 'style') {
 			Object.assign(node.style, value);
 		} else if (key === 'unstable__transformChildren') {
 			node.unstable__transformChildren = value; // eslint-disable-line camelcase
@@ -39,9 +32,7 @@ export default onRender => {
 		prepareForCommit: () => {},
 		resetAfterCommit: () => {},
 		getChildHostContext: () => childHostContext,
-		shouldSetTextContent: (type, props) => {
-			return typeof props.children === 'string' || typeof props.children === 'number';
-		},
+		shouldSetTextContent: () => false,
 		createInstance: (type, newProps) => {
 			const node = createNode(type);
 			applyProps(node, newProps);

--- a/src/dom.js
+++ b/src/dom.js
@@ -31,7 +31,8 @@ export const setAttribute = (node, key, value) => {
 	node.attributes[key] = value;
 };
 
-export const createTextNode = text => ({
-	nodeName: '#text',
-	nodeValue: text
-});
+export const createTextNode = text => {
+	const textNode = createNode('span');
+	textNode.textContent = text;
+	return textNode;
+};


### PR DESCRIPTION
Hi,

first thanks for your great work! :)

While playing around with the `next` branch I've found that text nodes are not rendered correctly when they are the only child.
E.g. the spinner (copied from `ink-spinner` and made compatible with `next`, I will create a separate PR for this)
```javascript
"use strict";

const { Color, render } = require("ink");
const React = require("react");
const spinners = require("cli-spinners");
const omit = require("object.omit");

class Spinner extends React.Component {
	constructor() {
		super();
		this.state = { frame: 0 };
		this.switchFrame = this.switchFrame.bind(this);
	}

	getSpinner() {
		return spinners[this.props.type] || spinners.dots;
	}

	render() {
		const colorProps = omit(this.props, "type");
		const spinner = this.getSpinner();
		const frame = spinner.frames[this.state.frame];
		return <Color {...colorProps}>{frame}</Color>;
	}

	componentDidMount() {
		const spinner = this.getSpinner();
		this.timer = setInterval(this.switchFrame, spinner.interval);
	}

	componentWillUnmount() {
		clearInterval(this.timer);
	}

	switchFrame() {
		const { frame } = this.state;
		const spinner = this.getSpinner();
		const isLastFrame = frame === spinner.frames.length - 1;
		const nextFrame = isLastFrame ? 0 : frame + 1;

		this.setState({ frame: nextFrame });
	}
}

render(<Spinner>);
```

It prints:
```
⠋⠹⠙⠹⠸⠼⠴⠦⠧⠇⠏⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏⠋⠙⠹...
# (the output is growing)
```

This only happens, when there is only one child with type string. If we change the render method to `return <Color {...colorProps}>{frame}{frame}</Color>;` (two childs with type string), everything works as expected.

I found out that the implemented `reconciler` logic creates and adds always a new childNode, if the `children` property is of type string (or number).

After digging some time in the react repo I also found out that if you really want to wrap all text nodes in another node (as the comment is saying in the `create-reconciler.js#15` file), you should disable the `shouldSetTextContent` hook and use `createTextInstance` to create these text nodes in the host config.

I'm not sure if this will break something or not. So please review these changes carefully. :)