### PR TITLE
Revert "Rewrite text squashing and text wrapping"

### DIFF
--- a/src/get-max-width.js
+++ b/src/get-max-width.js
@@ -1,3 +1,0 @@
-export default yogaNode => {
-	return yogaNode.getComputedWidth() - (yogaNode.getComputedPadding() * 2);
-};

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -3,37 +3,7 @@ import Output from './output';
 import {createNode, appendStaticNode} from './dom';
 import buildLayout from './build-layout';
 import renderNodeToOutput from './render-node-to-output';
-import measureText from './measure-text';
 import wrapText from './wrap-text';
-import getMaxWidth from './get-max-width';
-
-// Since we need to know the width of text container to wrap text, we have to calculate layout twice
-// This function is executed after first layout calculation to reassign width and height of text nodes
-const calculateWrappedText = node => {
-	if (node.textContent && typeof node.parentNode.style.textWrap === 'string') {
-		const {yogaNode} = node;
-		const parentYogaNode = node.parentNode.yogaNode;
-		const maxWidth = getMaxWidth(parentYogaNode);
-		const currentWidth = yogaNode.getComputedWidth();
-
-		if (currentWidth > maxWidth) {
-			const {textWrap} = node.parentNode.style;
-			const wrappedText = wrapText(node.textContent, maxWidth, {textWrap});
-			const {width, height} = measureText(wrappedText);
-
-			yogaNode.setWidth(width);
-			yogaNode.setHeight(height);
-		}
-
-		return;
-	}
-
-	if (Array.isArray(node.childNodes) && node.childNodes.length > 0) {
-		for (const childNode of node.childNodes) {
-			calculateWrappedText(childNode);
-		}
-	}
-};
 
 // Since <Static> components can be placed anywhere in the tree, this helper finds and returns them
 const getStaticNodes = element => {
@@ -89,7 +59,7 @@ export default ({terminalWidth}) => {
 			});
 
 			staticYogaNode.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
-			calculateWrappedText(rootNode);
+			wrapText(rootNode);
 			staticYogaNode.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
 
 			// Save current Yoga node tree to free up memory later
@@ -110,7 +80,7 @@ export default ({terminalWidth}) => {
 		});
 
 		yogaNode.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
-		calculateWrappedText(node);
+		wrapText(node);
 		yogaNode.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
 
 		// Save current node tree to free up memory later

--- a/src/wrap-text.js
+++ b/src/wrap-text.js
@@ -1,31 +1,59 @@
 import wrapAnsi from 'wrap-ansi';
 import cliTruncate from 'cli-truncate';
+import measureText from './measure-text';
 
-export default (text, maxWidth, {textWrap} = {}) => {
-	if (textWrap === 'wrap') {
-		return wrapAnsi(text, maxWidth, {
-			trim: false,
-			hard: true
-		});
+const wrapText = node => {
+	if (node.textContent && typeof node.parentNode.style.textWrap === 'string') {
+		const {yogaNode} = node;
+		const parentYogaNode = node.parentNode.yogaNode;
+
+		const maxWidth = parentYogaNode.getComputedWidth() - (parentYogaNode.getComputedPadding() * 2);
+		const currentWidth = yogaNode.getComputedWidth();
+
+		if (currentWidth > maxWidth) {
+			const {textWrap} = node.parentNode.style;
+			let wrappedText = node.textContent;
+
+			if (textWrap === 'wrap') {
+				wrappedText = wrapAnsi(node.textContent, maxWidth, {
+					trim: false,
+					hard: true
+				});
+			}
+
+			if (textWrap.startsWith('truncate')) {
+				let position;
+
+				if (textWrap === 'truncate' || textWrap === 'truncate-end') {
+					position = 'end';
+				}
+
+				if (textWrap === 'truncate-middle') {
+					position = 'middle';
+				}
+
+				if (textWrap === 'truncate-start') {
+					position = 'start';
+				}
+
+				wrappedText = cliTruncate(node.textContent, maxWidth, {position});
+			}
+
+			const {width, height} = measureText(wrappedText);
+			node.textContent = wrappedText;
+
+			yogaNode.setWidth(width);
+			yogaNode.setHeight(height);
+		}
+
+		return;
 	}
 
-	if (String(textWrap).startsWith('truncate')) {
-		let position;
-
-		if (textWrap === 'truncate' || textWrap === 'truncate-end') {
-			position = 'end';
+	if (Array.isArray(node.childNodes) && node.childNodes.length > 0) {
+		for (const childNode of node.childNodes) {
+			wrapText(childNode);
 		}
-
-		if (textWrap === 'truncate-middle') {
-			position = 'middle';
-		}
-
-		if (textWrap === 'truncate-start') {
-			position = 'start';
-		}
-
-		return cliTruncate(text, maxWidth, {position});
 	}
-
-	return text;
 };
+
+export default wrapText;

--- a/test/components.js
+++ b/test/components.js
@@ -5,7 +5,7 @@ import test from 'ava';
 import chalk from 'chalk';
 import {spy} from 'sinon';
 import stripAnsi from 'strip-ansi';
-import {Box, Color, Text, Static, StdinContext, render} from '..';
+import {Box, Color, Static, StdinContext, render} from '..';
 import renderToString from './helpers/render-to-string';
 import run from './helpers/run';
 
@@ -126,24 +126,11 @@ test('transform children', t => {
 	t.is(output, '[{test}]');
 });
 
-test('squash multiple text nodes', t => {
+test('apply transform once to multiple text children', t => {
 	const output = renderToString(
 		<Box unstable__transformChildren={str => `[${str}]`}>
 			<Box unstable__transformChildren={str => `{${str}}`}>
 				hello{' '}world
-			</Box>
-		</Box>
-	);
-
-	t.is(output, '[{hello world}]');
-});
-
-test('squash multiple nested text nodes', t => {
-	const output = renderToString(
-		<Box unstable__transformChildren={str => `[${str}]`}>
-			<Box unstable__transformChildren={str => `{${str}}`}>
-				hello
-				<Text>{' '}world</Text>
 			</Box>
 		</Box>
 	);


### PR DESCRIPTION
This reverts commit 1a9ba27397c92a4301c0c80e451a39be4aa7a650.

Fixes issue where `undefined` is being passed to slice-ansi, resulting in hella crashes.

There may be a more surgical way to fix the problem, but everything else that I tried (detecting undefined and passing `''` instead for example) changed the output or had some other side effects.