### PR TITLE
Don't error on empty string input to <Color>

### DIFF
--- a/src/components/Color.js
+++ b/src/components/Color.js
@@ -19,6 +19,10 @@ const methods = [
 ];
 
 const Color = ({children, ...colorProps}) => {
+	if (children === '') {
+		return null;
+	}
+	
 	const transformChildren = children => {
 		Object.keys(colorProps).forEach(method => {
 			if (colorProps[method]) {
@@ -41,7 +45,11 @@ const Color = ({children, ...colorProps}) => {
 };
 
 Color.propTypes = {
-	children: PropTypes.node.isRequired
+	children: PropTypes.node
+};
+
+Color.defaultProps = {
+	children: ''
 };
 
 export default Color;

--- a/src/components/Color.js
+++ b/src/components/Color.js
@@ -22,7 +22,7 @@ const Color = ({children, ...colorProps}) => {
 	if (children === '') {
 		return null;
 	}
-	
+
 	const transformChildren = children => {
 		Object.keys(colorProps).forEach(method => {
 			if (colorProps[method]) {

--- a/test/components.js
+++ b/test/components.js
@@ -229,13 +229,8 @@ test('ensure wrap-ansi doesn\'t trim leading whitespace', t => {
 	t.is(output, chalk.red(' ERROR '));
 });
 
-test('ensure Color doesn\'t throw on no children', t => {
-	const output = renderToString(
-		<Color>
-			{undefined}
-		</Color>
-	);
-
+test('ensure Color doesn\'t throw on empty children', t => {
+	const output = renderToString(<Color/>);
 	t.is(output, '');
 });
 

--- a/test/components.js
+++ b/test/components.js
@@ -229,6 +229,16 @@ test('ensure wrap-ansi doesn\'t trim leading whitespace', t => {
 	t.is(output, chalk.red(' ERROR '));
 });
 
+test('ensure Color doesn\'t throw on no children', t => {
+	const output = renderToString(
+		<Color>
+			{undefined}
+		</Color>
+	);
+
+	t.is(output, '');
+});
+
 test('replace child node with text', t => {
 	const stdout = {
 		write: spy(),


### PR DESCRIPTION
Even though only dev error, it's convenient to not have to guard against temporarily empty strings getting passed to <Color>.

Obviously, this is just a suggestion and one of many ways to implement. It's easy enough to write a wrapper around <Color> to handle this if that's preferred.

The specific use case is rendering of fields in color that may, at times, be empty strings.

I don't use Typescript, so sorry if this breaks something in that world.