### PR TITLE
Fix padding with newlines and text wrapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"chalk": "^3.0.0",
 		"cli-cursor": "^3.1.0",
 		"cli-truncate": "^2.1.0",
+		"indent-string": "^4.0.0",
 		"is-ci": "^2.0.0",
 		"lodash.throttle": "^4.1.1",
 		"prop-types": "^15.6.2",

--- a/src/get-max-width.ts
+++ b/src/get-max-width.ts
@@ -1,0 +1,8 @@
+import Yoga from 'yoga-layout-prebuilt';
+
+export const getMaxWidth = (yogaNode: Yoga.YogaNode) => {
+	return (
+		yogaNode.getComputedWidth() -
+		yogaNode.getComputedPadding(Yoga.EDGE_LEFT) * 2
+	);
+};

--- a/src/get-max-width.ts
+++ b/src/get-max-width.ts
@@ -3,6 +3,7 @@ import Yoga from 'yoga-layout-prebuilt';
 export const getMaxWidth = (yogaNode: Yoga.YogaNode) => {
 	return (
 		yogaNode.getComputedWidth() -
-		yogaNode.getComputedPadding(Yoga.EDGE_LEFT) * 2
+		yogaNode.getComputedPadding(Yoga.EDGE_LEFT) -
+		yogaNode.getComputedPadding(Yoga.EDGE_RIGHT)
 	);
 };

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -1,5 +1,6 @@
 import Yoga from 'yoga-layout-prebuilt';
 import widestLine from 'widest-line';
+import indentString from 'indent-string';
 import {wrapText} from './wrap-text';
 import {getMaxWidth} from './get-max-width';
 import {DOMNode, DOMElement} from './dom';
