### PR TITLE
Adds support for ansi and ansi256

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,12 +100,16 @@ export function render<Props>(
 ): Instance;
 
 export interface ColorProps {
+	readonly ansi?: number;
+	readonly ansi256?: number;		
 	readonly hex?: string;
 	readonly hsl?: [number, number, number];
 	readonly hsv?: [number, number, number];
 	readonly hwb?: [number, number, number];
 	readonly rgb?: [number, number, number];
 	readonly keyword?: string;
+	readonly bgAnsi?: number;
+	readonly bgAnsi256?: number;	
 	readonly bgHex?: string;
 	readonly bgHsl?: [number, number, number];
 	readonly bgHsv?: [number, number, number];

--- a/src/components/Color.js
+++ b/src/components/Color.js
@@ -4,12 +4,16 @@ import arrify from 'arrify';
 import chalk from 'chalk';
 
 const methods = [
+	'ansi',
+	'ansi256',
 	'hex',
 	'hsl',
 	'hsv',
 	'hwb',
 	'rgb',
 	'keyword',
+	'bgAnsi',
+	'bgAnsi256',
 	'bgHex',
 	'bgHsl',
 	'bgHsv',


### PR DESCRIPTION
Hi!

I'm working on a CLI and currently in need of support for `ansi` and `ansi256` from Chalk.

This PR declares four methods from Chalk's API: `ansi`, `bgAnsi`, `ansi256` and `bgAnsi256`.