### PR TITLE
Add focus management

### DIFF
--- a/examples/use-focus/index.js
+++ b/examples/use-focus/index.js
@@ -1,0 +1,2 @@
+'use strict';
+require('import-jsx')('./use-focus');

--- a/examples/use-focus/use-focus.js
+++ b/examples/use-focus/use-focus.js
@@ -1,0 +1,27 @@
+/* eslint-disable react/prop-types */
+'use strict';
+const React = require('react');
+const {render, Box, Text, Color, useFocus} = require('../..');
+
+const Focus = () => (
+	<Box flexDirection="column" padding={1}>
+		<Box marginBottom={1}>
+			Press Tab to focus next element, Shift+Tab to focus previous element, Esc
+			to reset focus.
+		</Box>
+		<Item label="First" />
+		<Item label="Second" />
+		<Item label="Third" />
+	</Box>
+);
+
+const Item = ({label}) => {
+	const {isFocused} = useFocus();
+	return (
+		<Text>
+			{label} {isFocused && <Color green>(focused)</Color>}
+		</Text>
+	);
+};
+
+render(<Focus />);

--- a/readme.md
+++ b/readme.md
@@ -1108,6 +1108,128 @@ const Example = () => {
 };
 ```
 
+### useFocus(options?)
+
+Component that uses `useFocus` hook becomes "focusable" to Ink, so when user presses <kbd>Tab</kbd>, Ink will switch focus to this component.
+If there are multiple components that execute `useFocus` hook, focus will be given to them in the order that these components are rendered in.
+This hook returns an object with `isFocused` boolean property, which determines if this component is focused or not.
+
+#### options
+
+##### autoFocus
+
+Type: `boolean`<br>
+Default: `false`
+
+Auto focus this component, if there's no active (focused) component right now.
+
+##### isActive
+
+Type: `boolean`<br>
+Default: `true`
+
+Enable or disable this component's focus, while still maintaining its position in the list of focusable components.
+This is useful for inputs that are temporarily disabled.
+
+```js
+import {useFocus} from 'ink';
+
+const Example = () => {
+	const {isFocused} = useFocus();
+
+	return <Text>{isFocused ? 'I am focused' : 'I am not focused'}</Text>;
+};
+```
+
+See example in [examples/use-focus](examples/use-focus/use-focus.js).
+
+### useFocusManager
+
+This hook exposes methods to enable or disable focus management for all components or manually switch focus to next or previous components.
+
+#### enableFocus()
+
+Enable focus management for all components.
+
+**Note:** You don't need to call this method manually, unless you've disabled focus management. Focus management is enabled by default.
+
+```js
+import {useFocusManager} from 'ink';
+
+const Example = () => {
+	const {enableFocus} = useFocusManager();
+
+	useEffect(() => {
+		enableFocus();
+	}, []);
+
+	return …
+};
+```
+
+#### disableFocus()
+
+Disable focus management for all components.
+Currently active component (if there's one) will lose its focus.
+
+```js
+import {useFocusManager} from 'ink';
+
+const Example = () => {
+	const {disableFocus} = useFocusManager();
+
+	useEffect(() => {
+		disableFocus();
+	}, []);
+
+	return …
+};
+```
+
+#### focusNext()
+
+Switch focus to the next focusable component.
+If there's no active component right now, focus will be given to the first focusable component.
+If active component is the last in the list of focusable components, focus will be switched to the first component.
+
+**Note:** Ink calls this method when user presses <kbd>Tab</kbd>.
+
+```js
+import {useFocusManager} from 'ink';
+
+const Example = () => {
+	const {focusNext} = useFocusManager();
+
+	useEffect(() => {
+		focusNext();
+	}, []);
+
+	return …
+};
+```
+
+#### focusPrevious()
+
+Switch focus to the previous focusable component.
+If there's no active component right now, focus will be given to the first focusable component.
+If active component is the first in the list of focusable components, focus will be switched to the last component.
+
+**Note:** Ink calls this method when user presses <kbd>Shift</kbd>+<kbd>Tab</kbd>.
+
+```js
+import {useFocusManager} from 'ink';
+
+const Example = () => {
+	const {focusPrevious} = useFocusManager();
+
+	useEffect(() => {
+		focusPrevious();
+	}, []);
+
+	return …
+};
+```
+
 ## Useful Hooks
 
 - [ink-use-stdout-dimensions](https://github.com/cameronhunter/ink-monorepo/tree/master/packages/ink-use-stdout-dimensions) - Subscribe to stdout dimensions.

--- a/src/components/FocusContext.ts
+++ b/src/components/FocusContext.ts
@@ -1,0 +1,29 @@
+import {createContext} from 'react';
+
+export interface Props {
+	activeId?: string;
+	add: (id: string, options: {autoFocus: boolean}) => void;
+	remove: (id: string) => void;
+	activate: (id: string) => void;
+	deactivate: (id: string) => void;
+	enableFocus: () => void;
+	disableFocus: () => void;
+	focusNext: () => void;
+	focusPrevious: () => void;
+}
+
+const FocusContext = createContext<Props>({
+	activeId: undefined,
+	add: () => {},
+	remove: () => {},
+	activate: () => {},
+	deactivate: () => {},
+	enableFocus: () => {},
+	disableFocus: () => {},
+	focusNext: () => {},
+	focusPrevious: () => {}
+});
+
+FocusContext.displayName = 'InternalFocusContext';
+
+export default FocusContext;

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -54,6 +54,13 @@ customGlobal.window.__REACT_DEVTOOLS_COMPONENT_FILTERS__ = [
 		value: 'InternalStdinContext',
 		isEnabled: true,
 		isValid: true
+	},
+	{
+		// ComponentFilterDisplayName
+		type: 2,
+		value: 'InternalFocusContext',
+		isEnabled: true,
+		isValid: true
 	}
 ];
 

--- a/src/hooks/use-focus-manager.ts
+++ b/src/hooks/use-focus-manager.ts
@@ -1,0 +1,46 @@
+import {useContext} from 'react';
+import FocusContext from '../components/FocusContext';
+import type {Props} from '../components/FocusContext';
+
+interface Output {
+	/**
+	 * Enable focus management for all components.
+	 */
+	enableFocus: Props['enableFocus'];
+
+	/**
+	 * Disable focus management for all components. Currently active component (if there's one) will lose its focus.
+	 */
+	disableFocus: Props['disableFocus'];
+
+	/**
+	 * Switch focus to the next focusable component.
+	 * If there's no active component right now, focus will be given to the first focusable component.
+	 * If active component is the last in the list of focusable components, focus will be switched to the first component.
+	 */
+	focusNext: Props['focusNext'];
+
+	/**
+	 * Switch focus to the previous focusable component.
+	 * If there's no active component right now, focus will be given to the first focusable component.
+	 * If active component is the first in the list of focusable components, focus will be switched to the last component.
+	 */
+	focusPrevious: Props['focusPrevious'];
+}
+
+/**
+ * This hook exposes methods to enable or disable focus management for all
+ * components or manually switch focus to next or previous components.
+ */
+const useFocusManager = (): Output => {
+	const focusContext = useContext(FocusContext);
+
+	return {
+		enableFocus: focusContext.enableFocus,
+		disableFocus: focusContext.disableFocus,
+		focusNext: focusContext.focusNext,
+		focusPrevious: focusContext.focusPrevious
+	};
+};
+
+export default useFocusManager;

--- a/src/hooks/use-focus.ts
+++ b/src/hooks/use-focus.ts
@@ -1,0 +1,73 @@
+import {useEffect, useContext, useMemo} from 'react';
+import FocusContext from '../components/FocusContext';
+import useStdin from './use-stdin';
+
+interface Input {
+	/**
+	 * Enable or disable this component's focus, while still maintaining its position in the list of focusable components.
+	 */
+	isActive?: boolean;
+
+	/**
+	 * Auto focus this component, if there's no active (focused) component right now.
+	 */
+	autoFocus?: boolean;
+}
+
+interface Output {
+	/**
+	 * Determines whether this component is focused or not.
+	 */
+	isFocused: boolean;
+}
+
+/**
+ * Component that uses `useFocus` hook becomes "focusable" to Ink,
+ * so when user presses <kbd>Tab</kbd>, Ink will switch focus to this component.
+ * If there are multiple components that execute `useFocus` hook, focus will be
+ * given to them in the order that these components are rendered in.
+ * This hook returns an object with `isFocused` boolean property, which
+ * determines if this component is focused or not.
+ */
+const useFocus = ({isActive = true, autoFocus = false}: Input = {}): Output => {
+	const {isRawModeSupported, setRawMode} = useStdin();
+	const {activeId, add, remove, activate, deactivate} = useContext(
+		FocusContext
+	);
+
+	const id = useMemo(() => Math.random().toString().slice(2, 7), []);
+
+	useEffect(() => {
+		add(id, {autoFocus});
+
+		return () => {
+			remove(id);
+		};
+	}, [id, autoFocus]);
+
+	useEffect(() => {
+		if (isActive) {
+			activate(id);
+		} else {
+			deactivate(id);
+		}
+	}, [isActive, id]);
+
+	useEffect(() => {
+		if (!isRawModeSupported || !isActive) {
+			return;
+		}
+
+		setRawMode(true);
+
+		return () => {
+			setRawMode(false);
+		};
+	}, [isActive]);
+
+	return {
+		isFocused: Boolean(id) && activeId === id
+	};
+};
+
+export default useFocus;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,3 +18,5 @@ export {default as useApp} from './hooks/use-app';
 export {default as useStdin} from './hooks/use-stdin';
 export {default as useStdout} from './hooks/use-stdout';
 export {default as useStderr} from './hooks/use-stderr';
+export {default as useFocus} from './hooks/use-focus';
+export {default as useFocusManager} from './hooks/use-focus-manager';

--- a/test/focus.tsx
+++ b/test/focus.tsx
@@ -1,0 +1,392 @@
+import EventEmitter from 'events';
+import React, {useEffect} from 'react';
+import type {FC} from 'react';
+import delay from 'delay';
+import test from 'ava';
+import {spy} from 'sinon';
+import {render, Box, Text, useFocus, useFocusManager} from '..';
+
+const createStdout = () => ({
+	write: spy(),
+	columns: 100
+});
+
+const createStdin = () => {
+	const stdin = new EventEmitter();
+	stdin.isTTY = true;
+	stdin.setRawMode = spy();
+	stdin.setEncoding = () => {};
+	stdin.resume = () => {};
+
+	return stdin;
+};
+
+interface TestProps {
+	showFirst?: boolean;
+	disableSecond?: boolean;
+	autoFocus?: boolean;
+	disabled?: boolean;
+	focusNext?: boolean;
+	focusPrevious?: boolean;
+}
+
+const Test: FC<TestProps> = ({
+	showFirst = true,
+	disableSecond = false,
+	autoFocus = false,
+	disabled = false,
+	focusNext = false,
+	focusPrevious = false
+}) => {
+	const focusManager = useFocusManager();
+
+	useEffect(() => {
+		if (disabled) {
+			focusManager.disableFocus();
+		} else {
+			focusManager.enableFocus();
+		}
+	}, [disabled]);
+
+	useEffect(() => {
+		if (focusNext) {
+			focusManager.focusNext();
+		}
+	}, [focusNext]);
+
+	useEffect(() => {
+		if (focusPrevious) {
+			focusManager.focusPrevious();
+		}
+	}, [focusPrevious]);
+
+	return (
+		<Box flexDirection="column">
+			{showFirst && <Item label="First" autoFocus={autoFocus} />}
+			<Item label="Second" autoFocus={autoFocus} disabled={disableSecond} />
+			<Item label="Third" autoFocus={autoFocus} />
+		</Box>
+	);
+};
+
+interface ItemProps {
+	label: string;
+	autoFocus: boolean;
+	disabled?: boolean;
+}
+
+const Item: FC<ItemProps> = ({label, autoFocus, disabled = false}) => {
+	const {isFocused} = useFocus({
+		autoFocus,
+		isActive: !disabled
+	});
+
+	return (
+		<Text>
+			{label} {isFocused && '✔'}
+		</Text>
+	);
+};
+
+test('dont focus on register when auto focus is off', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	render(<Test />, {
+		stdout,
+		stdin,
+		debug: true
+	});
+
+	await delay(100);
+
+	t.is(stdout.write.lastCall.args[0], ['First', 'Second', 'Third'].join('\n'));
+});
+
+test('focus the first component to register', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	render(<Test autoFocus />, {
+		stdout,
+		stdin,
+		debug: true
+	});
+
+	await delay(100);
+
+	t.is(
+		stdout.write.lastCall.args[0],
+		['First ✔', 'Second', 'Third'].join('\n')
+	);
+});
+
+test('unfocus active component on Esc', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	render(<Test />, {
+		stdout,
+		stdin,
+		debug: true
+	});
+
+	await delay(100);
+	stdin.emit('data', '\u001B');
+	await delay(100);
+	t.is(stdout.write.lastCall.args[0], ['First', 'Second', 'Third'].join('\n'));
+});
+
+test('switch focus to first component on Tab', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	render(<Test />, {
+		stdout,
+		stdin,
+		debug: true
+	});
+
+	await delay(100);
+	stdin.emit('data', '\t');
+	await delay(100);
+
+	t.is(
+		stdout.write.lastCall.args[0],
+		['First ✔', 'Second', 'Third'].join('\n')
+	);
+});
+
+test('switch focus to the next component on Tab', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	render(<Test />, {
+		stdout,
+		stdin,
+		debug: true
+	});
+
+	await delay(100);
+	stdin.emit('data', '\t');
+	stdin.emit('data', '\t');
+	await delay(100);
+
+	t.is(
+		stdout.write.lastCall.args[0],
+		['First', 'Second ✔', 'Third'].join('\n')
+	);
+});
+
+test('switch focus to the first component if currently focused component is the last one on Tab', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	render(<Test autoFocus />, {
+		stdout,
+		stdin,
+		debug: true
+	});
+
+	await delay(100);
+	stdin.emit('data', '\t');
+	stdin.emit('data', '\t');
+	await delay(100);
+
+	t.is(
+		stdout.write.lastCall.args[0],
+		['First', 'Second', 'Third ✔'].join('\n')
+	);
+
+	stdin.emit('data', '\t');
+	await delay(100);
+
+	t.is(
+		stdout.write.lastCall.args[0],
+		['First ✔', 'Second', 'Third'].join('\n')
+	);
+});
+
+test('skip disabled component on Tab', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	render(<Test autoFocus disableSecond />, {
+		stdout,
+		stdin,
+		debug: true
+	});
+
+	await delay(100);
+	stdin.emit('data', '\t');
+	await delay(100);
+
+	t.is(
+		stdout.write.lastCall.args[0],
+		['First', 'Second', 'Third ✔'].join('\n')
+	);
+});
+
+test('switch focus to the previous component on Shift+Tab', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	render(<Test autoFocus />, {
+		stdout,
+		stdin,
+		debug: true
+	});
+
+	await delay(100);
+	stdin.emit('data', '\t');
+	await delay(100);
+
+	t.is(
+		stdout.write.lastCall.args[0],
+		['First', 'Second ✔', 'Third'].join('\n')
+	);
+
+	stdin.emit('data', '\u001B[Z');
+	await delay(100);
+
+	t.is(
+		stdout.write.lastCall.args[0],
+		['First ✔', 'Second', 'Third'].join('\n')
+	);
+});
+
+test('switch focus to the last component if currently focused component is the first one on Shift+Tab', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	render(<Test autoFocus />, {
+		stdout,
+		stdin,
+		debug: true
+	});
+
+	await delay(100);
+	stdin.emit('data', '\u001B[Z');
+
+	t.is(
+		stdout.write.lastCall.args[0],
+		['First', 'Second', 'Third ✔'].join('\n')
+	);
+});
+
+test('skip disabled component on Shift+Tab', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	render(<Test autoFocus disableSecond />, {
+		stdout,
+		stdin,
+		debug: true
+	});
+
+	await delay(100);
+	stdin.emit('data', '\u001B[Z');
+	stdin.emit('data', '\u001B[Z');
+	await delay(100);
+
+	t.is(
+		stdout.write.lastCall.args[0],
+		['First ✔', 'Second', 'Third'].join('\n')
+	);
+});
+
+test('reset focus when focused component unregisters', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	const {rerender} = render(<Test autoFocus />, {
+		stdout,
+		stdin,
+		debug: true
+	});
+
+	await delay(100);
+	rerender(<Test autoFocus showFirst={false} />);
+	await delay(100);
+
+	t.is(stdout.write.lastCall.args[0], ['Second', 'Third'].join('\n'));
+});
+
+test('focus first component after focused component unregisters', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	const {rerender} = render(<Test autoFocus />, {
+		stdout,
+		stdin,
+		debug: true
+	});
+
+	await delay(100);
+	rerender(<Test autoFocus showFirst={false} />);
+	await delay(100);
+
+	t.is(stdout.write.lastCall.args[0], ['Second', 'Third'].join('\n'));
+
+	stdin.emit('data', '\t');
+	await delay(100);
+
+	t.is(stdout.write.lastCall.args[0], ['Second ✔', 'Third'].join('\n'));
+});
+
+test('toggle focus management', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	const {rerender} = render(<Test autoFocus />, {
+		stdout,
+		stdin,
+		debug: true
+	});
+
+	await delay(100);
+	rerender(<Test autoFocus disabled />);
+	await delay(100);
+	stdin.emit('data', '\t');
+	await delay(100);
+
+	t.is(
+		stdout.write.lastCall.args[0],
+		['First ✔', 'Second', 'Third'].join('\n')
+	);
+
+	rerender(<Test autoFocus />);
+	await delay(100);
+	stdin.emit('data', '\t');
+	await delay(100);
+
+	t.is(
+		stdout.write.lastCall.args[0],
+		['First', 'Second ✔', 'Third'].join('\n')
+	);
+});
+
+test('manually focus next component', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	const {rerender} = render(<Test autoFocus />, {
+		stdout,
+		stdin,
+		debug: true
+	});
+
+	await delay(100);
+	rerender(<Test autoFocus focusNext />);
+	await delay(100);
+
+	t.is(
+		stdout.write.lastCall.args[0],
+		['First', 'Second ✔', 'Third'].join('\n')
+	);
+});
+
+test('manually focus previous component', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	const {rerender} = render(<Test autoFocus />, {
+		stdout,
+		stdin,
+		debug: true
+	});
+
+	await delay(100);
+	rerender(<Test autoFocus focusPrevious />);
+	await delay(100);
+
+	t.is(
+		stdout.write.lastCall.args[0],
+		['First', 'Second', 'Third ✔'].join('\n')
+	);
+});


### PR DESCRIPTION
This PR adds a simple focus management mechanism to Ink. It's based on @jdeniau's work in https://github.com/vadimdemedes/ink/pull/262 and [Focus Management RFC](https://github.com/reactjs/rfcs/issues/104) in React.

You can check out the documentation for changes made here in https://github.com/vadimdemedes/ink/tree/focus#usefocusoptions, but the gist is that components can call `useFocus()` hook to notify Ink that they can be focused and when user presses <kbd>Tab</kbd>, Ink is going to move focus between focusable components.

```js
import {useFocus} from 'ink';

const FocusableComponent = () => {
  const {isFocused} = useFocus();
  // `isFocused` will equal `true` after user presses Tab and this component receives focus

  return <Text>{isFocused ? 'I am focused' : 'I am not focused'}</Text>;
};
```