### PR TITLE
Optionally allow the use of external DOMs

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"cli-cursor": "^2.1.0",
 		"cli-truncate": "^1.1.0",
 		"is-ci": "^2.0.0",
+		"jsdom": "^15.1.1",
 		"lodash.throttle": "^4.1.1",
 		"log-update": "^3.0.0",
 		"prop-types": "^15.6.2",
@@ -72,6 +73,7 @@
 		"eslint-plugin-react": "^7.11.1",
 		"eslint-plugin-react-hooks": "^1.4.0",
 		"import-jsx": "^1.3.0",
+		"inspect-process": "^0.5.0",
 		"ms": "^2.1.1",
 		"node-pty": "^0.8.1",
 		"p-queue": "^3.0.0",
@@ -82,7 +84,8 @@
 		"xo": "^0.24.0"
 	},
 	"peerDependencies": {
-		"react": ">=16.8.0"
+		"react": ">=16.8.0",
+		"react-dom": "^16.8.6"
 	},
 	"babel": {
 		"plugins": [

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 		"cli-truncate": "^1.1.0",
 		"is-ci": "^2.0.0",
 		"jsdom": "^15.1.1",
+		"keycode": "^2.2.0",
 		"lodash.throttle": "^4.1.1",
 		"log-update": "^3.0.0",
 		"prop-types": "^15.6.2",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -6,6 +6,7 @@ import AppContext from './AppContext';
 import StdinContext from './StdinContext';
 import StdoutContext from './StdoutContext';
 
+
 // Root component for all Ink apps
 // It renders stdin and stdout contexts, so that children can access them if needed
 // It also handles Ctrl+C exiting and cursor visibility

--- a/src/dom.js
+++ b/src/dom.js
@@ -1,5 +1,54 @@
 // Helper utilities implementing some common DOM methods to simplify reconciliation code
-export const createNode = tagName => ({
+const _documentCreateNode = (document, tagName) => {
+	return document.createElement(tagName);
+};
+
+const _documentAppendChildNode = (node, childNode) => {
+	if (childNode.parentNode) {
+		childNode.parentNode.removeChild(childNode);
+	}
+
+	node.append(childNode);
+}; // Same as `appendChildNode`, but without removing child node from parent node
+
+const _documentAppendStaticNode = (node, childNode) => {
+	node.append(childNode);
+};
+
+const _documentInsertBeforeNode = (node, newChildNode, beforeChildNode) => {
+	if (newChildNode.parentNode) {
+		newChildNode.parentNode.removeChild(newChildNode);
+	}
+
+	node.insertBefore(newChildNode, beforeChildNode);
+};
+
+const _documentRemoveChildNode = (node, removeNode) => {
+	node.removeChild(removeNode);
+};
+
+const _documentSetAttribute = (node, key, value) => {
+	node.setAttribute(key, value);
+};
+
+const _documentCreateTextNode = (document, text) => {
+	return document.createTextNode(text);
+};
+
+const _documentGetChildNodes = node => {
+	return [...node.childNodes];
+};
+
+const _documentGetTextContent = node => {
+	if (node.nodeType === 3) {
+		return node.data;
+	}
+
+	return null;
+};
+
+// Helper utilities implementing some common DOM methods to simplify reconciliation code
+const _createNode = tagName => ({
 	nodeName: tagName.toUpperCase(),
 	style: {},
 	attributes: {},
@@ -7,9 +56,9 @@ export const createNode = tagName => ({
 	parentNode: null
 });
 
-export const appendChildNode = (node, childNode) => {
+const _appendChildNode = (node, childNode) => {
 	if (childNode.parentNode) {
-		removeChildNode(childNode.parentNode, childNode);
+		_removeChildNode(childNode.parentNode, childNode);
 	}
 
 	childNode.parentNode = node;
@@ -18,13 +67,13 @@ export const appendChildNode = (node, childNode) => {
 };
 
 // Same as `appendChildNode`, but without removing child node from parent node
-export const appendStaticNode = (node, childNode) => {
+const _appendStaticNode = (node, childNode) => {
 	node.childNodes.push(childNode);
 };
 
-export const insertBeforeNode = (node, newChildNode, beforeChildNode) => {
+const _insertBeforeNode = (node, newChildNode, beforeChildNode) => {
 	if (newChildNode.parentNode) {
-		removeChildNode(newChildNode.parentNode, newChildNode);
+		_removeChildNode(newChildNode.parentNode, newChildNode);
 	}
 
 	newChildNode.parentNode = node;
@@ -38,7 +87,7 @@ export const insertBeforeNode = (node, newChildNode, beforeChildNode) => {
 	node.childNodes.push(newChildNode);
 };
 
-export const removeChildNode = (node, removeNode) => {
+const _removeChildNode = (node, removeNode) => {
 	removeNode.parentNode = null;
 
 	const index = node.childNodes.indexOf(removeNode);
@@ -47,11 +96,47 @@ export const removeChildNode = (node, removeNode) => {
 	}
 };
 
-export const setAttribute = (node, key, value) => {
+const _setAttribute = (node, key, value) => {
 	node.attributes[key] = value;
 };
 
-export const createTextNode = text => ({
+const _createTextNode = text => ({
 	nodeName: '#text',
 	nodeValue: text
 });
+
+const _getChildNodes = node => {
+	return node.childNodes;
+};
+
+const _getTextContent = node => {
+	return node.textContent;
+};
+
+export const createDocumentHelpers = document => {
+	if (document) {
+		return Object.freeze({
+			createNode: tagName => _documentCreateNode(document, tagName),
+			appendChildNode: _documentAppendChildNode,
+			appendStaticNode: _documentAppendStaticNode,
+			insertBeforeNode: _documentInsertBeforeNode,
+			removeChildNode: _documentRemoveChildNode,
+			setAttribute: _documentSetAttribute,
+			createTextNode: text => _documentCreateTextNode(document, text),
+			getChildNodes: _documentGetChildNodes,
+			getTextContent: _documentGetTextContent
+		});
+	}
+
+	return Object.freeze({
+		createNode: _createNode,
+		appendChildNode: _appendChildNode,
+		appendStaticNode: _appendStaticNode,
+		insertBeforeNode: _insertBeforeNode,
+		removeChildNode: _removeChildNode,
+		setAttribute: _setAttribute,
+		createTextNode: _createTextNode,
+		getChildNodes: _getChildNodes,
+		getTextContent: _getTextContent
+	});
+};

--- a/src/instance.js
+++ b/src/instance.js
@@ -102,6 +102,8 @@ export default class Instance {
 			<App
 				stdin={this.options.stdin}
 				stdout={this.options.stdout}
+				window={this.options.window}
+				document={this.options.document}
 				exitOnCtrlC={this.options.exitOnCtrlC}
 				onExit={this.unmount}
 			>

--- a/src/reconciler.js
+++ b/src/reconciler.js
@@ -3,122 +3,128 @@ import {
 	unstable_cancelCallback as cancelPassiveEffects
 } from 'scheduler';
 import ReactReconciler from 'react-reconciler';
-import {
-	createNode,
-	createTextNode,
-	appendChildNode,
-	insertBeforeNode,
-	removeChildNode,
-	setAttribute
-} from './dom';
 
 const NO_CONTEXT = true;
 
-const hostConfig = {
-	schedulePassiveEffects,
-	cancelPassiveEffects,
-	now: Date.now,
-	getRootHostContext: () => NO_CONTEXT,
-	prepareForCommit: () => {},
-	resetAfterCommit: rootNode => {
-		rootNode.onRender();
-	},
-	getChildHostContext: () => NO_CONTEXT,
-	shouldSetTextContent: (type, props) => {
-		return typeof props.children === 'string' || typeof props.children === 'number';
-	},
-	createInstance: (type, newProps) => {
-		const node = createNode(type);
+function createHostConfig(documentHelpers) {
+	return {
+		schedulePassiveEffects,
+		cancelPassiveEffects,
+		now: Date.now,
+		getRootHostContext: () => NO_CONTEXT,
+		prepareForCommit: () => {},
+		resetAfterCommit: rootNode => {
+			rootNode.onRender();
+		},
+		getChildHostContext: () => NO_CONTEXT,
+		shouldSetTextContent: (type, props) => {
+			return typeof props.children === 'string' || typeof props.children === 'number';
+		},
+		createInstance: (type, newProps) => {
+			const node = documentHelpers.createNode(type);
 
-		for (const [key, value] of Object.entries(newProps)) {
-			if (key === 'children') {
-				if (typeof value === 'string' || typeof value === 'number') {
-					if (type === 'div') {
-						// Text node must be wrapped in another node, so that text can be aligned within container
-						const textElement = createNode('div');
-						textElement.textContent = String(value);
-						appendChildNode(node, textElement);
-					}
-
-					if (type === 'span') {
-						node.textContent = String(value);
-					}
-				}
-			} else if (key === 'style') {
-				Object.assign(node.style, value);
-			} else if (key === 'unstable__transformChildren') {
-				node.unstable__transformChildren = value; // eslint-disable-line camelcase
-			} else if (key === 'unstable__static') {
-				node.unstable__static = true; // eslint-disable-line camelcase
-			} else {
-				setAttribute(node, key, value);
-			}
-		}
-
-		return node;
-	},
-	createTextInstance: createTextNode,
-	resetTextContent: node => {
-		if (node.textContent) {
-			node.textContent = '';
-		}
-
-		if (node.childNodes.length > 0) {
-			for (const childNode of node.childNodes) {
-				childNode.yogaNode.free();
-				removeChildNode(node, childNode);
-			}
-		}
-	},
-	getPublicInstance: instance => instance,
-	appendInitialChild: appendChildNode,
-	appendChild: appendChildNode,
-	insertBefore: insertBeforeNode,
-	finalizeInitialChildren: () => {},
-	supportsMutation: true,
-	appendChildToContainer: appendChildNode,
-	insertInContainerBefore: insertBeforeNode,
-	removeChildFromContainer: removeChildNode,
-	prepareUpdate: () => true,
-	commitUpdate: (node, updatePayload, type, oldProps, newProps) => {
-		for (const [key, value] of Object.entries(newProps)) {
-			if (key === 'children') {
-				if (typeof value === 'string' || typeof value === 'number') {
-					if (type === 'div') {
-						// Text node must be wrapped in another node, so that text can be aligned within container
-						// If there's no such node, a new one must be created
-						if (node.childNodes.length === 0) {
-							const textElement = createNode('div');
+			for (const [key, value] of Object.entries(newProps)) {
+				if (key === 'children') {
+					if (typeof value === 'string' || typeof value === 'number') {
+						if (type === 'div') {
+							// Text node must be wrapped in another node, so that text can be aligned within container
+							const textElement = documentHelpers.createNode('div');
 							textElement.textContent = String(value);
-							appendChildNode(node, textElement);
-						} else {
-							node.childNodes[0].textContent = String(value);
+							documentHelpers.appendChildNode(node, textElement);
+						}
+
+						if (type === 'span') {
+							node.textContent = String(value);
 						}
 					}
-
-					if (type === 'span') {
-						node.textContent = String(value);
-					}
+				} else if (key === 'style') {
+					Object.assign(node.style, value);
+				} else if (key === 'unstable__transformChildren') {
+					node.unstable__transformChildren = value; // eslint-disable-line camelcase
+				} else if (key === 'unstable__static') {
+					node.unstable__static = true; // eslint-disable-line camelcase
+				} else {
+					documentHelpers.setAttribute(node, key, value);
 				}
-			} else if (key === 'style') {
-				Object.assign(node.style, value);
-			} else if (key === 'unstable__transformChildren') {
-				node.unstable__transformChildren = value; // eslint-disable-line camelcase
-			} else if (key === 'unstable__static') {
-				node.unstable__static = true; // eslint-disable-line camelcase
-			} else {
-				setAttribute(node, key, value);
 			}
-		}
-	},
-	commitTextUpdate: (node, oldText, newText) => {
-		if (node.nodeName === '#text') {
-			node.nodeValue = newText;
-		} else {
-			node.textContent = newText;
-		}
-	},
-	removeChild: removeChildNode
-};
 
-export default ReactReconciler(hostConfig); // eslint-disable-line new-cap
+			return node;
+		},
+		createTextInstance: documentHelpers.createTextNode,
+		resetTextContent: node => {
+			if (node.textContent) {
+				node.textContent = '';
+			}
+
+			const childNodes = documentHelpers.getChildNodes(node);
+
+			if (childNodes.length > 0) {
+				for (const childNode of childNodes) {
+					childNode.yogaNode.free();
+					documentHelpers.removeChildNode(node, childNode);
+				}
+			}
+		},
+		getPublicInstance: instance => instance,
+		appendInitialChild: documentHelpers.appendChildNode,
+		appendChild: documentHelpers.appendChildNode,
+		insertBefore: documentHelpers.insertBeforeNode,
+		finalizeInitialChildren: () => {},
+		supportsMutation: true,
+		appendChildToContainer: documentHelpers.appendChildNode,
+		insertInContainerBefore: documentHelpers.insertBeforeNode,
+		removeChildFromContainer: documentHelpers.removeChildNode,
+		prepareUpdate: () => true,
+		commitUpdate: (node, updatePayload, type, oldProps, newProps) => {
+			for (const [key, value] of Object.entries(newProps)) {
+				if (key === 'children') {
+					if (typeof value === 'string' || typeof value === 'number') {
+						if (type === 'div') {
+							// Text node must be wrapped in another node, so that text can be aligned within container
+							// If there's no such node, a new one must be created
+							if (node.childNodes.length === 0) {
+								const textElement = documentHelpers.createNode('div');
+								textElement.textContent = String(value);
+								documentHelpers.appendChildNode(node, textElement);
+							} else {
+								node.childNodes[0].textContent = String(value);
+							}
+						}
+
+						if (type === 'span') {
+							node.textContent = String(value);
+						}
+					}
+				} else if (key === 'style') {
+					Object.assign(node.style, value);
+				} else if (key === 'unstable__transformChildren') {
+					node.unstable__transformChildren = value; // eslint-disable-line camelcase
+				} else if (key === 'unstable__static') {
+					node.unstable__static = true; // eslint-disable-line camelcase
+				} else {
+					documentHelpers.setAttribute(node, key, value);
+				}
+			}
+		},
+		commitTextUpdate: (node, oldText, newText) => {
+			if (node.nodeName === '#text') {
+				node.nodeValue = newText;
+			} else {
+				node.textContent = newText;
+			}
+		},
+		removeChild: documentHelpers.removeChildNode
+	};
+}
+
+var _cachedReconciler = null; // eslint-disable-line no-var
+
+export const createReconciler = documentHelpers => {
+	if (_cachedReconciler) {
+		return _cachedReconciler;
+	}
+
+	// Hopefully documentHelpers is the same...
+	_cachedReconciler = ReactReconciler(createHostConfig(documentHelpers)); // eslint-disable-line new-cap
+	return _cachedReconciler;
+};

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,6 +1,5 @@
 import Yoga from 'yoga-layout-prebuilt';
 import Output from './output';
-import {createNode, appendStaticNode} from './dom';
 import buildLayout from './build-layout';
 import renderNodeToOutput from './render-node-to-output';
 import measureText from './measure-text';
@@ -9,8 +8,9 @@ import getMaxWidth from './get-max-width';
 
 // Since we need to know the width of text container to wrap text, we have to calculate layout twice
 // This function is executed after first layout calculation to reassign width and height of text nodes
-const calculateWrappedText = node => {
-	if (node.textContent && typeof node.parentNode.style.textWrap === 'string') {
+const calculateWrappedText = (documentHelpers, node) => {
+	const textContent = documentHelpers.getTextContent(node);
+	if (textContent && node.parentNode && node.parentNode.style && typeof node.parentNode.style.textWrap === 'string') {
 		const {yogaNode} = node;
 		const parentYogaNode = node.parentNode.yogaNode;
 		const maxWidth = getMaxWidth(parentYogaNode);
@@ -28,24 +28,30 @@ const calculateWrappedText = node => {
 		return;
 	}
 
-	if (Array.isArray(node.childNodes) && node.childNodes.length > 0) {
-		for (const childNode of node.childNodes) {
-			calculateWrappedText(childNode);
+	const childNodes = documentHelpers.getChildNodes(node);
+
+	if (childNodes && childNodes.length > 0) {
+		for (const childNode of childNodes) {
+			calculateWrappedText(documentHelpers, childNode);
 		}
 	}
 };
 
 // Since <Static> components can be placed anywhere in the tree, this helper finds and returns them
-const getStaticNodes = element => {
+const getStaticNodes = (documentHelpers, element) => {
 	const staticNodes = [];
 
-	for (const childNode of element.childNodes) {
+	const elementChildNodes = documentHelpers.getChildNodes(element);
+
+	for (const childNode of elementChildNodes) {
 		if (childNode.unstable__static) {
 			staticNodes.push(childNode);
 		}
 
-		if (Array.isArray(childNode.childNodes) && childNode.childNodes.length > 0) {
-			staticNodes.push(...getStaticNodes(childNode));
+		const childNodes = documentHelpers.getChildNodes(childNode);
+
+		if (Array.isArray(childNodes) && childNodes.length > 0) {
+			staticNodes.push(...getStaticNodes(documentHelpers, childNode));
 		}
 	}
 
@@ -53,7 +59,7 @@ const getStaticNodes = element => {
 };
 
 // Build layout, apply styles, build text output of all nodes and return it
-export default ({terminalWidth}) => {
+export default ({documentHelpers, terminalWidth}) => {
 	const config = Yoga.Config.create();
 
 	// Used to free up memory used by last Yoga node tree
@@ -69,7 +75,7 @@ export default ({terminalWidth}) => {
 			lastStaticYogaNode.freeRecursive();
 		}
 
-		const staticElements = getStaticNodes(node);
+		const staticElements = getStaticNodes(documentHelpers, node);
 		if (staticElements.length > 1) {
 			if (process.env.NODE_ENV !== 'production') {
 				console.error('Warning: There can only be one <Static> component');
@@ -79,17 +85,17 @@ export default ({terminalWidth}) => {
 		// <Static> component must be built and rendered separately, so that the layout of the other output is unaffected
 		let staticOutput;
 		if (staticElements.length === 1) {
-			const rootNode = createNode('root');
-			appendStaticNode(rootNode, staticElements[0]);
+			const rootNode = documentHelpers.createNode('root');
+			documentHelpers.appendStaticNode(rootNode, staticElements[0]);
 
-			const {yogaNode: staticYogaNode} = buildLayout(rootNode, {
+			const {yogaNode: staticYogaNode} = buildLayout(documentHelpers, rootNode, {
 				config,
 				terminalWidth,
 				skipStaticElements: false
 			});
 
 			staticYogaNode.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
-			calculateWrappedText(rootNode);
+			calculateWrappedText(documentHelpers, rootNode);
 			staticYogaNode.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
 
 			// Save current Yoga node tree to free up memory later
@@ -100,17 +106,17 @@ export default ({terminalWidth}) => {
 				height: staticYogaNode.getComputedHeight()
 			});
 
-			renderNodeToOutput(rootNode, staticOutput, {skipStaticElements: false});
+			renderNodeToOutput(documentHelpers, rootNode, staticOutput, {skipStaticElements: false});
 		}
 
-		const {yogaNode} = buildLayout(node, {
+		const {yogaNode} = buildLayout(documentHelpers, node, {
 			config,
 			terminalWidth,
 			skipStaticElements: true
 		});
 
 		yogaNode.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
-		calculateWrappedText(node);
+		calculateWrappedText(documentHelpers, node);
 		yogaNode.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
 
 		// Save current node tree to free up memory later
@@ -121,7 +127,7 @@ export default ({terminalWidth}) => {
 			height: yogaNode.getComputedHeight()
 		});
 
-		renderNodeToOutput(node, output, {skipStaticElements: true});
+		renderNodeToOutput(documentHelpers, node, output, {skipStaticElements: true});
 
 		return {
 			output: output.get(),


### PR DESCRIPTION
External DOMs like jsdom are more featureful than the DOM present in ink.
Features like focus and event dispatch can allow for much richer UIs with react.

These commits allow the client to create a DOM and specify its objects to the
render method via options.

Additionally, when the external DOM is available, it is assumed it supports
event dispatch and so ink uses a keyboard event dispatcher.

This enables the use of features like `react-hotkeys` and other event-based
functionality. For instance, this opens the door to mouse events being
delivered.