### PR TITLE
Memoize <Color>, <Text> and <Transform> components

### DIFF
--- a/src/components/Color.tsx
+++ b/src/components/Color.tsx
@@ -1,4 +1,4 @@
-import React, {FC, ReactNode} from 'react';
+import React, {FC, ReactNode, memo} from 'react';
 import PropTypes from 'prop-types';
 import arrify from 'arrify';
 import chalk, {Chalk} from 'chalk';
@@ -46,7 +46,7 @@ const methods = [
 /**
  * The `<Color>` compoment is a simple wrapper around the `chalk` API. It supports all of the `chalk`'s methods as `props`.
  */
-export const Color: FC<ColorProps> = ({children, ...colorProps}) => {
+export const Color: FC<ColorProps> = memo(({children, ...colorProps}) => {
 	if (children === '') {
 		return null;
 	}
@@ -69,7 +69,7 @@ export const Color: FC<ColorProps> = ({children, ...colorProps}) => {
 	};
 
 	return <Transform transform={transform}>{children}</Transform>;
-};
+});
 
 Color.propTypes = {
 	children: PropTypes.node

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -1,4 +1,4 @@
-import React, {FC, ReactNode} from 'react';
+import React, {FC, ReactNode, memo} from 'react';
 import PropTypes from 'prop-types';
 import chalk from 'chalk';
 import {Transform} from './Transform';
@@ -15,40 +15,42 @@ export interface TextProps {
 /**
  * This component can change the style of the text, make it bold, underline, italic or strikethrough.
  */
-export const Text: FC<TextProps> = ({
-	bold,
-	italic,
-	underline,
-	strikethrough,
-	children,
-	unstable__transformChildren
-}) => {
-	const transform = (children: ReactNode) => {
-		if (bold) {
-			children = chalk.bold(children);
-		}
+export const Text: FC<TextProps> = memo(
+	({
+		bold,
+		italic,
+		underline,
+		strikethrough,
+		children,
+		unstable__transformChildren
+	}) => {
+		const transform = (children: ReactNode) => {
+			if (bold) {
+				children = chalk.bold(children);
+			}
 
-		if (italic) {
-			children = chalk.italic(children);
-		}
+			if (italic) {
+				children = chalk.italic(children);
+			}
 
-		if (underline) {
-			children = chalk.underline(children);
-		}
+			if (underline) {
+				children = chalk.underline(children);
+			}
 
-		if (strikethrough) {
-			children = chalk.strikethrough(children);
-		}
+			if (strikethrough) {
+				children = chalk.strikethrough(children);
+			}
 
-		if (typeof unstable__transformChildren === 'function') {
-			children = unstable__transformChildren(children);
-		}
+			if (typeof unstable__transformChildren === 'function') {
+				children = unstable__transformChildren(children);
+			}
 
-		return children;
-	};
+			return children;
+		};
 
-	return <Transform transform={transform}>{children}</Transform>;
-};
+		return <Transform transform={transform}>{children}</Transform>;
+	}
+);
 
 /* eslint-disable react/boolean-prop-naming */
 Text.propTypes = {

--- a/src/components/Transform.tsx
+++ b/src/components/Transform.tsx
@@ -1,4 +1,4 @@
-import React, {FC, ReactNode} from 'react';
+import React, {FC, ReactNode, memo} from 'react';
 import PropTypes from 'prop-types';
 
 export interface TransformProps {
@@ -9,7 +9,7 @@ export interface TransformProps {
 /*
  * Transform a string representation of React components before they are written to output.
  */
-export const Transform: FC<TransformProps> = ({children, transform}) => (
+export const Transform: FC<TransformProps> = memo(({children, transform}) => (
 	<span
 		style={{flexDirection: 'row'}}
 		// @ts-ignore
@@ -17,7 +17,7 @@ export const Transform: FC<TransformProps> = ({children, transform}) => (
 	>
 		{children}
 	</span>
-);
+));
 
 Transform.propTypes = {
 	transform: PropTypes.func.isRequired,


### PR DESCRIPTION
Since all of these components are pure (don't have side effects), it's safe to
memoize their output. This means that the output of these components will be
rerendered only when their props change.

This small optimization results in a nice performance boost in Ink's rendering
process - from ~3,6k ops/sec to ~4,6k ops/sec.