### PR TITLE
Add new experimental reconciler

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,13 @@ export interface RenderOptions {
 	 * @default false
 	 */
 	readonly debug?: boolean;
+	/**
+	 * Enable experimental mode and use a new and faster reconciler and renderer.
+	 * There should be no changes to the output. If there are, please report it.
+	 *
+	 * @default false
+	 */
+	readonly experimental?: boolean;
 }
 
 export type Instance = {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"scripts": {
 		"build": "babel src --out-dir=build",
 		"prepare": "npm run build",
-		"test": "FORCE_COLOR=true EXPERIMENTAL=true ava; xo && FORCE_COLOR=true ava && tsd",
+		"test": "xo && FORCE_COLOR=true EXPERIMENTAL=true ava && FORCE_COLOR=true ava && tsd",
 		"pretest": "npm run build",
 		"cast": "svg-term --command='node media/demo.js' --out=media/demo.svg --from=100 --window --width=50 --height=8 --term=iterm2 --profile=Snazzy"
 	},

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"scripts": {
 		"build": "babel src --out-dir=build",
 		"prepare": "npm run build",
-		"test": "xo && FORCE_COLOR=true ava && tsd",
+		"test": "FORCE_COLOR=true EXPERIMENTAL=true ava; xo && FORCE_COLOR=true ava && tsd",
 		"pretest": "npm run build",
 		"cast": "svg-term --command='node media/demo.js' --out=media/demo.svg --from=100 --window --width=50 --height=8 --term=iterm2 --profile=Snazzy"
 	},

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,7 @@ Feel free to play around with the code and fork this repl at [https://repl.it/@v
 - [Built-in Components](#built-in-components)
 - [Useful Components](#useful-components)
 - [Testing](#testing)
+- [Experimental mode](#experimental-mode)
 
 
 ## Getting Started
@@ -186,6 +187,13 @@ Type: `boolean`<br>
 Default: `false`
 
 If `true`, each update will be rendered as a separate output, without replacing the previous one.
+
+###### experimental
+
+Type: `boolean`<br>
+Default: `false`
+
+Enables [experimental mode](#experimental-mode).
 
 ```jsx
 import React, {Component} from 'react';
@@ -890,6 +898,20 @@ lastFrame() === 'Hello World'; //=> true
 ```
 
 Visit [ink-testing-library](https://github.com/vadimdemedes/ink-testing-library) for more examples and full documentation.
+
+## Experimental Mode
+
+Ink has experimental mode, which currently enables a more efficient and faster reconciler and renderer.
+Instead of shipping it under `next` tag or something similar, Ink ships it as part of a regular release.
+It can be enabled simply by passing `experimental` parameter to `render()` function:
+
+```jsx
+render(<App/>, {experimental: true});
+```
+
+Experimental mode actually includes stable features, but I want to be extra sure that it doesn't introduce regressions before shipping this new code for everyone and making it a default.
+
+Feel free to use experimental mode in development and I would appreciate if you reported any regressions you might see.
 
 
 ## Maintainers

--- a/src/calculate-wrapped-text.js
+++ b/src/calculate-wrapped-text.js
@@ -1,0 +1,33 @@
+import measureText from './measure-text';
+import wrapText from './wrap-text';
+import getMaxWidth from './get-max-width';
+
+// Since we need to know the width of text container to wrap text, we have to calculate layout twice
+// This function is executed after first layout calculation to reassign width and height of text nodes
+const calculateWrappedText = node => {
+	if (node.textContent && typeof node.parentNode.style.textWrap === 'string') {
+		const {yogaNode} = node;
+		const parentYogaNode = node.parentNode.yogaNode;
+		const maxWidth = getMaxWidth(parentYogaNode);
+		const currentWidth = yogaNode.getComputedWidth();
+
+		if (currentWidth > maxWidth) {
+			const {textWrap} = node.parentNode.style;
+			const wrappedText = wrapText(node.textContent, maxWidth, {textWrap});
+			const {width, height} = measureText(wrappedText);
+
+			yogaNode.setWidth(width);
+			yogaNode.setHeight(height);
+		}
+
+		return;
+	}
+
+	if (Array.isArray(node.childNodes) && node.childNodes.length > 0) {
+		for (const childNode of node.childNodes) {
+			calculateWrappedText(childNode);
+		}
+	}
+};
+
+export default calculateWrappedText;

--- a/src/components/Box.js
+++ b/src/components/Box.js
@@ -26,7 +26,7 @@ export default class Box extends PureComponent {
 		flexShrink: PropTypes.number,
 		flexDirection: PropTypes.oneOf(['row', 'row-reverse', 'column', 'column-reverse']),
 		flexBasis: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-		alignItems: PropTypes.oneOf(['flex-start', 'center', 'flex-end']),
+		alignItems: PropTypes.oneOf(['stretch', 'flex-start', 'center', 'flex-end']),
 		justifyContent: PropTypes.oneOf(['flex-start', 'center', 'flex-end', 'space-between', 'space-around']),
 		textWrap: PropTypes.oneOf(['wrap', 'truncate', 'truncate-start', 'truncate-middle', 'truncate-end']),
 		unstable__transformChildren: PropTypes.func,

--- a/src/components/Static.js
+++ b/src/components/Static.js
@@ -32,7 +32,14 @@ export default class Static extends Component {
 		}
 
 		return (
-			<div unstable__static style={otherProps}>
+			<div
+				unstable__static
+				style={{
+					position: 'absolute',
+					flexDirection: 'column',
+					...otherProps
+				}}
+			>
 				{newChildren}
 			</div>
 		);

--- a/src/experimental/apply-style.js
+++ b/src/experimental/apply-style.js
@@ -1,0 +1,129 @@
+import Yoga from 'yoga-layout-prebuilt';
+
+const applyPositionStyles = (node, style) => {
+	if (!style.position) {
+		node.setPositionType(NaN);
+	}
+
+	if (style.position === 'absolute') {
+		node.setPositionType(Yoga.POSITION_TYPE_ABSOLUTE);
+	}
+};
+
+const applyMarginStyles = (node, style) => {
+	node.setMargin(Yoga.EDGE_START, style.marginLeft || style.marginX || style.margin || 0);
+	node.setMargin(Yoga.EDGE_END, style.marginRight || style.marginX || style.margin || 0);
+	node.setMargin(Yoga.EDGE_TOP, style.marginTop || style.marginY || style.margin || 0);
+	node.setMargin(Yoga.EDGE_BOTTOM, style.marginBottom || style.marginY || style.margin || 0);
+};
+
+const applyPaddingStyles = (node, style) => {
+	node.setPadding(Yoga.EDGE_LEFT, style.paddingLeft || style.paddingX || style.padding || 0);
+	node.setPadding(Yoga.EDGE_RIGHT, style.paddingRight || style.paddingX || style.padding || 0);
+	node.setPadding(Yoga.EDGE_TOP, style.paddingTop || style.paddingY || style.padding || 0);
+	node.setPadding(Yoga.EDGE_BOTTOM, style.paddingBottom || style.paddingY || style.padding || 0);
+};
+
+const applyFlexStyles = (node, style) => {
+	node.setFlexGrow(style.flexGrow || 0);
+	node.setFlexShrink(typeof style.flexShrink === 'number' ? style.flexShrink : 1);
+
+	if (style.flexDirection === 'row' || !style.flexDirection) {
+		node.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+	}
+
+	if (style.flexDirection === 'row-reverse') {
+		node.setFlexDirection(Yoga.FLEX_DIRECTION_ROW_REVERSE);
+	}
+
+	if (style.flexDirection === 'column') {
+		node.setFlexDirection(Yoga.FLEX_DIRECTION_COLUMN);
+	}
+
+	if (style.flexDirection === 'column-reverse') {
+		node.setFlexDirection(Yoga.FLEX_DIRECTION_COLUMN_REVERSE);
+	}
+
+	if (typeof style.flexBasis === 'number') {
+		node.setFlexBasis(style.flexBasis);
+	} else if (typeof style.flexBasis === 'string') {
+		node.setFlexBasisPercent(parseInt(style.flexBasis, 10));
+	} else {
+		// This should be replaced with node.setFlexBasisAuto() when new Yoga release is out
+		node.setFlexBasis(NaN);
+	}
+
+	if (style.alignItems === 'stretch' || !style.alignItems) {
+		node.setAlignItems(Yoga.ALIGN_STRETCH);
+	}
+
+	if (style.alignItems === 'flex-start') {
+		node.setAlignItems(Yoga.ALIGN_FLEX_START);
+	}
+
+	if (style.alignItems === 'center') {
+		node.setAlignItems(Yoga.ALIGN_CENTER);
+	}
+
+	if (style.alignItems === 'flex-end') {
+		node.setAlignItems(Yoga.ALIGN_FLEX_END);
+	}
+
+	if (style.justifyContent === 'flex-start' || !style.justifyContent) {
+		node.setJustifyContent(Yoga.JUSTIFY_FLEX_START);
+	}
+
+	if (style.justifyContent === 'center') {
+		node.setJustifyContent(Yoga.JUSTIFY_CENTER);
+	}
+
+	if (style.justifyContent === 'flex-end') {
+		node.setJustifyContent(Yoga.JUSTIFY_FLEX_END);
+	}
+
+	if (style.justifyContent === 'space-between') {
+		node.setJustifyContent(Yoga.JUSTIFY_SPACE_BETWEEN);
+	}
+
+	if (style.justifyContent === 'space-around') {
+		node.setJustifyContent(Yoga.JUSTIFY_SPACE_AROUND);
+	}
+};
+
+const applyDimensionStyles = (node, style) => {
+	if (typeof style.width === 'number') {
+		node.setWidth(style.width);
+	} else if (typeof style.width === 'string') {
+		node.setWidthPercent(parseInt(style.width, 10));
+	} else {
+		node.setWidthAuto();
+	}
+
+	if (typeof style.height === 'number') {
+		node.setHeight(style.height);
+	} else if (typeof style.height === 'string') {
+		node.setHeightPercent(parseInt(style.height, 10));
+	} else {
+		node.setHeightAuto();
+	}
+
+	if (typeof style.minWidth === 'string') {
+		node.setMinWidthPercent(parseInt(style.minWidth, 10));
+	} else {
+		node.setMinWidth(style.minWidth || 0);
+	}
+
+	if (typeof style.minHeight === 'string') {
+		node.setMinHeightPercent(parseInt(style.minHeight, 10));
+	} else {
+		node.setMinHeight(style.minHeight || 0);
+	}
+};
+
+export default (node, style = {}) => {
+	applyPositionStyles(node, style);
+	applyMarginStyles(node, style);
+	applyPaddingStyles(node, style);
+	applyFlexStyles(node, style);
+	applyDimensionStyles(node, style);
+};

--- a/src/experimental/apply-style.js
+++ b/src/experimental/apply-style.js
@@ -28,7 +28,7 @@ const applyFlexStyles = (node, style) => {
 	node.setFlexGrow(style.flexGrow || 0);
 	node.setFlexShrink(typeof style.flexShrink === 'number' ? style.flexShrink : 1);
 
-	if (style.flexDirection === 'row' || !style.flexDirection) {
+	if (style.flexDirection === 'row') {
 		node.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
 	}
 

--- a/src/experimental/dom.js
+++ b/src/experimental/dom.js
@@ -1,0 +1,99 @@
+import Yoga from 'yoga-layout-prebuilt';
+import measureText from '../measure-text';
+import applyStyle from './apply-style';
+
+// Helper utilities implementing some common DOM methods to simplify reconciliation code
+export const createNode = tagName => ({
+	nodeName: tagName.toUpperCase(),
+	style: {},
+	attributes: {},
+	childNodes: [],
+	parentNode: null,
+	textContent: null,
+	yogaNode: Yoga.Node.create()
+});
+
+export const appendChildNode = (node, childNode) => {
+	if (childNode.parentNode) {
+		removeChildNode(childNode.parentNode, childNode);
+	}
+
+	childNode.parentNode = node;
+
+	node.childNodes.push(childNode);
+	node.yogaNode.insertChild(childNode.yogaNode, node.yogaNode.getChildCount());
+};
+
+export const insertBeforeNode = (node, newChildNode, beforeChildNode) => {
+	if (newChildNode.parentNode) {
+		removeChildNode(newChildNode.parentNode, newChildNode);
+	}
+
+	newChildNode.parentNode = node;
+
+	const index = node.childNodes.indexOf(beforeChildNode);
+	if (index >= 0) {
+		node.childNodes.splice(index, 0, newChildNode);
+		node.yogaNode.insertChild(newChildNode.yogaNode, index);
+		return;
+	}
+
+	node.childNodes.push(newChildNode);
+	node.yogaNode.insertChild(newChildNode.yogaNode, node.yogaNode.getChildCount());
+};
+
+export const removeChildNode = (node, removeNode) => {
+	removeNode.parentNode.yogaNode.removeChild(removeNode.yogaNode);
+	removeNode.parentNode = null;
+
+	const index = node.childNodes.indexOf(removeNode);
+	if (index >= 0) {
+		node.childNodes.splice(index, 1);
+	}
+};
+
+export const setStyle = (node, style) => {
+	node.style = style;
+	applyStyle(node.yogaNode, style);
+};
+
+export const setAttribute = (node, key, value) => {
+	node.attributes[key] = value;
+};
+
+export const createTextNode = text => {
+	const node = {
+		nodeName: '#text',
+		nodeValue: text,
+		yogaNode: Yoga.Node.create()
+	};
+
+	setTextContent(node, text);
+
+	return node;
+};
+
+export const setTextContent = (node, text) => {
+	if (typeof text !== 'string') {
+		text = String(text);
+	}
+
+	let width = 0;
+	let height = 0;
+
+	if (text.length > 0) {
+		const dimensions = measureText(text);
+		width = dimensions.width;
+		height = dimensions.height;
+	}
+
+	if (node.nodeName === '#text') {
+		node.nodeValue = text;
+		node.yogaNode.setWidth(width);
+		node.yogaNode.setHeight(height);
+	} else {
+		node.textContent = text;
+		node.yogaNode.setWidth(node.style.width || width);
+		node.yogaNode.setHeight(node.style.height || height);
+	}
+};

--- a/src/experimental/output.js
+++ b/src/experimental/output.js
@@ -1,0 +1,65 @@
+import stringLength from 'string-length';
+import sliceAnsi from 'slice-ansi';
+
+/**
+ * "Virtual" output class
+ *
+ * Handles the positioning and saving of the output of each node in the tree.
+ * Also responsible for applying transformations to each character of the output.
+ *
+ * Used to generate the final output of all nodes before writing it to actual output stream (e.g. stdout)
+ */
+
+export default class Output {
+	constructor({width, height}) {
+		this.width = width;
+		this.height = height;
+		this.writes = [];
+		// Initialize output array with a specific set of rows, so that margin/padding at the bottom is preserved
+	}
+
+	write(x, y, text, {transformers}) {
+		if (!text) {
+			return;
+		}
+
+		this.writes.push({x, y, text, transformers});
+	}
+
+	get() {
+		const output = [];
+
+		for (let y = 0; y < this.height; y++) {
+			output.push(' '.repeat(this.width));
+		}
+
+		for (const write of this.writes) {
+			const {x, y, text, transformers} = write;
+			const lines = text.split('\n');
+			let offsetY = 0;
+
+			for (let line of lines) {
+				const currentLine = output[y + offsetY];
+
+				// Line can be missing if `text` is taller than height of pre-initialized `this.output`
+				if (!currentLine) {
+					continue;
+				}
+
+				const length = stringLength(line);
+
+				for (const transformer of transformers) {
+					line = transformer(line);
+				}
+
+				output[y + offsetY] = sliceAnsi(currentLine, 0, x) + line + sliceAnsi(currentLine, x + length);
+
+				offsetY++;
+			}
+		}
+
+		return output
+			.map(line => line.trimRight())
+			.join('\n');
+	}
+}

--- a/src/experimental/reconciler.js
+++ b/src/experimental/reconciler.js
@@ -1,0 +1,140 @@
+import {
+	unstable_scheduleCallback as schedulePassiveEffects,
+	unstable_cancelCallback as cancelPassiveEffects
+} from 'scheduler';
+import ReactReconciler from 'react-reconciler';
+import {
+	createNode,
+	createTextNode,
+	appendChildNode,
+	insertBeforeNode,
+	removeChildNode,
+	setAttribute,
+	setStyle,
+	setTextContent
+} from './dom';
+
+const NO_CONTEXT = true;
+
+const hostConfig = {
+	schedulePassiveEffects,
+	cancelPassiveEffects,
+	now: Date.now,
+	getRootHostContext: () => NO_CONTEXT,
+	prepareForCommit: () => {},
+	resetAfterCommit: rootNode => {
+		// Since renders are throttled at the instance level and <Static> component children
+		// are rendered only once and then get deleted, we need an escape hatch to
+		// trigger an immediate render to ensure <Static> children are written to output before they get erased
+		if (rootNode.isStaticDirty) {
+			rootNode.isStaticDirty = false;
+			rootNode.onImmediateRender();
+			return;
+		}
+
+		rootNode.onRender();
+	},
+	getChildHostContext: () => NO_CONTEXT,
+	shouldSetTextContent: (type, props) => {
+		return typeof props.children === 'string' || typeof props.children === 'number';
+	},
+	createInstance: (type, newProps) => {
+		const node = createNode(type);
+
+		for (const [key, value] of Object.entries(newProps)) {
+			if (key === 'children') {
+				if (typeof value === 'string' || typeof value === 'number') {
+					if (type === 'div') {
+						// Text node must be wrapped in another node, so that text can be aligned within container
+						const textNode = createNode('div');
+						setTextContent(textNode, value);
+						appendChildNode(node, textNode);
+					}
+
+					if (type === 'span') {
+						setTextContent(node, value);
+					}
+				}
+			} else if (key === 'style') {
+				setStyle(node, value);
+			} else if (key === 'unstable__transformChildren') {
+				node.unstable__transformChildren = value; // eslint-disable-line camelcase
+			} else if (key === 'unstable__static') {
+				node.unstable__static = true; // eslint-disable-line camelcase
+			} else {
+				setAttribute(node, key, value);
+			}
+		}
+
+		return node;
+	},
+	createTextInstance: createTextNode,
+	resetTextContent: node => {
+		if (node.textContent) {
+			node.textContent = '';
+		}
+
+		if (node.childNodes.length > 0) {
+			for (const childNode of node.childNodes) {
+				removeChildNode(node, childNode);
+			}
+		}
+	},
+	getPublicInstance: instance => instance,
+	appendInitialChild: appendChildNode,
+	appendChild: appendChildNode,
+	insertBefore: insertBeforeNode,
+	finalizeInitialChildren: (node, type, props, rootNode) => {
+		if (node.unstable__static) {
+			rootNode.isStaticDirty = true;
+		}
+	},
+	supportsMutation: true,
+	appendChildToContainer: appendChildNode,
+	insertInContainerBefore: insertBeforeNode,
+	removeChildFromContainer: removeChildNode,
+	prepareUpdate: (node, type, oldProps, newProps, rootNode) => {
+		if (node.unstable__static) {
+			rootNode.isStaticDirty = true;
+		}
+
+		return true;
+	},
+	commitUpdate: (node, updatePayload, type, oldProps, newProps) => {
+		for (const [key, value] of Object.entries(newProps)) {
+			if (key === 'children') {
+				if (typeof value === 'string' || typeof value === 'number') {
+					if (type === 'div') {
+						// Text node must be wrapped in another node, so that text can be aligned within container
+						// If there's no such node, a new one must be created
+						if (node.childNodes.length === 0) {
+							const textNode = createNode('div');
+							setTextContent(textNode, value);
+							appendChildNode(node, textNode);
+						} else {
+							setTextContent(node.childNodes[0], value);
+						}
+					}
+
+					if (type === 'span') {
+						setTextContent(node, value);
+					}
+				}
+			} else if (key === 'style') {
+				setStyle(node, value);
+			} else if (key === 'unstable__transformChildren') {
+				node.unstable__transformChildren = value; // eslint-disable-line camelcase
+			} else if (key === 'unstable__static') {
+				node.unstable__static = true; // eslint-disable-line camelcase
+			} else {
+				setAttribute(node, key, value);
+			}
+		}
+	},
+	commitTextUpdate: (node, oldText, newText) => {
+		setTextContent(node, newText);
+	},
+	removeChild: removeChildNode
+};
+
+export default ReactReconciler(hostConfig); // eslint-disable-line new-cap

--- a/src/experimental/renderer.js
+++ b/src/experimental/renderer.js
@@ -1,0 +1,60 @@
+import Yoga from 'yoga-layout-prebuilt';
+import renderNodeToOutput from '../render-node-to-output';
+import calculateWrappedText from '../calculate-wrapped-text';
+import Output from './output';
+import {setStyle} from './dom';
+
+// Since <Static> components can be placed anywhere in the tree, this helper finds and returns them
+const findStaticNode = node => {
+	if (node.unstable__static) {
+		return node;
+	}
+
+	for (const childNode of node.childNodes) {
+		if (childNode.unstable__static) {
+			return childNode;
+		}
+
+		if (Array.isArray(childNode.childNodes) && childNode.childNodes.length > 0) {
+			return findStaticNode(childNode);
+		}
+	}
+};
+
+export default ({terminalWidth = 100}) => {
+	return node => {
+		setStyle(node, {
+			width: terminalWidth
+		});
+
+		node.yogaNode.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+		calculateWrappedText(node);
+		node.yogaNode.calculateLayout(Yoga.UNDEFINED, Yoga.UNDEFINED, Yoga.DIRECTION_LTR);
+
+		const output = new Output({
+			width: node.yogaNode.getComputedWidth(),
+			height: node.yogaNode.getComputedHeight()
+		});
+
+		renderNodeToOutput(node, output, {skipStaticElements: true});
+
+		const staticNode = findStaticNode(node);
+		let staticOutput;
+
+		if (staticNode) {
+			staticOutput = new Output({
+				width: staticNode.yogaNode.getComputedWidth(),
+				height: staticNode.yogaNode.getComputedHeight()
+			});
+
+			renderNodeToOutput(staticNode, staticOutput, {skipStaticElements: false});
+		}
+
+		return {
+			output: output.get(),
+			// Newline at the end is needed, because static output doesn't have one, so
+			// interactive output will override last line of static output
+			staticOutput: staticOutput ? `${staticOutput.get()}\n` : undefined
+		};
+	};
+};

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -3,37 +3,7 @@ import Output from './output';
 import {createNode, appendStaticNode} from './dom';
 import buildLayout from './build-layout';
 import renderNodeToOutput from './render-node-to-output';
-import measureText from './measure-text';
-import wrapText from './wrap-text';
-import getMaxWidth from './get-max-width';
-
-// Since we need to know the width of text container to wrap text, we have to calculate layout twice
-// This function is executed after first layout calculation to reassign width and height of text nodes
-const calculateWrappedText = node => {
-	if (node.textContent && typeof node.parentNode.style.textWrap === 'string') {
-		const {yogaNode} = node;
-		const parentYogaNode = node.parentNode.yogaNode;
-		const maxWidth = getMaxWidth(parentYogaNode);
-		const currentWidth = yogaNode.getComputedWidth();
-
-		if (currentWidth > maxWidth) {
-			const {textWrap} = node.parentNode.style;
-			const wrappedText = wrapText(node.textContent, maxWidth, {textWrap});
-			const {width, height} = measureText(wrappedText);
-
-			yogaNode.setWidth(width);
-			yogaNode.setHeight(height);
-		}
-
-		return;
-	}
-
-	if (Array.isArray(node.childNodes) && node.childNodes.length > 0) {
-		for (const childNode of node.childNodes) {
-			calculateWrappedText(childNode);
-		}
-	}
-};
+import calculateWrappedText from './calculate-wrapped-text';
 
 // Since <Static> components can be placed anywhere in the tree, this helper finds and returns them
 const getStaticNodes = element => {

--- a/test/components.js
+++ b/test/components.js
@@ -9,6 +9,8 @@ import renderToString from './helpers/render-to-string';
 import run from './helpers/run';
 import {Box, Color, Text, Static, StdinContext, render} from '..';
 
+const isExperimental = process.env.EXPERIMENTAL === 'true';
+
 test('text', t => {
 	const output = renderToString(<Box>Hello World</Box>);
 
@@ -209,7 +211,8 @@ test('skip previous output when rendering new static output', t => {
 
 	const {rerender} = render(<Dynamic items={['A']}/>, {
 		stdout,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	});
 
 	t.is(stdout.write.lastCall.args[0], 'A\n');
@@ -248,7 +251,8 @@ test('replace child node with text', t => {
 
 	const {rerender} = render(<Dynamic/>, {
 		stdout,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	});
 
 	t.is(stdout.write.lastCall.args[0], chalk.green('test'));
@@ -274,7 +278,8 @@ test('disable raw mode when all input components are unmounted', t => {
 	const options = {
 		stdout,
 		stdin,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	};
 
 	class Input extends React.Component {
@@ -342,7 +347,8 @@ test('setRawMode() should throw if raw mode is not supported', t => {
 	const options = {
 		stdout,
 		stdin,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	};
 
 	class Input extends React.Component {
@@ -401,7 +407,8 @@ test('render different component based on whether stdin is a TTY or not', t => {
 	const options = {
 		stdout,
 		stdin,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	};
 
 	class Input extends React.Component {

--- a/test/fixtures/ci.js
+++ b/test/fixtures/ci.js
@@ -52,4 +52,6 @@ class Test extends React.Component {
 	}
 }
 
-render(<Test/>);
+render(<Test/>, {
+	experimental: process.env.EXPERIMENTAL === 'true'
+});

--- a/test/fixtures/exit-double-raw-mode.js
+++ b/test/fixtures/exit-double-raw-mode.js
@@ -26,7 +26,9 @@ const {unmount, waitUntilExit} = render((
 			<ExitDoubleRawMode setRawMode={setRawMode}/>
 		)}
 	</StdinContext.Consumer>
-));
+), {
+	experimental: process.env.EXPERIMENTAL === 'true'
+});
 
 process.stdin.on('data', data => {
 	if (String(data) === 'q') {

--- a/test/fixtures/exit-normally.js
+++ b/test/fixtures/exit-normally.js
@@ -2,5 +2,8 @@
 const React = require('react');
 const {render, Box} = require('../..');
 
-const {waitUntilExit} = render(<Box>Hello World</Box>);
+const {waitUntilExit} = render(<Box>Hello World</Box>, {
+	experimental: process.env.EXPERIMENTAL === 'true'
+});
+
 waitUntilExit().then(() => console.log('exited'));

--- a/test/fixtures/exit-on-exit-with-error.js
+++ b/test/fixtures/exit-on-exit-with-error.js
@@ -39,6 +39,8 @@ const app = render((
 			<Test onExit={exit}/>
 		)}
 	</AppContext.Consumer>
-));
+), {
+	experimental: process.env.EXPERIMENTAL === 'true'
+});
 
 app.waitUntilExit().catch(error => console.log(error.message));

--- a/test/fixtures/exit-on-exit.js
+++ b/test/fixtures/exit-on-exit.js
@@ -39,6 +39,8 @@ const app = render((
 			<Test onExit={exit}/>
 		)}
 	</AppContext.Consumer>
-));
+), {
+	experimental: process.env.EXPERIMENTAL === 'true'
+});
 
 app.waitUntilExit().then(() => console.log('exited'));

--- a/test/fixtures/exit-on-finish.js
+++ b/test/fixtures/exit-on-finish.js
@@ -38,4 +38,6 @@ class Test extends React.Component {
 	}
 }
 
-render(<Test/>);
+render(<Test/>, {
+	experimental: process.env.EXPERIMENTAL === 'true'
+});

--- a/test/fixtures/exit-on-unmount.js
+++ b/test/fixtures/exit-on-unmount.js
@@ -30,6 +30,9 @@ class Test extends React.Component {
 	}
 }
 
-const app = render(<Test/>);
+const app = render(<Test/>, {
+	experimental: process.env.EXPERIMENTAL === 'true'
+});
+
 setTimeout(() => app.unmount(), 500);
 app.waitUntilExit().then(() => console.log('exited'));

--- a/test/fixtures/exit-raw-on-exit-with-error.js
+++ b/test/fixtures/exit-raw-on-exit-with-error.js
@@ -26,6 +26,8 @@ const app = render((
 			</StdinContext.Consumer>
 		)}
 	</AppContext.Consumer>
-));
+), {
+	experimental: process.env.EXPERIMENTAL === 'true'
+});
 
 app.waitUntilExit().catch(error => console.log(error.message));

--- a/test/fixtures/exit-raw-on-exit.js
+++ b/test/fixtures/exit-raw-on-exit.js
@@ -26,6 +26,8 @@ const app = render((
 			</StdinContext.Consumer>
 		)}
 	</AppContext.Consumer>
-));
+), {
+	experimental: process.env.EXPERIMENTAL === 'true'
+});
 
 app.waitUntilExit().then(() => console.log('exited'));

--- a/test/fixtures/exit-raw-on-unmount.js
+++ b/test/fixtures/exit-raw-on-unmount.js
@@ -21,7 +21,9 @@ const app = render((
 			<Test onSetRawMode={setRawMode}/>
 		)}
 	</StdinContext.Consumer>
-));
+), {
+	experimental: process.env.EXPERIMENTAL === 'true'
+});
 
 setTimeout(() => app.unmount(), 500);
 app.waitUntilExit().then(() => console.log('exited'));

--- a/test/fixtures/exit-with-thrown-error.js
+++ b/test/fixtures/exit-with-thrown-error.js
@@ -8,6 +8,8 @@ class Test extends React.Component {
 	}
 }
 
-const app = render(<Test/>);
+const app = render(<Test/>, {
+	experimental: process.env.EXPERIMENTAL === 'true'
+});
 
 app.waitUntilExit().catch(error => console.log(error.message));

--- a/test/helpers/render-to-string.js
+++ b/test/helpers/render-to-string.js
@@ -21,7 +21,8 @@ export default (node, {columns} = {}) => {
 
 	render(node, {
 		stdout: stream,
-		debug: true
+		debug: true,
+		experimental: process.env.EXPERIMENTAL === 'true'
 	});
 
 	return stream.get();

--- a/test/reconciler.js
+++ b/test/reconciler.js
@@ -5,6 +5,8 @@ import chalk from 'chalk';
 import {spy} from 'sinon';
 import {Box, Color, render} from '..';
 
+const isExperimental = process.env.EXPERIMENTAL === 'true';
+
 const createStdout = () => ({
 	write: spy(),
 	columns: 100
@@ -18,12 +20,14 @@ test('update child', t => {
 
 	const actual = render(<Test/>, {
 		stdout: stdoutActual,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	});
 
 	const expected = render(<Box>A</Box>, {
 		stdout: stdoutExpected,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	});
 
 	t.is(stdoutActual.write.lastCall.args[0], stdoutExpected.write.lastCall.args[0]);
@@ -42,12 +46,14 @@ test('update text node', t => {
 
 	const actual = render(<Test/>, {
 		stdout: stdoutActual,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	});
 
 	const expected = render(<Box>Hello A</Box>, {
 		stdout: stdoutExpected,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	});
 
 	t.is(stdoutActual.write.lastCall.args[0], stdoutExpected.write.lastCall.args[0]);
@@ -81,7 +87,8 @@ test('append child', t => {
 
 	const actual = render(<Test/>, {
 		stdout: stdoutActual,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	});
 
 	const expected = render((
@@ -90,7 +97,8 @@ test('append child', t => {
 		</Box>
 	), {
 		stdout: stdoutExpected,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	});
 
 	t.is(stdoutActual.write.lastCall.args[0], stdoutExpected.write.lastCall.args[0]);
@@ -132,7 +140,8 @@ test('insert child between other children', t => {
 
 	const actual = render(<Test/>, {
 		stdout: stdoutActual,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	});
 
 	const expected = render((
@@ -142,7 +151,8 @@ test('insert child between other children', t => {
 		</Box>
 	), {
 		stdout: stdoutExpected,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	});
 
 	t.is(stdoutActual.write.lastCall.args[0], stdoutExpected.write.lastCall.args[0]);
@@ -183,7 +193,8 @@ test('remove child', t => {
 
 	const actual = render(<Test/>, {
 		stdout: stdoutActual,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	});
 
 	const expected = render((
@@ -193,7 +204,8 @@ test('remove child', t => {
 		</Box>
 	), {
 		stdout: stdoutExpected,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	});
 
 	t.is(stdoutActual.write.lastCall.args[0], stdoutExpected.write.lastCall.args[0]);
@@ -233,7 +245,8 @@ test('reorder children', t => {
 
 	const actual = render(<Test/>, {
 		stdout: stdoutActual,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	});
 
 	const expected = render((
@@ -243,7 +256,8 @@ test('reorder children', t => {
 		</Box>
 	), {
 		stdout: stdoutExpected,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	});
 
 	t.is(stdoutActual.write.lastCall.args[0], stdoutExpected.write.lastCall.args[0]);
@@ -271,7 +285,8 @@ test('replace child node with text', t => {
 
 	const {rerender} = render(<Dynamic/>, {
 		stdout,
-		debug: true
+		debug: true,
+		experimental: isExperimental
 	});
 
 	t.is(stdout.write.lastCall.args[0], chalk.green('test'));


### PR DESCRIPTION
This work has started after issue on Gatsby's repo was raised about performance implications of using Ink - https://github.com/gatsbyjs/gatsby/issues/15505.

Currently Ink regenerates the entire layout on each render and rebuilds the output as well. This involves recreating all Yoga nodes, which can become expensive as number and frequency of renders grows.

This PR introduces a new experimental reconciler, which only updates necessary bits of the Yoga layout tree on every render. It still rebuilds output from layout every time, but now Ink limits amount of writes into terminal output to 60 frames per second, which should be more than enough for CLIs, which should mitigate that tradeoff.

Author of the Gatsby issue above reported a significant speedup when using this reconciler and I'd appreciate if you also tried it out in your project. This is as simply as passing `experimental` option:

```js
render(<JSX/>, {experimental: true});
```

I want to test it a little more to ensure there are no visual regressions and then I'll replace current reconciler with this one.

As a side effect, this PR also fixes https://github.com/vadimdemedes/ink/issues/183.