### PR TITLE
Add `useApp`, `useStdin` and `useStdout` hooks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -236,7 +236,7 @@ interface AppProps {
 }
 
 /**
- * `<AppContext>` is a React context, which exposes a method to manually exit the app (unmount).
+ * `AppContext` is a React context, which exposes a method to manually exit the app (unmount).
  */
 export const AppContext: React.Context<AppProps>;
 
@@ -281,7 +281,7 @@ interface StdinProps {
 }
 
 /**
- * <StdinContext> is a React context, which exposes input stream.
+ * `StdinContext` is a React context, which exposes input stream.
  */
 export const StdinContext: React.Context<StdinProps>;
 
@@ -299,7 +299,7 @@ interface StdoutProps {
 }
 
 /**
- * `<StdoutContext>` is a React context, which exposes stdout stream, where Ink renders your app.
+ * `StdoutContext` is a React context, which exposes stdout stream, where Ink renders your app.
  */
 export const StdoutContext: React.Context<StdoutProps>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -241,7 +241,24 @@ interface AppProps {
 export const AppContext: React.Context<AppProps>;
 
 /**
- * `useApp()` is a React hook, which exposes props of `AppContext`.
+ * `useApp` is a React hook, which exposes props of `AppContext`.
+ * ```js
+ * import {useApp} from 'ink';
+ *
+ * const MyApp = () => {
+ *   const {exit} = useApp();
+ * };
+ * ```
+ *
+ * It's equivalent to consuming `AppContext` props via `AppContext.Consumer`:
+ *
+ * ```jsx
+ * <AppContext.Consumer>
+ *   {({exit}) => {
+ *     // …
+ *   }}
+ * </AppContext.Consumer>
+ * ```
  */
 export function useApp(): AppProps;
 
@@ -269,7 +286,8 @@ interface StdinProps {
 export const StdinContext: React.Context<StdinProps>;
 
 /**
- * `useStdin()` is a React hook, which exposes props of `StdinContext`.
+ * `useStdin` is a React hook, which exposes props of `StdinContext`.
+ * Similar to `useApp`, it's equivalent to consuming `StdinContext` directly.
  */
 export function useStdin(): StdinProps;
 
@@ -286,6 +304,7 @@ interface StdoutProps {
 export const StdoutContext: React.Context<StdoutProps>;
 
 /**
- * `useStdout()` is a React hook, which exposes props of `StdoutContext`.
+ * `useStdout` is a React hook, which exposes props of `StdoutContext`.
+ * Similar to `useStdout`, it's equivalent to consuming `StdoutContext` directly.
  */
 export function useStdout(): StdoutProps;

--- a/index.d.ts
+++ b/index.d.ts
@@ -228,20 +228,24 @@ export const Text: React.FC<TextProps>;
  */
 export const Static: React.FC<{children: React.ReactNodeArray}>;
 
-/**
- * `<AppContext>` is a React context, which exposes a method to manually exit the app (unmount).
- */
-export const AppContext: React.Context<{
+interface AppProps {
 	/**
 	 * Exit (unmount) the whole Ink app.
 	 */
 	readonly exit: (error?: Error) => void;
-}>;
+}
 
 /**
- * <StdinContext> is a React context, which exposes input stream.
+ * `<AppContext>` is a React context, which exposes a method to manually exit the app (unmount).
  */
-export const StdinContext: React.Context<{
+export const AppContext: React.Context<AppProps>;
+
+/**
+ * `useApp()` is a React hook, which exposes props of `AppContext`.
+ */
+export function useApp(): AppProps;
+
+interface StdinProps {
 	/**
 	 * Stdin stream passed to `render()` in `options.stdin` or `process.stdin` by default. Useful if your app needs to handle user input.
 	 */
@@ -257,14 +261,31 @@ export const StdinContext: React.Context<{
 	 * If the `stdin` stream passed to Ink does not support setRawMode, this function does nothing.
 	 */
 	readonly setRawMode: NodeJS.ReadStream['setRawMode'];
-}>;
+}
 
 /**
- * `<StdoutContext>` is a React context, which exposes stdout stream, where Ink renders your app.
+ * <StdinContext> is a React context, which exposes input stream.
  */
-export const StdoutContext: React.Context<{
+export const StdinContext: React.Context<StdinProps>;
+
+/**
+ * `useStdin()` is a React hook, which exposes props of `StdinContext`.
+ */
+export function useStdin(): StdinProps;
+
+interface StdoutProps {
 	/**
 	 * Stdout stream passed to `render()` in `options.stdout` or `process.stdout` by default.
 	 */
 	readonly stdout: NodeJS.WriteStream;
-}>;
+}
+
+/**
+ * `<StdoutContext>` is a React context, which exposes stdout stream, where Ink renders your app.
+ */
+export const StdoutContext: React.Context<StdoutProps>;
+
+/**
+ * `useStdout()` is a React hook, which exposes props of `StdoutContext`.
+ */
+export function useStdout(): StdoutProps;

--- a/readme.md
+++ b/readme.md
@@ -928,6 +928,38 @@ Default: `false`
 
 [Meta key](https://en.wikipedia.org/wiki/Meta_key) was pressed.
 
+### useApp
+
+`useApp()` is a React hook, which exposes props of [`AppContext`](#app-context).
+
+```js
+import {useApp} from 'ink';
+
+const MyApp = () => {
+	const {exit} = useApp();
+};
+```
+
+It's equivalent to consuming `AppContext` props via `AppContext.Consumer`:
+
+```jsx
+<AppContext.Consumer>
+	{({exit}) => {
+		// …
+	}}
+</AppContext.Consumer>
+```
+
+### useStdin
+
+`useStdin()` is a React hook, which exposes props of [`StdinContext`](#stdin-context).
+Similar to `useApp`, it's equivalent to consuming `StdinContext` directly.
+
+### useStdout
+
+`useStdout()` is a React hook, which exposes props of [`StdoutContext`](#stdout-context).
+Similar to `useApp`, it's equivalent to consuming `StdoutContext` directly.
+
 
 ## Useful Components
 

--- a/readme.md
+++ b/readme.md
@@ -930,7 +930,7 @@ Default: `false`
 
 ### useApp
 
-`useApp()` is a React hook, which exposes props of [`AppContext`](#appcontext).
+`useApp` is a React hook, which exposes props of [`AppContext`](#appcontext).
 
 ```js
 import {useApp} from 'ink';
@@ -952,12 +952,12 @@ It's equivalent to consuming `AppContext` props via `AppContext.Consumer`:
 
 ### useStdin
 
-`useStdin()` is a React hook, which exposes props of [`StdinContext`](#stdincontext).
+`useStdin` is a React hook, which exposes props of [`StdinContext`](#stdincontext).
 Similar to `useApp`, it's equivalent to consuming `StdinContext` directly.
 
 ### useStdout
 
-`useStdout()` is a React hook, which exposes props of [`StdoutContext`](#stdoutcontext).
+`useStdout` is a React hook, which exposes props of [`StdoutContext`](#stdoutcontext).
 Similar to `useApp`, it's equivalent to consuming `StdoutContext` directly.
 
 

--- a/readme.md
+++ b/readme.md
@@ -930,7 +930,7 @@ Default: `false`
 
 ### useApp
 
-`useApp()` is a React hook, which exposes props of [`AppContext`](#app-context).
+`useApp()` is a React hook, which exposes props of [`AppContext`](#appcontext).
 
 ```js
 import {useApp} from 'ink';
@@ -952,12 +952,12 @@ It's equivalent to consuming `AppContext` props via `AppContext.Consumer`:
 
 ### useStdin
 
-`useStdin()` is a React hook, which exposes props of [`StdinContext`](#stdin-context).
+`useStdin()` is a React hook, which exposes props of [`StdinContext`](#stdincontext).
 Similar to `useApp`, it's equivalent to consuming `StdinContext` directly.
 
 ### useStdout
 
-`useStdout()` is a React hook, which exposes props of [`StdoutContext`](#stdout-context).
+`useStdout()` is a React hook, which exposes props of [`StdoutContext`](#stdoutcontext).
 Similar to `useApp`, it's equivalent to consuming `StdoutContext` directly.
 
 

--- a/src/hooks/use-app.js
+++ b/src/hooks/use-app.js
@@ -1,0 +1,4 @@
+import {useContext} from 'react';
+import AppContext from '../components/AppContext';
+
+export default () => useContext(AppContext);

--- a/src/hooks/use-stdin.js
+++ b/src/hooks/use-stdin.js
@@ -1,0 +1,4 @@
+import {useContext} from 'react';
+import StdinContext from '../components/StdinContext';
+
+export default () => useContext(StdinContext);

--- a/src/hooks/use-stdout.js
+++ b/src/hooks/use-stdout.js
@@ -1,0 +1,4 @@
+import {useContext} from 'react';
+import StdoutContext from '../components/StdoutContext';
+
+export default () => useContext(StdoutContext);

--- a/src/index.js
+++ b/src/index.js
@@ -7,3 +7,6 @@ export {default as StdinContext} from './components/StdinContext';
 export {default as StdoutContext} from './components/StdoutContext';
 export {default as Static} from './components/Static';
 export {default as useInput} from './hooks/use-input';
+export {default as useApp} from './hooks/use-app';
+export {default as useStdin} from './hooks/use-stdin';
+export {default as useStdout} from './hooks/use-stdout';

--- a/test/components.js
+++ b/test/components.js
@@ -1,4 +1,4 @@
-/* eslint-disable react/prop-types */
+/* eslint-disable react/prop-types, react/jsx-curly-brace-presence */
 import EventEmitter from 'events';
 import React, {useState} from 'react';
 import test from 'ava';

--- a/test/flex-align-items.js
+++ b/test/flex-align-items.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-curly-brace-presence */
 import React from 'react';
 import test from 'ava';
 import renderToString from './helpers/render-to-string';

--- a/test/flex-justify-content.js
+++ b/test/flex-justify-content.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-curly-brace-presence */
 import React from 'react';
 import test from 'ava';
 import chalk from 'chalk';


### PR DESCRIPTION
Refs #137.

```js
import {useApp, useStdin, useStdout} from 'ink';

...

const {exit} = useApp();
const {stdin, isRawModeSupported, setRawMode} = useStdin();
const {stdout} = useStdout();
```