### PR TITLE
Fix text wrapping inside padded container

### DIFF
--- a/src/get-max-width.ts
+++ b/src/get-max-width.ts
@@ -1,8 +1,0 @@
-import Yoga from 'yoga-layout-prebuilt';
-
-export const getMaxWidth = (yogaNode: Yoga.YogaNode) => {
-	return (
-		yogaNode.getComputedWidth() -
-		yogaNode.getComputedPadding(Yoga.EDGE_LEFT) * 2
-	);
-};

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -1,7 +1,6 @@
 import Yoga from 'yoga-layout-prebuilt';
 import widestLine from 'widest-line';
 import {wrapText} from './wrap-text';
-import {getMaxWidth} from './get-max-width';
 import {DOMNode, DOMElement} from './dom';
 import {Output} from './output';
 
@@ -128,7 +127,7 @@ export const renderNodeToOutput = (
 			if (node.parentNode) {
 				const currentWidth = widestLine(text);
 				const maxWidth = node.parentNode.yogaNode
-					? getMaxWidth(node.parentNode.yogaNode)
+					? node.parentNode.yogaNode.getComputedWidth()
 					: 0;
 
 				if (currentWidth > maxWidth) {
@@ -146,7 +145,7 @@ export const renderNodeToOutput = (
 		if (isFlexDirectionRow && node.childNodes.every(isAllTextNodes)) {
 			let text = squashTextNodes(node);
 			const currentWidth = widestLine(text);
-			const maxWidth = getMaxWidth(yogaNode);
+			const maxWidth = yogaNode.getComputedWidth();
 
 			if (currentWidth > maxWidth) {
 				const wrapType = node.style.textWrap ?? 'wrap';

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -183,6 +183,20 @@ test('squash empty `<Text>` nodes', t => {
 	t.is(output, '');
 });
 
+test('squash multiple nested text nodes within a container with padding', t => {
+	const output = renderToString(
+		<Box padding={1}>
+			{1} new message:{' '}
+			<Color green>
+				{'Hello '}
+				{'World'}
+			</Color>
+		</Box>
+	);
+
+	t.is(output, `\n 1 new message: ${chalk.green('Hello World')}\n`);
+});
+
 test('hooks', t => {
 	const WithHooks = () => {
 		const [value] = useState('Hello');

--- a/test/padding.tsx
+++ b/test/padding.tsx
@@ -68,3 +68,14 @@ test('padding with multiline string', t => {
 
 	t.is(output, '\n\n  A\n  B\n\n');
 });
+
+test('don’t take padding dimensions into account when wrapping text', t => {
+	const output = renderToString(
+		<Box>
+			<Box padding={1}>Hello World</Box>
+			<Box>It works</Box>
+		</Box>
+	);
+
+	t.is(output, '             It works\n Hello World\n');
+});


### PR DESCRIPTION
Fixes regression from https://github.com/vadimdemedes/ink/pull/276.

If padding is taken into account when calculating max width of parent container
to decide whether to wrap text or not, it results in invalid text wrapping.
For example, if there's a "Hello World" text that fits inside container,
adding padding to that container will basically subtract max width of it
and cause text wrapping when it's not needed.

This change removes padding from max width calculation.