### PR TITLE
Fix error when squashing empty text nodes

### DIFF
--- a/src/render-node-to-output.js
+++ b/src/render-node-to-output.js
@@ -27,6 +27,10 @@ const isAllTextNodes = node => {
 // Also, this is necessary for libraries like ink-link (https://github.com/sindresorhus/ink-link),
 // which need to wrap all children at once, instead of wrapping 3 text nodes separately.
 const squashTextNodes = node => {
+	if (node.childNodes.length === 0) {
+		return '';
+	}
+
 	// If parent container is `<Box>`, text nodes will be treated as separate nodes in
 	// the tree and will have their own coordinates in the layout.
 	// To ensure text nodes are aligned correctly, take X and Y of the first text node

--- a/test/components.js
+++ b/test/components.js
@@ -164,10 +164,10 @@ test('squash multiple nested text nodes', t => {
 	t.is(output, '[{hello world}]');
 });
 
-test('squash empty <Text> nodes', t => {
+test('squash empty `<Text>` nodes', t => {
 	const output = renderToString(
-		<Box unstable__transformChildren={str => `[${str}]`}>
-			<Box unstable__transformChildren={str => `{${str}}`}>
+		<Box unstable__transformChildren={string => `[${string}]`}>
+			<Box unstable__transformChildren={string => `{${string}}`}>
 				<Text>{[]}</Text>
 			</Box>
 		</Box>

--- a/test/components.js
+++ b/test/components.js
@@ -164,6 +164,18 @@ test('squash multiple nested text nodes', t => {
 	t.is(output, '[{hello world}]');
 });
 
+test('squash empty <Text> nodes', t => {
+	const output = renderToString(
+		<Box unstable__transformChildren={str => `[${str}]`}>
+			<Box unstable__transformChildren={str => `{${str}}`}>
+				<Text>{[]}</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, '');
+});
+
 test('hooks', t => {
 	const WithHooks = () => {
 		const [value] = useState('Hello');


### PR DESCRIPTION
Ink currently (since the [improvements to alignment](https://github.com/vadimdemedes/ink/compare/v2.4.0...v2.5.0?diff=unified#diff-38693372290cabd092ab6ade4a4db655) in 2.5.0) throws an error when trying to squash text nodes with zero child nodes. This PR avoids that error by bailing out early on empty text nodes.

Fixes #241