### PR TITLE
Move `@types/react` to be an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,11 @@
 		"@types/react": ">=16.8.0",
 		"react": ">=16.8.0"
 	},
+	"peerDependenciesMeta": {
+		"@types/react": {
+			"optional": true
+		}
+	},
 	"babel": {
 		"plugins": [
 			"@babel/plugin-proposal-class-properties",


### PR DESCRIPTION
This should remove one of the warnings about `@types/react` missing that I get on `npm install`:

<img width="641" alt="image" src="https://user-images.githubusercontent.com/2098462/72993251-5c1e6880-3df5-11ea-9fcb-fc6624053a79.png">

This is basically what Sindre did for `auto-bind`: https://github.com/sindresorhus/auto-bind/commit/66a053fbc3782b425e98693c0a78b22847e724c1

Ideally, we'd also upgrade the dependency on `auto-bind` itself from `3.0.0` to `4.0.0`, so that the change I linked is included.