### PR TITLE
Add write() function to write any string to stdout

### DIFF
--- a/examples/use-stdout/index.js
+++ b/examples/use-stdout/index.js
@@ -1,0 +1,2 @@
+'use strict';
+require('import-jsx')('./use-stdout');

--- a/examples/use-stdout/use-stdout.js
+++ b/examples/use-stdout/use-stdout.js
@@ -1,0 +1,34 @@
+'use strict';
+const React = require('react');
+const {render, Box, Text, useStdout} = require('../..');
+
+const Example = () => {
+	const {stdout, write} = useStdout();
+
+	React.useEffect(() => {
+		const timer = setInterval(() => {
+			write('Hello from Ink to stdout\n');
+		}, 1000);
+
+		return () => {
+			clearInterval(timer);
+		};
+	}, []);
+
+	return (
+		<Box flexDirection="column" paddingX={2} paddingY={1}>
+			<Text bold underline>
+				Terminal dimensions:
+			</Text>
+
+			<Box marginTop={1}>
+				Width: <Text bold>{stdout.columns}</Text>
+			</Box>
+			<Box>
+				Height: <Text bold>{stdout.rows}</Text>
+			</Box>
+		</Box>
+	);
+};
+
+render(<Example />);

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
 		"prettier": "^2.0.4",
 		"react": "^16.9.0",
 		"sinon": "^8.1.1",
+		"strip-ansi": "^6.0.0",
 		"svg-term-cli": "^2.1.1",
 		"ts-node": "7.0.0",
 		"typescript": "^3.8.3",