@@ -32,39 +33,43 @@ const isAllTextNodes = (node: DOMNode): boolean => {
 const squashTextNodes = (node: DOMElement): string => {
 	let text = '';
 	if (node.childNodes.length > 0) {
-		// If parent container is `<Box>`, text nodes will be treated as separate nodes in
-		// the tree and will have their own coordinates in the layout.
-		// To ensure text nodes are aligned correctly, take X and Y of the first text node
-		// and use them as offset for the rest of the nodes
-		// Only first node is taken into account, because other text nodes can't have margin or padding,
-		// so their coordinates will be relative to the first node anyway
-		const [{yogaNode}] = node.childNodes;
-		if (yogaNode) {
-			const offsetX = yogaNode.getComputedLeft();
-			const offsetY = yogaNode.getComputedTop();
+		for (const childNode of node.childNodes) {
+			let nodeText = '';
 
-			text = '\n'.repeat(offsetY) + ' '.repeat(offsetX);
-
-			for (const childNode of node.childNodes) {
-				let nodeText = '';
-
-				if (childNode.nodeName === '#text') {
-					nodeText = childNode.nodeValue;
-				} else {
-					if (childNode.nodeName === 'SPAN') {
-						nodeText = childNode.textContent ?? squashTextNodes(childNode);
-					}
-
-					// Since these text nodes are being concatenated, `Output` instance won't be able to
-					// apply children transform, so we have to do it manually here for each text node
-					if (typeof childNode.internal_transform === 'function') {
-						nodeText = childNode.internal_transform(nodeText);
-					}
+			if (childNode.nodeName === '#text') {
+				nodeText = childNode.nodeValue;
+			} else {
+				if (childNode.nodeName === 'SPAN') {
+					nodeText = childNode.textContent ?? squashTextNodes(childNode);
 				}
 
-				text += nodeText;
+				// Since these text nodes are being concatenated, `Output` instance won't be able to
+				// apply children transform, so we have to do it manually here for each text node
+				if (typeof childNode.internal_transform === 'function') {
+					nodeText = childNode.internal_transform(nodeText);
+				}
 			}
+
+			text += nodeText;
 		}
+	}
+
+	return text;
+};
+
+// If parent container is `<Box>`, text nodes will be treated as separate nodes in
+// the tree and will have their own coordinates in the layout.
+// To ensure text nodes are aligned correctly, take X and Y of the first text node
+// and use it as offset for the rest of the nodes
+// Only first node is taken into account, because other text nodes can't have margin or padding,
+// so their coordinates will be relative to the first node anyway
+const applyPaddingToText = (node: DOMElement, text: string): string => {
+	const yogaNode = node.childNodes[0]?.yogaNode;
+
+	if (yogaNode) {
+		const offsetX = yogaNode.getComputedLeft();
+		const offsetY = yogaNode.getComputedTop();
+		text = '\n'.repeat(offsetY) + indentString(text, offsetX);
 	}
 
 	return text;
@@ -153,6 +158,7 @@ export const renderNodeToOutput = (
 				text = wrapText(text, maxWidth, wrapType);
 			}
 
+			text = applyPaddingToText(node, text);
 			output.write(x, y, text, {transformers: newTransformers});
 			return;
 		}

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -1,6 +1,7 @@
 import Yoga from 'yoga-layout-prebuilt';
 import widestLine from 'widest-line';
 import {wrapText} from './wrap-text';
+import {getMaxWidth} from './get-max-width';
 import {DOMNode, DOMElement} from './dom';
 import {Output} from './output';
 
@@ -127,7 +128,7 @@ export const renderNodeToOutput = (
 			if (node.parentNode) {
 				const currentWidth = widestLine(text);
 				const maxWidth = node.parentNode.yogaNode
-					? node.parentNode.yogaNode.getComputedWidth()
+					? getMaxWidth(node.parentNode.yogaNode)
 					: 0;
 
 				if (currentWidth > maxWidth) {
@@ -145,7 +146,7 @@ export const renderNodeToOutput = (
 		if (isFlexDirectionRow && node.childNodes.every(isAllTextNodes)) {
 			let text = squashTextNodes(node);
 			const currentWidth = widestLine(text);
-			const maxWidth = yogaNode.getComputedWidth();
+			const maxWidth = getMaxWidth(yogaNode);
 
 			if (currentWidth > maxWidth) {
 				const wrapType = node.style.textWrap ?? 'wrap';

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -183,20 +183,6 @@ test('squash empty `<Text>` nodes', t => {
 	t.is(output, '');
 });
 
-test('squash multiple nested text nodes within a container with padding', t => {
-	const output = renderToString(
-		<Box padding={1}>
-			{1} new message:{' '}
-			<Color green>
-				{'Hello '}
-				{'World'}
-			</Color>
-		</Box>
-	);
-
-	t.is(output, `\n 1 new message: ${chalk.green('Hello World')}\n`);
-});
-
 test('hooks', t => {
 	const WithHooks = () => {
 		const [value] = useState('Hello');

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -103,7 +103,7 @@ test('truncate text in the beginning', t => {
 	t.is(output, '… World');
 });
 
-test('empty text node', t => {
+test('ignore empty text node', t => {
 	const output = renderToString(
 		<Box flexDirection="column">
 			<Box>Hello World</Box>
@@ -112,6 +112,11 @@ test('empty text node', t => {
 	);
 
 	t.is(output, 'Hello World');
+});
+
+test('render a single empty text node', t => {
+	const output = renderToString(<Text>{''}</Text>);
+	t.is(output, '');
 });
 
 test('number', t => {

--- a/test/margin.tsx
+++ b/test/margin.tsx
@@ -68,3 +68,18 @@ test('margin with multiline string', t => {
 
 	t.is(output, '\n\n  A\n  B\n\n');
 });
+
+test('apply margin to text with newlines', t => {
+	const output = renderToString(<Box margin={1}>Hello{'\n'}World</Box>);
+	t.is(output, '\n Hello\n World\n');
+});
+
+test('apply margin to wrapped text', t => {
+	const output = renderToString(
+		<Box margin={1} width={6}>
+			Hello World
+		</Box>
+	);
+
+	t.is(output, '\n Hello\n World\n');
+});

--- a/test/padding.tsx
+++ b/test/padding.tsx
@@ -68,14 +68,3 @@ test('padding with multiline string', t => {
 
 	t.is(output, '\n\n  A\n  B\n\n');
 });
-
-test('don’t take padding dimensions into account when wrapping text', t => {
-	const output = renderToString(
-		<Box>
-			<Box padding={1}>Hello World</Box>
-			<Box>It works</Box>
-		</Box>
-	);
-
-	t.is(output, '             It works\n Hello World\n');
-});

--- a/test/padding.tsx
+++ b/test/padding.tsx
@@ -68,3 +68,18 @@ test('padding with multiline string', t => {
 
 	t.is(output, '\n\n  A\n  B\n\n');
 });
+
+test('apply padding to text with newlines', t => {
+	const output = renderToString(<Box padding={1}>Hello{'\n'}World</Box>);
+	t.is(output, '\n Hello\n World\n');
+});
+
+test('apply padding to wrapped text', t => {
+	const output = renderToString(
+		<Box padding={1} width={5}>
+			Hello World
+		</Box>
+	);
+
+	t.is(output, '\n Hel\n lo\n Wor\n ld\n');
+});


### PR DESCRIPTION
As part of this change #283 is reverted.
That PR incorrectly changed padding behavior to expand container dimensions,
instead of shrinking available space for its content, which is not what Yoga does.

This PR restores the original behavior, consistent with Yoga. It also fixes
support for newlines (`\n`) in text when there's padding or text wrapping.
After this change, all lines in text will have correct padding.