### PR TITLE
Allow passing an error on exit

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -182,7 +182,7 @@ export const AppContext: React.Context<{
 	/**
 	 * Exit (unmount) the whole Ink app.
 	 */
-	readonly exit: () => void;
+	readonly exit: (error?: Error) => void;
 }>;
 
 /**

--- a/readme.md
+++ b/readme.md
@@ -707,6 +707,8 @@ Usage:
 </AppContext.Consumer>
 ```
 
+If `exit` is called with an Error, `waitUntilExit` will reject with the error.
+
 #### `<StdinContext>`
 
 `<StdinContext>` is a [React context](https://reactjs.org/docs/context.html#reactcreatecontext), which exposes input stream.

--- a/readme.md
+++ b/readme.md
@@ -707,7 +707,7 @@ Usage:
 </AppContext.Consumer>
 ```
 
-If `exit` is called with an Error, `waitUntilExit` will reject with the error.
+If `exit` is called with an Error, `waitUntilExit` will reject with that error.
 
 #### `<StdinContext>`
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -93,8 +93,8 @@ export default class App extends PureComponent {
 		}
 	};
 
-	handleExit = () => {
+	handleExit = error => {
 		this.handleSetRawMode(false);
-		this.props.onExit();
+		this.props.onExit(error);
 	}
 }

--- a/src/instance.js
+++ b/src/instance.js
@@ -38,8 +38,9 @@ export default class Instance {
 
 		this.container = reconciler.createContainer(this.rootNode, false, false);
 
-		this.exitPromise = new Promise(resolve => {
+		this.exitPromise = new Promise((resolve, reject) => {
 			this.resolveExitPromise = resolve;
+			this.rejectExitPromise = reject;
 		});
 	}
 
@@ -94,12 +95,16 @@ export default class Instance {
 		reconciler.updateContainer(tree, this.container);
 	}
 
-	unmount() {
+	unmount(error) {
 		this.onRender();
 		this.log.done();
 		this.ignoreRender = true;
 		reconciler.updateContainer(null, this.container);
-		this.resolveExitPromise();
+		if (error instanceof Error) {
+			this.rejectExitPromise(error);
+		} else {
+			this.resolveExitPromise();
+		}
 	}
 
 	waitUntilExit() {

--- a/src/render.js
+++ b/src/render.js
@@ -31,7 +31,7 @@ export default (node, options = {}) => {
 
 	return {
 		rerender: instance.render,
-		unmount: instance.unmount,
+		unmount: () => instance.unmount(),
 		waitUntilExit: instance.waitUntilExit,
 		cleanup: () => instances.delete(options.stdout)
 	};

--- a/test/exit.js
+++ b/test/exit.js
@@ -47,9 +47,19 @@ test('exit on exit()', async t => {
 	t.true(output.includes('exited'));
 });
 
+test('exit on exit() with error', async t => {
+	const output = await run('exit-on-exit-with-error');
+	t.true(output.includes('errored'));
+});
+
 test('exit on exit() with raw mode', async t => {
 	const output = await run('exit-raw-on-exit');
 	t.true(output.includes('exited'));
+});
+
+test('exit on exit() with raw mode with error', async t => {
+	const output = await run('exit-raw-on-exit-with-error');
+	t.true(output.includes('errored'));
 });
 
 test('exit on unmount() with raw mode', async t => {

--- a/test/fixtures/exit-on-exit-with-error.js
+++ b/test/fixtures/exit-on-exit-with-error.js
@@ -1,0 +1,44 @@
+/* eslint-disable react/prop-types */
+'use strict';
+const React = require('react');
+const {render, Box, AppContext} = require('../..');
+
+class Test extends React.Component {
+	constructor() {
+		super();
+
+		this.state = {
+			counter: 0
+		};
+	}
+
+	render() {
+		return (
+			<Box>Counter: {this.state.counter}</Box>
+		);
+	}
+
+	componentDidMount() {
+		setTimeout(() => this.props.onExit(new Error('errored')), 500);
+
+		this.timer = setInterval(() => {
+			this.setState(prevState => ({
+				counter: prevState.counter + 1
+			}));
+		}, 100);
+	}
+
+	componentWillUnmount() {
+		clearInterval(this.timer);
+	}
+}
+
+const app = render((
+	<AppContext.Consumer>
+		{({exit}) => (
+			<Test onExit={exit}/>
+		)}
+	</AppContext.Consumer>
+));
+
+app.waitUntilExit().catch(error => console.log(error.message));

--- a/test/fixtures/exit-raw-on-exit-with-error.js
+++ b/test/fixtures/exit-raw-on-exit-with-error.js
@@ -1,0 +1,31 @@
+/* eslint-disable react/prop-types */
+'use strict';
+const React = require('react');
+const {render, Box, AppContext, StdinContext} = require('../..');
+
+class Test extends React.Component {
+	render() {
+		return (
+			<Box>Hello World</Box>
+		);
+	}
+
+	componentDidMount() {
+		this.props.onSetRawMode(true);
+		setTimeout(() => this.props.onExit(new Error('errored')), 500);
+	}
+}
+
+const app = render((
+	<AppContext.Consumer>
+		{({exit}) => (
+			<StdinContext.Consumer>
+				{({setRawMode}) => (
+					<Test onExit={exit} onSetRawMode={setRawMode}/>
+				)}
+			</StdinContext.Consumer>
+		)}
+	</AppContext.Consumer>
+));
+
+app.waitUntilExit().catch(error => console.log(error.message));


### PR DESCRIPTION
Passing a result to `exit` will cause `waitUntilExit` to reject
with the value as the error.

Fixes #163.