### PR TITLE
docs(readme): adds the link for the unofficial starter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ Feel free to play around with the code and fork this repl at [https://repl.it/@v
 
 
 ## Built with Ink
-- [ink-starter](https://github.com/pranshuchittora/ink) - Boilerplate for ink
+- [ink-starter](https://github.com/pranshuchittora/ink-starter) - Boilerplate for ink (Unofficial)
 - [emoj](https://github.com/sindresorhus/emoj) - Find relevant emoji on the command-line.
 - [emma](https://github.com/maticzav/emma-cli) - Terminal assistant to find and install npm packages.
 - [swiff](https://github.com/simple-integrated-marketing/swiff) - Multi-environment command line tools for time-saving web developers.

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ Feel free to play around with the code and fork this repl at [https://repl.it/@v
 
 
 ## Built with Ink
-
+- [ink-starter](https://github.com/pranshuchittora/ink) - Boilerplate for ink
 - [emoj](https://github.com/sindresorhus/emoj) - Find relevant emoji on the command-line.
 - [emma](https://github.com/maticzav/emma-cli) - Terminal assistant to find and install npm packages.
 - [swiff](https://github.com/simple-integrated-marketing/swiff) - Multi-environment command line tools for time-saving web developers.


### PR DESCRIPTION
I know its quite difficult and opinionated, but there must be some base on top of which one can build upon.

As @sindresorhus said, one can fork and build upon existing CLI. Unfortunately, that comes with a lot of problems.
- One has to remove all the source code.
- Change the project structure.
- Change/modify dependencies.
- Change scripts.

Let's discuss more.