### PR TITLE
Add warning to check support before calling setRawMode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -791,7 +791,7 @@ Type: `function`<br>
 See [`setRawMode`](https://nodejs.org/api/tty.html#tty_readstream_setrawmode_mode).
 Ink exposes this function via own `<StdinContext>` to be able to handle <kbd>Ctrl</kbd>+<kbd>C</kbd>, that's why you should use Ink's `setRawMode` instead of `process.stdin.setRawMode`. Ink also enables `keypress` events via [`readline.emitKeypressEvents()`](https://nodejs.org/api/readline.html#readline_readline_emitkeypressevents_stream_interface) when raw mode is enabled.
 
-**Warning: This function will throw unless the current `stdin` supports `setRawMode`. Use [`isRawModeSupported`](https://github.com/vadimdemedes/ink/#israwmodesupported) to detect `setRawMode` support.**
+**Warning:** This function will throw unless the current `stdin` supports `setRawMode`. Use [`isRawModeSupported`](#israwmodesupported) to detect `setRawMode` support.
 
 Usage:
 

--- a/readme.md
+++ b/readme.md
@@ -791,6 +791,8 @@ Type: `function`<br>
 See [`setRawMode`](https://nodejs.org/api/tty.html#tty_readstream_setrawmode_mode).
 Ink exposes this function via own `<StdinContext>` to be able to handle <kbd>Ctrl</kbd>+<kbd>C</kbd>, that's why you should use Ink's `setRawMode` instead of `process.stdin.setRawMode`. Ink also enables `keypress` events via [`readline.emitKeypressEvents()`](https://nodejs.org/api/readline.html#readline_readline_emitkeypressevents_stream_interface) when raw mode is enabled.
 
+**Warning: This function will throw unless the current `stdin` supports `setRawMode`. Use [`isRawModeSupported`](https://github.com/vadimdemedes/ink/#israwmodesupported) to detect `setRawMode` support.**
+
 Usage:
 
 ```jsx


### PR DESCRIPTION
Followup to #172 - this PR adds a warning to the readme that indicates that `setRawMode` might throw depending on the value of `isRawModeSupported`.

Felt like this might be useful 👍 