### PR TITLE
Add ink-multi-select to useful components

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -817,6 +817,7 @@ Usage:
 - [ink-image](https://github.com/kevva/ink-image) - Display images inside the terminal.
 - [ink-tab](https://github.com/jdeniau/ink-tab) - Tab component.
 - [ink-color-pipe](https://github.com/LitoMore/ink-color-pipe) - Create color text with simpler style strings in Ink.
+- [ink-multi-select](https://github.com/karaggeorge/ink-multi-select) - Select one or more values from a list
 
 ### Incompatible components
 


### PR DESCRIPTION
Wanted to update `ink-select` to use Ink 2.0, but I can't think of anything that would be different from `ink-select-input` so I'm not sure what to do with it. Instead I made a `ink-multi-select` component, based on the `ink-select-input` which pretty much does the same as the outdated `ink-checkbox-list`.