### PR TITLE
Implement a new <Static> component

### DIFF
--- a/benchmark/static/index.js
+++ b/benchmark/static/index.js
@@ -1,0 +1,2 @@
+'use strict';
+require('import-jsx')('./static');

--- a/benchmark/static/static.js
+++ b/benchmark/static/static.js
@@ -1,0 +1,87 @@
+/* eslint-disable react/jsx-curly-brace-presence */
+'use strict';
+const React = require('react');
+const {render, Static, Box, Color, Text} = require('../..');
+const Spinner = require('ink-spinner').default;
+
+const App = () => {
+	const [items, setItems] = React.useState([]);
+	const [showSpinner, setShowSpinner] = React.useState(true);
+	const itemCountRef = React.useRef(0);
+
+	React.useEffect(() => {
+		let timer;
+
+		const run = () => {
+			if (itemCountRef.current++ > 1000) {
+				setShowSpinner(false);
+				return;
+			}
+
+			setItems(previousItems => [
+				...previousItems,
+				{
+					id: previousItems.length
+				}
+			]);
+
+			timer = setTimeout(run, 10);
+		};
+
+		run();
+
+		return () => {
+			clearTimeout(timer);
+		};
+	}, []);
+
+	return (
+		<Box flexDirection="column">
+			<Static items={items}>
+				{(item, index) => (
+					<Box key={item.id} padding={1} flexDirection="column">
+						<Color green>Item #{index}</Color>
+						<Text>Item content</Text>
+					</Box>
+				)}
+			</Static>
+
+			<Box flexDirection="column" padding={1}>
+				<Text underline bold>
+					<Color red>
+						{'Hello'} {'World'}
+					</Color>
+				</Text>
+
+				{showSpinner && <Spinner type="dots" />}
+				<Text>Rendered: {items.length}</Text>
+
+				<Box marginTop={1} width={60}>
+					Cupcake ipsum dolor sit amet candy candy. Sesame snaps cookie I love
+					tootsie roll apple pie bonbon wafer. Caramels sesame snaps icing
+					cotton candy I love cookie sweet roll. I love bonbon sweet.
+				</Box>
+
+				<Box marginTop={1} flexDirection="column">
+					<Color bgWhite black>
+						Colors:
+					</Color>
+
+					<Box flexDirection="column" paddingLeft={1}>
+						<Text>
+							- <Color red>Red</Color>
+						</Text>
+						<Text>
+							- <Color blue>Blue</Color>
+						</Text>
+						<Text>
+							- <Color green>Green</Color>
+						</Text>
+					</Box>
+				</Box>
+			</Box>
+		</Box>
+	);
+};
+
+render(<App />);

