### PR TITLE
Add componentDidCatch and exit if render throws

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -60,6 +60,10 @@ export default class App extends PureComponent {
 		this.handleSetRawMode(false);
 	}
 
+	componentDidCatch(error) {
+		this.handleExit(error);
+	}
+
 	handleSetRawMode = isEnabled => {
 		const {stdin} = this.props;
 

--- a/test/exit.js
+++ b/test/exit.js
@@ -42,6 +42,11 @@ test('exit on unmount() with raw mode', async t => {
 	t.true(output.includes('exited'));
 });
 
+test('exit with thrown error', async t => {
+	const output = await run('exit-with-thrown-error');
+	t.true(output.includes('errored'));
+});
+
 test.cb('don\'t exit while raw mode is active', t => {
 	const term = spawn('node', ['./fixtures/run', './exit-double-raw-mode'], {
 		name: 'xterm-color',

--- a/test/fixtures/exit-with-thrown-error.js
+++ b/test/fixtures/exit-with-thrown-error.js
@@ -1,0 +1,13 @@
+'use strict';
+const React = require('react');
+const {render} = require('../..');
+
+class Test extends React.Component {
+	render() {
+		throw new Error('errored');
+	}
+}
+
+const app = render(<Test/>);
+
+app.waitUntilExit().catch(error => console.log(error.message));


### PR DESCRIPTION
This ensures that any errors in child components can be
handled gracefully by the app with a proper Error.