### PR TITLE
Fix setRawMode with non-TTY stdin and expose isRawModeSupported on StdinContext

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -199,8 +199,15 @@ export const StdinContext: React.Context<{
 	 * Stdin stream passed to `render()` in `options.stdin` or `process.stdin` by default. Useful if your app needs to handle user input.
 	 */
 	readonly stdin: NodeJS.ReadStream;
+
+	/**
+	 * A boolean flag determining if the current `stdin` supports `setRawMode`. A component using `setRawMode` might want to use `isRawModeSupported` to nicely fall back in environments where raw mode is not supported.
+	 */
+	readonly isRawModeSupported: boolean;
+
 	/**
 	 * Ink exposes this function via own `<StdinContext>` to be able to handle Ctrl+C, that's why you should use Ink's `setRawMode` instead of `process.stdin.setRawMode`.
+	 * If the `stdin` stream passed to Ink does not support setRawMode, this function does nothing.
 	 */
 	readonly setRawMode: NodeJS.ReadStream["setRawMode"];
 }>;

--- a/readme.md
+++ b/readme.md
@@ -762,6 +762,23 @@ Usage:
 </StdinContext.Consumer>
 ```
 
+##### isRawModeSupported
+
+Type: `boolean`
+
+A boolean flag determining if the current `stdin` supports `setRawMode`.
+A component using `setRawMode` might want to use `isRawModeSupported` to nicely fall back in environments where raw mode is not supported.
+
+Usage:
+
+```jsx
+<StdinContext.Consumer>
+	{({ isRawModeSupported, setRawMode, stdin }) => (
+		isRawModeSupported ? <MyInputComponent setRawMode={setRawMode} stdin={stdin}/> : <MyComponentThatDoesntUseInput />
+	)}
+</StdinContext.Consumer>
+```
+
 ##### setRawMode
 
 Type: `function`<br>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -37,7 +37,7 @@ export default class App extends PureComponent {
 					value={{
 						stdin: this.props.stdin,
 						setRawMode: this.handleSetRawMode,
-						isRawModeSupported: this.isRawModeSupported(this.props.stdin.isTTY)
+						isRawModeSupported: this.isRawModeSupported(this.props.stdin)
 					}}
 				>
 					<StdoutContext.Provider

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -36,7 +36,8 @@ export default class App extends PureComponent {
 				<StdinContext.Provider
 					value={{
 						stdin: this.props.stdin,
-						setRawMode: this.handleSetRawMode
+						setRawMode: this.handleSetRawMode,
+						isRawModeSupported: this.isRawModeSupported(this.props.stdin.isTTY)
 					}}
 				>
 					<StdoutContext.Provider

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -18,6 +18,11 @@ export default class App extends PureComponent {
 		onExit: PropTypes.func.isRequired
 	};
 
+	// Determines if TTY is supported on the provided stdin
+	static isRawModeSupported(stdin) {
+		return stdin.isTTY;
+	}
+
 	constructor() {
 		super();
 
@@ -37,7 +42,7 @@ export default class App extends PureComponent {
 					value={{
 						stdin: this.props.stdin,
 						setRawMode: this.handleSetRawMode,
-						isRawModeSupported: this.isRawModeSupported(this.props.stdin)
+						isRawModeSupported: App.isRawModeSupported(this.props.stdin)
 					}}
 				>
 					<StdoutContext.Provider
@@ -60,7 +65,7 @@ export default class App extends PureComponent {
 		cliCursor.show(this.props.stdout);
 
 		// ignore calling setRawMode on an handle stdin it cannot be called
-		if (this.isRawModeSupported(this.props.stdin)) {
+		if (App.isRawModeSupported(this.props.stdin)) {
 			this.handleSetRawMode(false);
 		}
 	}
@@ -69,15 +74,10 @@ export default class App extends PureComponent {
 		this.handleExit(error);
 	}
 
-	// Pass stdin directly here, for theoretical better reusability
-	isRawModeSupported(stdin) {
-		return stdin.isTTY;
-	}
-
 	// Handle setRawMode being called. Throws if setRawMode cannot be called on 'this.props.stdin'.
 	handleSetRawMode = isEnabled => {
 		const {stdin} = this.props;
-		if (!this.isRawModeSupported(stdin)) {
+		if (!App.isRawModeSupported(stdin)) {
 			if (stdin === process.stdin) {
 				throw new Error(
 					'setRawMode is not supported on the current process.stdin, which Ink uses as input stream by default.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported'
@@ -121,7 +121,7 @@ export default class App extends PureComponent {
 
 	handleExit = error => {
 		// ignore calling setRawMode on an handle stdin it cannot be called
-		if (this.isRawModeSupported(this.props.stdin)) {
+		if (App.isRawModeSupported(this.props.stdin)) {
 			this.handleSetRawMode(false);
 		}
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -58,7 +58,11 @@ export default class App extends PureComponent {
 
 	componentWillUnmount() {
 		cliCursor.show(this.props.stdout);
-		this.handleSetRawMode(false);
+
+		// ignore calling setRawMode on an handle stdin it cannot be called
+		if (this.isRawModeSupported(this.props.stdin)) {
+			this.handleSetRawMode(false);
+		}
 	}
 
 	componentDidCatch(error) {
@@ -107,7 +111,11 @@ export default class App extends PureComponent {
 	};
 
 	handleExit = error => {
-		this.handleSetRawMode(false);
+		// ignore calling setRawMode on an handle stdin it cannot be called
+		if (this.isRawModeSupported(this.props.stdin)) {
+			this.handleSetRawMode(false);
+		}
+		
 		this.props.onExit(error);
 	}
 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -64,8 +64,16 @@ export default class App extends PureComponent {
 		this.handleExit(error);
 	}
 
+	isRawModeSupported(stdin) {
+		return stdin.isTTY;
+	}
+
 	handleSetRawMode = isEnabled => {
 		const {stdin} = this.props;
+		if (!this.isRawModeSupported(stdin)) {
+			// Do nothing if stdin doesn't support raw mode
+			return;
+		}
 
 		stdin.setEncoding('utf8');
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -19,8 +19,8 @@ export default class App extends PureComponent {
 	};
 
 	// Determines if TTY is supported on the provided stdin
-	static isRawModeSupported(stdin) {
-		return stdin.isTTY;
+	isRawModeSupported() {
+		return this.props.stdin.isTTY;
 	}
 
 	constructor() {
@@ -42,7 +42,7 @@ export default class App extends PureComponent {
 					value={{
 						stdin: this.props.stdin,
 						setRawMode: this.handleSetRawMode,
-						isRawModeSupported: App.isRawModeSupported(this.props.stdin)
+						isRawModeSupported: this.isRawModeSupported()
 					}}
 				>
 					<StdoutContext.Provider
@@ -65,7 +65,7 @@ export default class App extends PureComponent {
 		cliCursor.show(this.props.stdout);
 
 		// ignore calling setRawMode on an handle stdin it cannot be called
-		if (App.isRawModeSupported(this.props.stdin)) {
+		if (this.isRawModeSupported()) {
 			this.handleSetRawMode(false);
 		}
 	}
@@ -77,7 +77,7 @@ export default class App extends PureComponent {
 	// Handle setRawMode being called. Throws if setRawMode cannot be called on 'this.props.stdin'.
 	handleSetRawMode = isEnabled => {
 		const {stdin} = this.props;
-		if (!App.isRawModeSupported(stdin)) {
+		if (!this.isRawModeSupported()) {
 			if (stdin === process.stdin) {
 				throw new Error(
 					'setRawMode is not supported on the current process.stdin, which Ink uses as input stream by default.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported'
@@ -121,7 +121,7 @@ export default class App extends PureComponent {
 
 	handleExit = error => {
 		// ignore calling setRawMode on an handle stdin it cannot be called
-		if (App.isRawModeSupported(this.props.stdin)) {
+		if (this.isRawModeSupported()) {
 			this.handleSetRawMode(false);
 		}
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -76,7 +76,7 @@ export default class App extends PureComponent {
 
 	handleSetRawMode = isEnabled => {
 		const {stdin} = this.props;
-		
+
 		if (!this.isRawModeSupported()) {
 			if (stdin === process.stdin) {
 				throw new Error(

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -74,17 +74,17 @@ export default class App extends PureComponent {
 		this.handleExit(error);
 	}
 
-	// Handle setRawMode being called. Throws if setRawMode cannot be called on 'this.props.stdin'.
 	handleSetRawMode = isEnabled => {
 		const {stdin} = this.props;
+		
 		if (!this.isRawModeSupported()) {
 			if (stdin === process.stdin) {
 				throw new Error(
-					'setRawMode is not supported on the current process.stdin, which Ink uses as input stream by default.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported'
+					'Raw mode is not supported on the current process.stdin, which Ink uses as input stream by default.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported'
 				);
 			} else {
 				throw new Error(
-					'setRawMode is not supported on the stdin provided to Ink.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported'
+					'Raw mode is not supported on the stdin provided to Ink.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported'
 				);
 			}
 		}
@@ -120,7 +120,6 @@ export default class App extends PureComponent {
 	};
 
 	handleExit = error => {
-		// ignore calling setRawMode on an handle stdin it cannot be called
 		if (this.isRawModeSupported()) {
 			this.handleSetRawMode(false);
 		}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -124,7 +124,7 @@ export default class App extends PureComponent {
 		if (this.isRawModeSupported(this.props.stdin)) {
 			this.handleSetRawMode(false);
 		}
-		
+
 		this.props.onExit(error);
 	}
 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -69,10 +69,12 @@ export default class App extends PureComponent {
 		this.handleExit(error);
 	}
 
+	// Pass stdin directly here, for theoretical better reusability
 	isRawModeSupported(stdin) {
 		return stdin.isTTY;
 	}
 
+	// Handle setRawMode being called. Throws if setRawMode cannot be called on 'this.props.stdin'.
 	handleSetRawMode = isEnabled => {
 		const {stdin} = this.props;
 		if (!this.isRawModeSupported(stdin)) {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -76,8 +76,15 @@ export default class App extends PureComponent {
 	handleSetRawMode = isEnabled => {
 		const {stdin} = this.props;
 		if (!this.isRawModeSupported(stdin)) {
-			// Do nothing if stdin doesn't support raw mode
-			return;
+			if (stdin === process.stdin) {
+				throw new Error(
+					'setRawMode is not supported on the current process.stdin, which Ink uses as input stream by default.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported'
+				);
+			} else {
+				throw new Error(
+					'setRawMode is not supported on the stdin provided to Ink.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported'
+				);
+			}
 		}
 
 		stdin.setEncoding('utf8');

--- a/test/components.js
+++ b/test/components.js
@@ -388,7 +388,9 @@ test('rendering should succeed when using isRawModeSupported to test for isTTY-c
 	const stdin = new EventEmitter();
 	stdin.setEncoding = () => {};
 	stdin.setRawMode = spy();
-	stdin.isTTY = false; // Without this, setRawMode will throw
+	stdin.isTTY = false;
+	// When this is false, setRawMode will throw.
+	// So isRawModeSupported is necessary to test for isTTY-capable stdin
 	stdin.resume = spy();
 	stdin.pause = spy();
 

--- a/test/components.js
+++ b/test/components.js
@@ -261,6 +261,7 @@ test('disable raw mode when all input components are unmounted', t => {
 	const stdin = new EventEmitter();
 	stdin.setEncoding = () => {};
 	stdin.setRawMode = spy();
+	stdin.isTTY = true; // Without this, setRawMode will throw
 	stdin.resume = spy();
 	stdin.pause = spy();
 

--- a/test/components.js
+++ b/test/components.js
@@ -329,8 +329,9 @@ test('setRawMode should throw if not supported', t => {
 	stdin.isTTY = false; // Without this, setRawMode will throw
 	stdin.resume = spy();
 	stdin.pause = spy();
-	
-	const didCatch = spy();
+
+	const didCatchInMount = spy();
+	const didCatchInUnmount = spy();
 
 	const options = {
 		stdout,
@@ -346,48 +347,33 @@ test('setRawMode should throw if not supported', t => {
 		componentDidMount() {
 			try {
 				this.props.setRawMode(true);
-			} catch(err) {
-				didCatch(err);
+			} catch (error) {
+				didCatchInMount(error);
 			}
 		}
 
 		componentWillUnmount() {
 			try {
 				this.props.setRawMode(false);
-			} catch(err) {
-				didCatch(err);
+			} catch (error) {
+				didCatchInUnmount(error);
 			}
 		}
 	}
 
-	const Test = ({renderFirstInput, renderSecondInput}) => (
+	const Test = () => (
 		<StdinContext.Consumer>
 			{({setRawMode}) => (
-				<>
-					{renderFirstInput && <Input setRawMode={setRawMode}/>}
-					{renderSecondInput && <Input setRawMode={setRawMode}/>}
-				</>
+				<Input setRawMode={setRawMode}/>
 			)}
 		</StdinContext.Consumer>
 	);
 
-	const {rerender} = render(<Test renderFirstInput renderSecondInput/>, options);
-	
-	t.true(didCatch.callCount == 4);
-	t.false(stdin.setRawMode.called);
-	t.false(stdin.resume.called);
-	t.false(stdin.pause.called);
+	const {unmount} = render(<Test/>, options);
+	unmount();
 
-	rerender(<Test renderFirstInput/>);
-
-	t.true(didCatch.callCount == 2);
-	t.false(stdin.setRawMode.called);
-	t.false(stdin.resume.called);
-	t.false(stdin.pause.called);
-
-	rerender(<Test/>);
-
-	t.true(didCatch.callCount == 0);
+	t.is(didCatchInMount.callCount, 1);
+	t.is(didCatchInUnmount.callCount, 1);
 	t.false(stdin.setRawMode.called);
 	t.false(stdin.resume.called);
 	t.false(stdin.pause.called);
@@ -438,7 +424,7 @@ test('isRawModeSupported should be used if setRawMode is not supported', t => {
 	);
 
 	const {rerender} = render(<Test renderFirstInput renderSecondInput/>, options);
-	
+
 	t.false(stdin.setRawMode.called);
 	t.false(stdin.resume.called);
 	t.false(stdin.pause.called);

--- a/test/components.js
+++ b/test/components.js
@@ -379,7 +379,7 @@ test('setRawMode should throw if not supported', t => {
 	t.false(stdin.pause.called);
 });
 
-test('isRawModeSupported should be used if setRawMode is not supported', t => {
+test('rendering should succeed when using isRawModeSupported to test for isTTY-capable stdin', t => {
 	const stdout = {
 		write: spy(),
 		columns: 100

--- a/test/components.js
+++ b/test/components.js
@@ -317,7 +317,7 @@ test('disable raw mode when all input components are unmounted', t => {
 	t.true(stdin.pause.calledOnce);
 });
 
-test('setRawMode should throw if not supported', t => {
+test('setRawMode() should throw if raw mode is not supported', t => {
 	const stdout = {
 		write: spy(),
 		columns: 100
@@ -326,7 +326,7 @@ test('setRawMode should throw if not supported', t => {
 	const stdin = new EventEmitter();
 	stdin.setEncoding = () => {};
 	stdin.setRawMode = spy();
-	stdin.isTTY = false; // Without this, setRawMode will throw
+	stdin.isTTY = false;
 	stdin.resume = spy();
 	stdin.pause = spy();
 
@@ -379,7 +379,7 @@ test('setRawMode should throw if not supported', t => {
 	t.false(stdin.pause.called);
 });
 
-test('rendering should succeed when using isRawModeSupported to test for isTTY-capable stdin', t => {
+test('render different component based on whether stdin is a TTY or not', t => {
 	const stdout = {
 		write: spy(),
 		columns: 100
@@ -389,8 +389,6 @@ test('rendering should succeed when using isRawModeSupported to test for isTTY-c
 	stdin.setEncoding = () => {};
 	stdin.setRawMode = spy();
 	stdin.isTTY = false;
-	// When this is false, setRawMode will throw.
-	// So isRawModeSupported is necessary to test for isTTY-capable stdin
 	stdin.resume = spy();
 	stdin.pause = spy();
 


### PR DESCRIPTION
This pull request tries to implement the fixes discussed in https://github.com/vadimdemedes/ink/issues/166

There are not yet any tests, as I'd like to get feedback on whether this is the route to go 👍 

A thing that is concerning is that it would be nice to have useful errors for the situation in https://github.com/vadimdemedes/ink-text-input/issues/25, while an application that supports running in CI might want to just ignore setRawMode.

## Todo
- [x] Should a helpful error be thrown if setRawMode isn't supported, with a configuration option to fall back to doing nothing?
- [x] Write tests