--- a/examples/jest/jest.js
+++ b/examples/jest/jest.js
@@ -38,10 +38,10 @@ class Jest extends React.Component {
 
 		return (
 			<Box flexDirection="column">
-				<Static>
-					{completedTests.map(test => (
+				<Static items={completedTests}>
+					{test => (
 						<Test key={test.path} status={test.status} path={test.path} />
-					))}
+					)}
 				</Static>
 
 				{runningTests.length > 0 && (

--- a/readme.md
+++ b/readme.md
@@ -644,25 +644,21 @@ Usage:
 
 #### `<Static>`
 
-`<Static>` component allows permanently rendering output to stdout and preserving it across renders.
-Components passed to `<Static>` as children will be written to stdout only once and will never be rerendered.
-`<Static>` output comes first, before any other output from your components, no matter where it is in the tree.
-In order for this mechanism to work properly, at most one `<Static>` component must be present in your node tree and components that were rendered must never update their output. Ink will detect new children appended to `<Static>` and render them to stdout.
+`<Static>` component permanently renders its output above everything else.
+It's useful for displaying activity like completed tasks or logs - things that
+are not changing after they're rendered (hence the name "Static").
 
-**Note:** `<Static>` accepts only an array of children and each of them must have a unique key.
+It's preferred to use `<Static>` for use cases like these, when you can't know
+or control the amount of items that need to be rendered.
 
-Example use case for this component is Jest's output:
-
-![](https://jestjs.io/img/content/feature-fast.png)
-
-Jest continuously writes the list of completed tests to the output, while updating test results at the bottom of the output in real-time. Here's how this user interface could be implemented with Ink:
+For example, [Tap](https://github.com/tapjs/node-tap) uses `<Static>` to display
+a list of completed tests. [Gatsby](https://github.com/gatsbyjs/gatsby) uses it
+to display a list of generated pages, while still displaying a live progress bar.
 
 ```jsx
 <>
-	<Static>
-		{tests.map(test => (
-			<Test key={test.id} title={test.title} />
-		))}
+	<Static items={tests}>
+		{test => <Test key={test.id} title={test.title} />}
 	</Static>
 
 	<Box marginTop={1}>
@@ -671,7 +667,52 @@ Jest continuously writes the list of completed tests to the output, while updati
 </>
 ```
 
-See [examples/jest](examples/jest/jest.js) for a basic implementation of Jest's UI.
+**Note:** `<Static>` only renders new items in `items` prop and ignores items
+that were previously rendered. This means that when you add new items to `items`
+array, changes you make to previous items will not trigger a rerender.
+
+See [examples/jest](examples/jest/jest.js) for a basic implementation of Jest's
+UI using `<Static>` component.
+
+##### items
+
+Type: `array`
+
+Array of items of any type to render using a function you pass as a component child.
+
+##### style
+
+Type: `object`
+
+Styles to apply to a container of child elements.
+See [`<Box>`](#box) for supported properties.
+
+```jsx
+<Static items={...} style={{padding: 1}}>
+	{...}
+</Static>
+```
+
+##### children
+
+Type: `Function`
+
+Function that is called to render every item in `items` array.
+First argument is an item itself and second argument is index of that item in
+`items` array.
+
+Note that `key` must be assigned to the root component.
+
+```jsx
+<Static items={['a', 'b', 'c']}>
+	{(item, index) => {
+		// This function is called for every item in ['a', 'b', 'c']
+		// `item` is 'a', 'b', 'c'
+		// `index` is 0, 1, 2
+		return <Box key={index}>Item: {item}</Box>;
+	}}
+</Static>
+```
 
 #### `<Transform>`
 

--- a/readme.md
+++ b/readme.md
@@ -676,7 +676,7 @@ UI using `<Static>` component.
 
 ##### items
 
-Type: `array`
+Type: `Array`
 
 Array of items of any type to render using a function you pass as a component child.
 

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -8,7 +8,7 @@ import {Styles} from './styles';
 interface InkNode {
 	parentNode: DOMElement | null;
 	yogaNode?: Yoga.YogaNode;
-	unstable__static?: boolean;
+	internal_static?: boolean;
 	style: Styles;
 }
 
@@ -25,10 +25,11 @@ export type DOMElement = {
 	textContent?: string;
 	childNodes: DOMNode[];
 	internal_transform?: OutputTransformer;
-	onRender?: () => void;
 
-	// Experimental properties
+	// Internal properties
 	isStaticDirty?: boolean;
+	staticNode?: any;
+	onRender?: () => void;
 	onImmediateRender?: () => void;
 } & InkNode;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export {Color, ColorProps} from './components/Color';
 export {AppContext, AppContextProps} from './components/AppContext';
 export {StdinContext, StdinContextProps} from './components/StdinContext';
 export {StdoutContext, StdoutContextProps} from './components/StdoutContext';
-export {Static} from './components/Static';
+export {Static, StaticProps} from './components/Static';
 export {Transform, TransformProps} from './components/Transform';
 export {useInput, Key} from './hooks/use-input';
 export {useApp} from './hooks/use-app';

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -133,11 +133,14 @@ export class Ink {
 		if (hasStaticOutput) {
 			this.log.clear();
 			this.options.stdout.write(staticOutput);
+			this.log(output);
 		}
 
-		if (output !== this.lastOutput) {
+		if (!hasStaticOutput && output !== this.lastOutput) {
 			this.throttledLog(output);
 		}
+
+		this.lastOutput = output;
 	};
 
 	render(node: ReactNode): void {

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -95,8 +95,8 @@ export const reconciler = createReconciler<
 				setStyle(node, value);
 			} else if (key === 'internal_transform') {
 				node.internal_transform = value;
-			} else if (key === 'unstable__static') {
-				node.unstable__static = true;
+			} else if (key === 'internal_static') {
+				node.internal_static = true;
 			} else {
 				setAttribute(node, key, value);
 			}
@@ -134,8 +134,12 @@ export const reconciler = createReconciler<
 	appendChild: appendChildNode,
 	insertBefore: insertBeforeNode,
 	finalizeInitialChildren: (node, _type, _props, rootNode) => {
-		if (node.unstable__static) {
+		if (node.internal_static) {
 			rootNode.isStaticDirty = true;
+
+			// Save reference to <Static> node to skip traversal of entire
+			// node tree to find it
+			rootNode.staticNode = node;
 		}
 
 		return false;
@@ -148,7 +152,7 @@ export const reconciler = createReconciler<
 		cleanupYogaNode(removeNode.yogaNode!);
 	},
 	prepareUpdate: (node, _type, _oldProps, _newProps, rootNode) => {
-		if (node.unstable__static) {
+		if (node.internal_static) {
 			rootNode.isStaticDirty = true;
 		}
 
@@ -178,8 +182,8 @@ export const reconciler = createReconciler<
 				setStyle(node, value);
 			} else if (key === 'internal_transform') {
 				node.internal_transform = value;
-			} else if (key === 'unstable__static') {
-				node.unstable__static = true;
+			} else if (key === 'internal_static') {
+				node.internal_static = true;
 			} else {
 				setAttribute(node, key, value);
 			}

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -90,7 +90,7 @@ export const renderNodeToOutput = (
 		skipStaticElements
 	} = options;
 
-	if (skipStaticElements && node.unstable__static) {
+	if (skipStaticElements && node.internal_static) {
 		return;
 	}
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,26 +1,7 @@
 import Yoga from 'yoga-layout-prebuilt';
 import {renderNodeToOutput} from './render-node-to-output';
 import {Output} from './output';
-import {setStyle, DOMElement, TEXT_NAME} from './dom';
-
-// Since <Static> components can be placed anywhere in the tree, this helper finds and returns them
-const findStaticNode = (node: DOMElement): DOMElement | undefined => {
-	if (node.unstable__static) {
-		return node;
-	}
-
-	for (const childNode of node.childNodes) {
-		if (childNode.nodeName !== TEXT_NAME) {
-			if (childNode.unstable__static) {
-				return childNode;
-			}
-
-			return findStaticNode(childNode);
-		}
-	}
-
-	return undefined;
-};
+import {setStyle, DOMElement} from './dom';
 
 export type Renderer = (
 	node: DOMElement
@@ -48,16 +29,15 @@ export const createRenderer: CreateRenderer = ({terminalWidth = 100}) => {
 
 			renderNodeToOutput(node, output, {skipStaticElements: true});
 
-			const staticNode = findStaticNode(node);
 			let staticOutput;
 
-			if (staticNode?.yogaNode) {
+			if (node.staticNode?.yogaNode) {
 				staticOutput = new Output({
-					width: staticNode.yogaNode.getComputedWidth(),
-					height: staticNode.yogaNode.getComputedHeight()
+					width: node.staticNode.yogaNode.getComputedWidth(),
+					height: node.staticNode.yogaNode.getComputedHeight()
 				});
 
-				renderNodeToOutput(staticNode, staticOutput, {
+				renderNodeToOutput(node.staticNode, staticOutput, {
 					skipStaticElements: false
 				});
 			}

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -197,10 +197,8 @@ test('hooks', t => {
 test('static output', t => {
 	const output = renderToString(
 		<Box>
-			<Static paddingBottom={1}>
-				<Box key="a">A</Box>
-				<Box key="b">B</Box>
-				<Box key="c">C</Box>
+			<Static items={['A', 'B', 'C']} style={{paddingBottom: 1}}>
+				{letter => <Box key={letter}>{letter}</Box>}
 			</Static>
 
 			<Box marginTop={1}>X</Box>
@@ -217,11 +215,7 @@ test('skip previous output when rendering new static output', t => {
 	};
 
 	const Dynamic: FC<{items: string[]}> = ({items}) => (
-		<Static>
-			{items.map(item => (
-				<Box key={item}>{item}</Box>
-			))}
-		</Static>
+		<Static items={items}>{item => <Box key={item}>{item}</Box>}</Static>
 	);
 
 	const {rerender} = render(<Dynamic items={['A']} />, {

--- a/test/fixtures/ci.tsx
+++ b/test/fixtures/ci.tsx
@@ -17,10 +17,8 @@ class Test extends React.Component<Record<string, unknown>, TestState> {
 	render() {
 		return (
 			<>
-				<Static>
-					{this.state.items.map(item => (
-						<Box key={item}>{item}</Box>
-					))}
+				<Static items={this.state.items}>
+					{item => <Box key={item}>{item}</Box>}
 				</Static>
 
 				<Box>Counter: {this.state.counter}</Box>

--- a/test/fixtures/erase-with-static.tsx
+++ b/test/fixtures/erase-with-static.tsx
@@ -3,10 +3,8 @@ import {Static, Box, Text, render} from '../../src';
 
 const EraseWithStatic = () => (
 	<>
-		<Static>
-			<Text key="a">A</Text>
-			<Text key="b">B</Text>
-			<Text key="c">C</Text>
+		<Static items={['A', 'B', 'C']}>
+			{item => <Text key={item}>{item}</Text>}
 		</Static>
 
 		<Box flexDirection="column">

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -48,6 +48,10 @@ test('do not erase screen', async t => {
 	const ps = term('erase', ['4']);
 	await ps.waitForExit();
 	t.false(ps.output.includes(ansiEscapes.clearTerminal));
+
+	['A', 'B', 'C'].forEach(letter => {
+		t.true(ps.output.includes(letter));
+	});
 });
 
 test('do not erase screen where <Static> is taller than viewport', async t => {
@@ -55,16 +59,28 @@ test('do not erase screen where <Static> is taller than viewport', async t => {
 
 	await ps.waitForExit();
 	t.false(ps.output.includes(ansiEscapes.clearTerminal));
+
+	['A', 'B', 'C', 'D', 'E', 'F'].forEach(letter => {
+		t.true(ps.output.includes(letter));
+	});
 });
 
 test('erase screen', async t => {
 	const ps = term('erase', ['3']);
 	await ps.waitForExit();
 	t.true(ps.output.includes(ansiEscapes.clearTerminal));
+
+	['A', 'B', 'C'].forEach(letter => {
+		t.true(ps.output.includes(letter));
+	});
 });
 
 test('erase screen where <Static> exists but interactive part is taller than viewport', async t => {
 	const ps = term('erase', ['3']);
 	await ps.waitForExit();
 	t.true(ps.output.includes(ansiEscapes.clearTerminal));
+
+	['A', 'B', 'C'].forEach(letter => {
+		t.true(ps.output.includes(letter));
+	});
 });


### PR DESCRIPTION
Previous implementation of `<Static>` component was performing poorly for apps
with thousands of items to render. Ink's rendering process slowed down
proportionally to the number of children in `<Static>` component, because
React has to call `React.createElement()` for each child, even if it was already
rendered. See https://github.com/gatsbyjs/gatsby/pull/21955#discussion_r387703540
for more context.

This change changes the API of a `<Static>` component to call `React.createElement()`
and render only new items, ignoring the items that were already rendered.
The new API is looking very similar to virtual list libraries.
You pass a list of items to render via `items` prop and specify a function
that is responsible for rendering each item, the rest is handled for you.

```jsx
<Static items={['a', 'b', 'c']}>
	{item => <Box key={item}>Item: {item}</Box>}
</Static>
```

This change also removes the need to traverse entire node tree on every render
to find where `<Static>` is located and extract its contents. Reconciler
is going to save a reference to `<Static>` node as soon as it encounters one,
saving precious CPU cycles and thus making rendering less expensive.