### PR TITLE
Mention `ink-use-stdout-dimensions` in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -942,6 +942,7 @@ Similar to `useApp`, it's equivalent to consuming `StdinContext` directly.
 Similar to `useApp`, it's equivalent to consuming `StdoutContext` directly.
 
 ## Useful Hooks
+
 -   [ink-use-stdout-dimensions](https://github.com/cameronhunter/ink-monorepo/tree/master/packages/ink-use-stdout-dimensions) - Subscribe to stdout dimensions.
 
 ## Useful Components

--- a/readme.md
+++ b/readme.md
@@ -941,6 +941,9 @@ Similar to `useApp`, it's equivalent to consuming `StdinContext` directly.
 `useStdout` is a React hook, which exposes props of [`StdoutContext`](#stdoutcontext).
 Similar to `useApp`, it's equivalent to consuming `StdoutContext` directly.
 
+## Useful Hooks
+-   [ink-use-stdout-dimensions](https://github.com/cameronhunter/ink-monorepo/tree/master/packages/ink-use-stdout-dimensions) - Subscribe to stdout dimensions.
+
 ## Useful Components
 
 -   [ink-text-input](https://github.com/vadimdemedes/ink-text-input) - Text input.


### PR DESCRIPTION
Add "Useful Hooks" section and a link to [`ink-use-stdout-dimensions`](https://github.com/cameronhunter/ink-monorepo/tree/master/packages/ink-use-stdout-dimensions).