### PR TITLE
Use the same rendering approach on CI and non-CI environment by default

### DIFF
--- a/src/instance.js
+++ b/src/instance.js
@@ -92,7 +92,7 @@ export default class Instance {
 			return;
 		}
 
-		if (isCI) {
+		if (this.options.CIMode && isCI) {
 			if (hasStaticOutput) {
 				this.options.stdout.write(staticOutput);
 			}
@@ -155,7 +155,7 @@ export default class Instance {
 
 		// CIs don't handle erasing ansi escapes well, so it's better to
 		// only render last frame of non-static output
-		if (isCI) {
+		if (this.options.CIMode && isCI) {
 			this.options.stdout.write(this.lastOutput + '\n');
 		} else if (!this.options.debug) {
 			this.log.done();


### PR DESCRIPTION
### Current behaviour
 
The components are rendered using different approaches on `CI` and `non-CI` environment.

- `CI` - Only the last frame is rendered on `CI` env. The output is rendered before exiting e.g before unmounting the component (for non-static output).
- `non-CI` - The components are rendered by erasing specified amount of lines (using `ascii` symbols) from terminal.

### The problem with current behaviour

We have `semi-integration` tests with the following setup:
* API calls are mocked
* A particular command is executed by spawning an interactive child process
* [An interactive inputs](https://github.com/vadimdemedes/ink-text-input) are shown and their values are entered by writing to the `stdin` of the spawned child process

So, we have interactive input fields (for example, with label `Enter your username`) and tests wait for that particular label (`Enter your username`) to be rendered before writing the input value.
However, the output on `CI` environment is rendered when unmounting the component. But the component is never unmounted as it waits for user input (`unmount` life cycle method is never called). All of this resulted in `timeout` issue **only on our `CI`**, locally tests are green.

After spending a lot of time investigating the issue and trying different things (changing `CI` build setup, running the tests on `self-hosted` agents in `AWS` and others) we found the problem comes from `ink` library and rendering approach on `CI` environment.

### Proposed behaviour

This PR changes the default behaviour and renders the same output on `CI` and `non-CI` environment by default. In case we want to render only last frame on `CI`, we can pass `CIMode ` option. This way, only the last frame will be rendered  on `CI` and all frames will be rendered on `non-CI` environment. Specifying `CIMode` as part of rendering options will confirm that we're expecting different output on `CI` and `non-CI`.

> NOTE:  If we agree on this approach and on the name of the new option (`CIMode`), I'll add a description in `readme`  as well.