### PR TITLE
Fix waitUntilExit TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,7 +39,7 @@ export type Instance = {
 	/**
 	 * Returns a promise, which resolves when app is unmounted.
 	 */
-	waitUntilExit: Promise<void>;
+	waitUntilExit: () => Promise<void>;
 };
 
 export type Unmount = () => void;


### PR DESCRIPTION
`waitUntilExit` is a function that returns a promise, rather than a promise itself