### PR TITLE
Add an `active` parameter to `useInput`

### DIFF
--- a/src/hooks/use-input.js
+++ b/src/hooks/use-input.js
@@ -1,18 +1,26 @@
 import {useEffect, useContext} from 'react';
 import {StdinContext} from '..';
 
-export default inputHandler => {
+export default (inputHandler, {active = true} = {}) => {
 	const {stdin, setRawMode} = useContext(StdinContext);
 
-	useEffect(() => {
+    useEffect(() => {
+		if (!active) {
+			return;
+		}
+
 		setRawMode(true);
 
 		return () => {
 			setRawMode(false);
 		};
-	}, [setRawMode]);
+    }, [active, setRawMode]);
 
-	useEffect(() => {
+    useEffect(() => {
+		if (!active) {
+			return;
+		}
+
 		const handleData = data => {
 			let input = String(data);
 			const key = {
@@ -52,5 +60,5 @@ export default inputHandler => {
 		return () => {
 			stdin.off('data', handleData);
 		};
-	}, [stdin, inputHandler]);
+    }, [active, stdin, inputHandler]);
 };


### PR DESCRIPTION
The `useInput` hook is nice, but it's always attaching itself to `stdin`. This may cause issues when too many elements are calling it, as Node will then print a warning that will glitch the output:

```
(node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.
```

In my case it happens because each row of a table has a `useInput` registration in order to navigate from left to right - but only when the row is selected in the first place.

A fix that works for me is to simply disable the `useInput` hook for components that don't need it right now (ie rows that aren't currently selected). Unfortunately, since hooks don't work when inside control flows, it means the check must be internalised into the hook - hence this PR.
