### PR TITLE
Add live demo to README.md

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+tasks:
+- init: npm install
+  command: node media/demo.js

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,12 @@ render(<Counter/>);
 	<img src="media/demo.svg" width="600">
 </p>
 
+## Live Demo
+
+Play with the example above in a free pre-configured online workspace:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/vadimdemedes/ink/blob/master/media/demo.js)
+
 ## Useful Components
 
 - [ink-redux](https://github.com/vadimdemedes/ink-redux) - Redux bindings.


### PR DESCRIPTION
Hi, thanks for making Ink! It's a really cool project.

I work on [gitpod.io](https://gitpod.io), and I thought you might like to have a live demo in your README.md, so I created one for you. Gitpod provides free online workspaces, and I've configured it to initialize this project with `npm install`, open `media/demo.js` in the editor, and run the demo with `node media/demo.js`.

Here is what it looks like:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/0e3fcd17-f401-42b8-aee4-ff64a957ac63)
<img width="1552" alt="screenshot 2019-01-29 at 13 42 11" src="https://user-images.githubusercontent.com/599268/51909560-3f5f7880-23cd-11e9-83ab-f3f150ddca9a.png">

Please let me know what you think. 🙂 