### PR TITLE
Use a fork of log-update for displaying output

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
 		"cli-truncate": "^2.1.0",
 		"is-ci": "^2.0.0",
 		"lodash.throttle": "^4.1.1",
-		"log-update": "^3.0.0",
 		"prop-types": "^15.6.2",
 		"react-reconciler": "^0.24.0",
 		"scheduler": "^0.18.0",

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -1,6 +1,6 @@
 import React, {ReactNode} from 'react';
 import throttle from 'lodash.throttle';
-import logUpdate, {LogUpdate} from 'log-update';
+import logUpdate, {LogUpdate} from './log-update';
 import ansiEscapes from 'ansi-escapes';
 import originalIsCI from 'is-ci';
 import autoBind from 'auto-bind';

--- a/src/log-update.ts
+++ b/src/log-update.ts
@@ -1,0 +1,51 @@
+import {Writable} from 'stream';
+import ansiEscapes from 'ansi-escapes';
+import cliCursor from 'cli-cursor';
+
+export interface LogUpdate {
+	clear: () => void;
+	done: () => void;
+	(str: string): void;
+}
+
+const create = (stream: Writable, {showCursor = false} = {}): LogUpdate => {
+	let previousLineCount = 0;
+	let previousOutput = '';
+	let hasHiddenCursor = false;
+
+	const render = (str: string) => {
+		if (!showCursor && !hasHiddenCursor) {
+			cliCursor.hide();
+			hasHiddenCursor = true;
+		}
+
+		const output = str + '\n';
+		if (output === previousOutput) {
+			return;
+		}
+
+		previousOutput = output;
+		stream.write(ansiEscapes.eraseLines(previousLineCount) + output);
+		previousLineCount = output.split('\n').length;
+	};
+
+	render.clear = () => {
+		stream.write(ansiEscapes.eraseLines(previousLineCount));
+		previousOutput = '';
+		previousLineCount = 0;
+	};
+
+	render.done = () => {
+		previousOutput = '';
+		previousLineCount = 0;
+
+		if (!showCursor) {
+			cliCursor.show();
+			hasHiddenCursor = false;
+		}
+	};
+
+	return render;
+};
+
+export default {create};


### PR DESCRIPTION
`log-update` module wraps output on every render, which slows down performance
of Ink apps. Ink doesn't need that and some other functionality, because it
handles wrapping itself, so `log-update` is essentially performing the same
work twice.

This change adds a forked and stripped down version of `log-update` with the
plan to merge the changes upstream in the future.