### PR TITLE
Extract console patching and make it configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"indent-string": "^4.0.0",
 		"is-ci": "^2.0.0",
 		"lodash.throttle": "^4.1.1",
+		"patch-console": "^1.0.0",
 		"react-devtools-core": "^4.6.0",
 		"react-reconciler": "^0.24.0",
 		"scheduler": "^0.18.0",

--- a/readme.md
+++ b/readme.md
@@ -167,6 +167,13 @@ Default: `true`
 Configure whether Ink should listen to Ctrl+C keyboard input and exit the app.
 This is needed in case `process.stdin` is in [raw mode](https://nodejs.org/api/tty.html#tty_readstream_setrawmode_mode), because then Ctrl+C is ignored by default and process is expected to handle it manually.
 
+###### patchConsole
+
+Type: `boolean`\
+Default: `true`
+
+Patch console methods to ensure console output doesn't mix with Ink output.
+
 ###### debug
 
 Type: `boolean`<br>

--- a/readme.md
+++ b/readme.md
@@ -173,6 +173,10 @@ Type: `boolean`\
 Default: `true`
 
 Patch console methods to ensure console output doesn't mix with Ink output.
+When any of `console.*` methods are called (like `console.log()`), Ink intercepts their output, clears main output, renders output from the console method and then rerenders main output again.
+That way both are visible and are not overlapping each other.
+
+This functionality is powered by [patch-console](https://github.com/vadimdemedes/patch-console), so if you need to disable Ink's interception of output but want to build something custom, you can use it.
 
 ###### debug
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -34,6 +34,13 @@ export interface RenderOptions {
 	 * @default true
 	 */
 	exitOnCtrlC?: boolean;
+
+	/**
+	 * Patch console methods to ensure console output doesn't mix with Ink output.
+	 *
+	 * @default true
+	 */
+	patchConsole?: boolean;
 }
 
 export interface Instance {
@@ -70,6 +77,7 @@ const render: RenderFunction = (node, options): Instance => {
 		stderr: process.stderr,
 		debug: false,
 		exitOnCtrlC: true,
+		patchConsole: true,
 		...getOptions(options)
 	};
 


### PR DESCRIPTION
This PR extracts console patching code into [patch-console](https://github.com/vadimdemedes/patch-console) module and exposes a `patchConsole` option to disable it (it's enabled by default). It's useful when users want to implement custom loggers and don't want Ink's handling of it.