### PR TITLE
chore(docs): adds ink-starter to the README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ Feel free to play around with the code and fork this repl at [https://repl.it/@v
 
 
 ## Built with Ink
-
+- [ink-starter](https://github.com/pranshuchittora/ink) - Boilerplate for ink
 - [emoj](https://github.com/sindresorhus/emoj) - Find relevant emoji on the command-line.
 - [emma](https://github.com/maticzav/emma-cli) - Terminal assistant to find and install npm packages.
 - [swiff](https://github.com/simple-integrated-marketing/swiff) - Multi-environment command line tools for time-saving web developers.


### PR DESCRIPTION
Added ink-starter to the README.md

**Why boilerplate?**
Because running ink program requires a lot of transformations to run. Like transpiring with babel,etc.

So the idea is that a user can focus on the business logic, not the infra.
