### PR TITLE
Add ink-markdown to the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -958,7 +958,7 @@ Similar to `useApp`, it's equivalent to consuming `StdoutContext` directly.
 -   [ink-progress-bar](https://github.com/brigand/ink-progress-bar) - Configurable component for rendering progress bars.
 -   [ink-table](https://github.com/maticzav/ink-table) - Table component.
 -   [ink-ascii](https://github.com/hexrcs/ink-ascii) - Awesome text component with more font choices, based on Figlet.
--   [ink-markdown](https://github.com/cameronhunter/ink-markdown) - Render syntax highlighted markdown.
+-   [ink-markdown](https://github.com/cameronhunter/ink-markdown) - Render syntax highlighted Markdown.
 
 ### Incompatible components
 

--- a/readme.md
+++ b/readme.md
@@ -958,6 +958,7 @@ Similar to `useApp`, it's equivalent to consuming `StdoutContext` directly.
 -   [ink-progress-bar](https://github.com/brigand/ink-progress-bar) - Configurable component for rendering progress bars.
 -   [ink-table](https://github.com/maticzav/ink-table) - Table component.
 -   [ink-ascii](https://github.com/hexrcs/ink-ascii) - Awesome text component with more font choices, based on Figlet.
+-   [ink-markdown](https://github.com/cameronhunter/ink-markdown) - Render syntax highlighted markdown.
 
 ### Incompatible components
 


### PR DESCRIPTION
Add a link to [`ink-markdown`](https://github.com/cameronhunter/ink-markdown) in the "Useful Components" section