### PR TITLE
Remove `@types/react` from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,6 @@
 		"colors",
 		"text"
 	],
-	"peerDependencies": {
-		"@types/react": "^16.8.6"
-	},
 	"dependencies": {
 		"ansi-escapes": "^4.2.1",
 		"arrify": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
 		"xo": "^0.24.0"
 	},
 	"peerDependencies": {
+		"@types/react": ">=16.8.0",
 		"react": ">=16.8.0"
 	},
 	"babel": {

--- a/package.json
+++ b/package.json
@@ -39,8 +39,10 @@
 		"colors",
 		"text"
 	],
+	"peerDependencies": {
+		"@types/react": "^16.8.6"
+	},
 	"dependencies": {
-		"@types/react": "^16.8.6",
 		"ansi-escapes": "^4.2.1",
 		"arrify": "^1.0.1",
 		"auto-bind": "^2.0.0",
@@ -61,6 +63,7 @@
 		"yoga-layout-prebuilt": "^1.9.3"
 	},
 	"devDependencies": {
+		"@types/react": "^16.8.6",
 		"@babel/cli": "^7.1.2",
 		"@babel/core": "^7.1.2",
 		"@babel/plugin-proposal-class-properties": "^7.1.0",


### PR DESCRIPTION
Introduced when adding typescript support https://github.com/vadimdemedes/ink/pull/136/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R43.

Adding `@types/react` to the `dependencies` is _great_. It allows users of the `ink` package to not worry about types. The react types are included automagically. However, having **multiple** `@types/react` in the dependency chain can cause havoc in a project, as `@types/react` tries to modify globals (specifically JSX globals). `tsc` will fail, noting that there are multiple declarations of X, Y and Z, where these are all the globals that are modified.

Having multiple `@types/react` in the chain happens for example when hoisting, when using workspaces, when using monorepos etc. Additionally, a user _should_ be able to provide their own `@types/react` version independent of this package.

A possible solution is to make this a peer dependency: it won't be provided by the `ink` library unless it's not present.

----

Note that in npm@3, it's likely that `peerDependencies` won't be automatically installed as they themselves can cause dependency hell. In this case, since typescript usage is optional, I would recommend adding this as an optional dependency.