--- a/readme.md
+++ b/readme.md
@@ -829,12 +829,6 @@ Usage:
 
 `<StdoutContext>` is a [React context](https://reactjs.org/docs/context.html#reactcreatecontext), which exposes stdout stream, where Ink renders your app.
 
-Import:
-
-```js
-import {StdoutContext} from 'ink';
-```
-
 ##### stdout
 
 Type: `stream.Writable`<br>
@@ -843,9 +837,40 @@ Default: `process.stdout`
 Usage:
 
 ```jsx
-<StdoutContext.Consumer>
-	{({stdout}) => <MyComponent stdout={stdout} />}
-</StdoutContext.Consumer>
+import {StdoutContext} from 'ink';
+
+const MyApp = () => {
+	const {stdout} = useContext(StdoutContext);
+
+	return …
+};
+```
+
+##### write(data)
+
+Write any string to stdout, while preserving Ink's output.
+It's useful when you want to display some external information outside of Ink's rendering and ensure there's no conflict between the two.
+It's similar to `<Static>`, except it can't accept components, it only works with strings.
+
+###### data
+
+Type: `string`
+
+Data to write to stdout.
+
+```jsx
+import {StdoutContext} from 'ink';
+
+const MyApp = () => {
+	const {write} = useContext(StdoutContext);
+
+	useEffect(() => {
+		// Write a single message to stdout, above Ink's output
+		write('Hello from Ink to stdout\n');
+	}, []);
+
+	return …
+};
 ```
 
 ## Hooks
@@ -981,33 +1006,6 @@ Similar to `useApp`, it's equivalent to consuming `StdinContext` directly.
 Similar to `useApp`, it's equivalent to consuming `StdoutContext` directly.
 
 See usage example in [examples/use-stdout](examples/use-stdout/use-stdout.js).
-
-#### write(data)
-
-Write any string to stdout, while preserving Ink's output.
-It's useful when you want to display some external information outside of Ink's rendering and ensure there's no conflict between the two.
-It's similar to `<Static>`, except it can't accept components, it only works with strings.
-
-##### data
-
-Type: `string`
-
-Data to write to stdout.
-
-```jsx
-import {useStdout} from 'ink';
-
-const MyApp = () => {
-	const {write} = useStdout();
-
-	useEffect(() => {
-		// Write a single message to stdout, above Ink's output
-		write('Hello from Ink to stdout\n');
-	}, []);
-
-	return <JSX />;
-};
-```
 
 ## Useful Hooks
 

--- a/readme.md
+++ b/readme.md
@@ -980,6 +980,35 @@ Similar to `useApp`, it's equivalent to consuming `StdinContext` directly.
 `useStdout` is a React hook, which exposes props of [`StdoutContext`](#stdoutcontext).
 Similar to `useApp`, it's equivalent to consuming `StdoutContext` directly.
 
+See usage example in [examples/use-stdout](examples/use-stdout/use-stdout.js).
+
+#### write(data)
+
+Write any string to stdout, while preserving Ink's output.
+It's useful when you want to display some external information outside of Ink's rendering and ensure there's no conflict between the two.
+It's similar to `<Static>`, except it can't accept components, it only works with strings.
+
+##### data
+
+Type: `string`
+
+Data to write to stdout.
+
+```jsx
+import {useStdout} from 'ink';
+
+const MyApp = () => {
+	const {write} = useStdout();
+
+	useEffect(() => {
+		// Write a single message to stdout, above Ink's output
+		write('Hello from Ink to stdout\n');
+	}, []);
+
+	return <JSX />;
+};
+```
+
 ## Useful Hooks
 
 - [ink-use-stdout-dimensions](https://github.com/cameronhunter/ink-monorepo/tree/master/packages/ink-use-stdout-dimensions) - Subscribe to stdout dimensions.

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -9,6 +9,7 @@ interface Props {
 	children: ReactNode;
 	stdin: NodeJS.ReadStream;
 	stdout: NodeJS.WriteStream;
+	writeToStdout: (data: string) => void;
 	exitOnCtrlC: boolean;
 	onExit: (error?: Error) => void;
 }
@@ -21,6 +22,7 @@ export class App extends PureComponent<Props> {
 		children: PropTypes.node.isRequired,
 		stdin: PropTypes.object.isRequired,
 		stdout: PropTypes.object.isRequired,
+		writeToStdout: PropTypes.func.isRequired,
 		exitOnCtrlC: PropTypes.bool.isRequired, // eslint-disable-line react/boolean-prop-naming
 		onExit: PropTypes.func.isRequired
 	};
@@ -50,7 +52,8 @@ export class App extends PureComponent<Props> {
 				>
 					<StdoutContext.Provider
 						value={{
-							stdout: this.props.stdout
+							stdout: this.props.stdout,
+							write: this.props.writeToStdout
 						}}
 					>
 						{this.props.children}

--- a/src/components/StdoutContext.ts
+++ b/src/components/StdoutContext.ts
@@ -5,11 +5,19 @@ export interface StdoutContextProps {
 	 * Stdout stream passed to `render()` in `options.stdout` or `process.stdout` by default.
 	 */
 	stdout?: NodeJS.WriteStream;
+
+	/**
+	 * Write any string to stdout, while preserving Ink's output.
+	 * It's useful when you want to display some external information outside of Ink's rendering and ensure there's no conflict between the two.
+	 * It's similar to `<Static>`, except it can't accept components, it only works with strings.
+	 */
+	write: (data: string) => void;
 }
 
 /**
  * `StdoutContext` is a React context, which exposes stdout stream, where Ink renders your app.
  */
 export const StdoutContext = createContext<StdoutContextProps>({
-	stdout: undefined
+	stdout: undefined,
+	write: () => {}
 });

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -148,6 +148,7 @@ export class Ink {
 			<App
 				stdin={this.options.stdin}
 				stdout={this.options.stdout}
+				writeToStdout={this.writeToStdout}
 				exitOnCtrlC={this.options.exitOnCtrlC}
 				onExit={this.unmount}
 			>
@@ -156,6 +157,26 @@ export class Ink {
 		);
 
 		reconciler.updateContainer(tree, this.container);
+	}
+
+	writeToStdout(data: string): void {
+		if (this.isUnmounted) {
+			return;
+		}
+
+		if (this.options.debug) {
+			this.options.stdout.write(data + this.fullStaticOutput + this.lastOutput);
+			return;
+		}
+
+		if (isCI) {
+			this.options.stdout.write(data);
+			return;
+		}
+
+		this.log.clear();
+		this.options.stdout.write(data);
+		this.log(this.lastOutput);
 	}
 
 	unmount(error?: Error | number | null): void {

--- a/test/fixtures/use-stdout.tsx
+++ b/test/fixtures/use-stdout.tsx
@@ -1,0 +1,19 @@
+import React, {FC, useEffect} from 'react';
+import {render, useStdout, Text} from '../../src';
+
+const WriteToStdout: FC = () => {
+	const {write} = useStdout();
+
+	useEffect(() => {
+		write('Hello from Ink to stdout\n');
+	}, []);
+
+	return <Text>Hello World</Text>;
+};
+
+const app = render(<WriteToStdout />);
+
+(async () => {
+	await app.waitUntilExit();
+	console.log('exited');
+})();

--- a/test/hooks.tsx
+++ b/test/hooks.tsx
@@ -12,11 +12,14 @@ const term = (fixture: string, args: string[] = []) => {
 		reject = reject2;
 	});
 
+	const env = {...process.env};
+	delete env.CI;
+
 	const ps = spawn('ts-node', [`./fixtures/${fixture}.tsx`, ...args], {
 		name: 'xterm-color',
 		cols: 100,
 		cwd: __dirname,
-		env: process.env
+		env
 	});
 
 	const result = {

--- a/test/hooks.tsx
+++ b/test/hooks.tsx
@@ -1,5 +1,6 @@
 import {serial as test} from 'ava';
 import {spawn} from 'node-pty';
+import stripAnsi from 'strip-ansi';
 
 const term = (fixture: string, args: string[] = []) => {
 	let resolve: (value?: any) => void;
@@ -116,8 +117,6 @@ test('useStdout - write to stdout', async t => {
 	const ps = term('use-stdout');
 	await ps.waitForExit();
 
-	const lines = ps.output.split('\n').slice(1);
-	t.true(lines[0].includes('Hello from Ink to stdout'));
-	t.true(lines[1].includes('Hello World'));
-	t.true(lines[2].includes('exited'));
+	const lines = stripAnsi(ps.output).split('\r\n').slice(1, -1);
+	t.deepEqual(lines, ['Hello from Ink to stdout', 'Hello World', 'exited']);
 });

--- a/test/hooks.tsx
+++ b/test/hooks.tsx
@@ -40,74 +40,84 @@ const term = (fixture: string, args: string[] = []) => {
 	return result;
 };
 
-test('handle lowercase character', async t => {
+test('useInput - handle lowercase character', async t => {
 	const ps = term('use-input', ['lowercase']);
 	ps.write('q');
 	await ps.waitForExit();
 	t.true(ps.output.includes('exited'));
 });
 
-test('handle uppercase character', async t => {
+test('useInput - handle uppercase character', async t => {
 	const ps = term('use-input', ['uppercase']);
 	ps.write('Q');
 	await ps.waitForExit();
 	t.true(ps.output.includes('exited'));
 });
 
-test('handle escape', async t => {
+test('useInput - handle escape', async t => {
 	const ps = term('use-input', ['escape']);
 	ps.write('\u001B');
 	await ps.waitForExit();
 	t.true(ps.output.includes('exited'));
 });
 
-test('handle ctrl', async t => {
+test('useInput - handle ctrl', async t => {
 	const ps = term('use-input', ['ctrl']);
 	ps.write('\u0006');
 	await ps.waitForExit();
 	t.true(ps.output.includes('exited'));
 });
 
-test('handle meta', async t => {
+test('useInput - handle meta', async t => {
 	const ps = term('use-input', ['meta']);
 	ps.write('\u001Bm');
 	await ps.waitForExit();
 	t.true(ps.output.includes('exited'));
 });
 
-test('handle up arrow', async t => {
+test('useInput - handle up arrow', async t => {
 	const ps = term('use-input', ['upArrow']);
 	ps.write('\u001B[A');
 	await ps.waitForExit();
 	t.true(ps.output.includes('exited'));
 });
 
-test('handle down arrow', async t => {
+test('useInput - handle down arrow', async t => {
 	const ps = term('use-input', ['downArrow']);
 	ps.write('\u001B[B');
 	await ps.waitForExit();
 	t.true(ps.output.includes('exited'));
 });
 
-test('handle left arrow', async t => {
+test('useInput - handle left arrow', async t => {
 	const ps = term('use-input', ['leftArrow']);
 	ps.write('\u001B[D');
 	await ps.waitForExit();
 	t.true(ps.output.includes('exited'));
 });
 
-test('handle right arrow', async t => {
+test('useInput - handle right arrow', async t => {
 	const ps = term('use-input', ['rightArrow']);
 	ps.write('\u001B[C');
 	await ps.waitForExit();
 	t.true(ps.output.includes('exited'));
 });
 
-test('ignore input if not active', async t => {
+test('useInput - ignore input if not active', async t => {
 	const ps = term('use-input-multiple');
 	ps.write('x');
 	await ps.waitForExit();
 	t.false(ps.output.includes('xx'));
 	t.true(ps.output.includes('x'));
 	t.true(ps.output.includes('exited'));
+});
+
+test('useStdout - write to stdout', async t => {
+	const ps = term('use-stdout');
+	await ps.waitForExit();
+
+	const lines = ps.output.split('\n').slice(1);
+	t.true(lines[0].includes('Hello from Ink to stdout'));
+	t.true(lines[1].includes('Hello World'));
+	t.true(lines[2].includes('exited'));
 });


### PR DESCRIPTION
I encountered a use case when people wanted to proxy `console.log()` and
`console.error()` to stdout and stderr respectively. Previously, they could
use `<Static>` component for this, but it only supports stdout. Adding stderr
support to `<Static>` turned out to not be viable, because it's still part of
CLI's output.

Instead, considering the specificity of this community request, I went for a
simpler solution - let you write any string to stdout and stderr.
Behavior is essentially the same as `<Static>`, except it results in much smaller
performance implications due to the fact that `write()` only accepts strings,
not React components.

This change adds support for stdout, support for stderr will be added separately.

```jsx
import {useStdout} from 'ink';

const MyApp = () => {
	const {write} = useStdout();

	useEffect(() => {
		// Write a single message to stdout, above Ink's output
		write('Hello from Ink to stdout\n');
	}, []);

	return <JSX />;
};
```