### PR TITLE
Rerender on resize

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,61 +1,54 @@
 import Yoga from 'yoga-layout-prebuilt';
 import renderNodeToOutput from './render-node-to-output';
 import Output from './output';
-import {setStyle} from './dom';
 import type {DOMElement} from './dom';
 
-export type Renderer = (
-	node: DOMElement
-) => {
+interface Result {
 	output: string;
 	outputHeight: number;
 	staticOutput: string;
-};
+}
 
-export default ({terminalWidth = 100}: {terminalWidth: number}): Renderer => {
-	return (node: DOMElement) => {
-		setStyle(node, {
-			width: terminalWidth
+export default (node: DOMElement, terminalWidth: number): Result => {
+	node.yogaNode!.setWidth(terminalWidth);
+
+	if (node.yogaNode) {
+		node.yogaNode.calculateLayout(undefined, undefined, Yoga.DIRECTION_LTR);
+
+		const output = new Output({
+			width: node.yogaNode.getComputedWidth(),
+			height: node.yogaNode.getComputedHeight()
 		});
 
-		if (node.yogaNode) {
-			node.yogaNode.calculateLayout(undefined, undefined, Yoga.DIRECTION_LTR);
+		renderNodeToOutput(node, output, {skipStaticElements: true});
 
-			const output = new Output({
-				width: node.yogaNode.getComputedWidth(),
-				height: node.yogaNode.getComputedHeight()
+		let staticOutput;
+
+		if (node.staticNode?.yogaNode) {
+			staticOutput = new Output({
+				width: node.staticNode.yogaNode.getComputedWidth(),
+				height: node.staticNode.yogaNode.getComputedHeight()
 			});
 
-			renderNodeToOutput(node, output, {skipStaticElements: true});
-
-			let staticOutput;
-
-			if (node.staticNode?.yogaNode) {
-				staticOutput = new Output({
-					width: node.staticNode.yogaNode.getComputedWidth(),
-					height: node.staticNode.yogaNode.getComputedHeight()
-				});
-
-				renderNodeToOutput(node.staticNode, staticOutput, {
-					skipStaticElements: false
-				});
-			}
-
-			const {output: generatedOutput, height: outputHeight} = output.get();
-
-			return {
-				output: generatedOutput,
-				outputHeight,
-				// Newline at the end is needed, because static output doesn't have one, so
-				// interactive output will override last line of static output
-				staticOutput: staticOutput ? `${staticOutput.get().output}\n` : ''
-			};
+			renderNodeToOutput(node.staticNode, staticOutput, {
+				skipStaticElements: false
+			});
 		}
 
+		const {output: generatedOutput, height: outputHeight} = output.get();
+
 		return {
-			output: '',
-			outputHeight: 0,
-			staticOutput: ''
+			output: generatedOutput,
+			outputHeight,
+			// Newline at the end is needed, because static output doesn't have one, so
+			// interactive output will override last line of static output
+			staticOutput: staticOutput ? `${staticOutput.get().output}\n` : ''
 		};
+	}
+
+	return {
+		output: '',
+		outputHeight: 0,
+		staticOutput: ''
 	};
 };

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -15,6 +15,7 @@ import {
 	useStdin,
 	render
 } from '../src';
+import createStdout from './helpers/create-stdout';
 
 test('text', t => {
 	const output = renderToString(<Text>Hello World</Text>);
@@ -191,10 +192,7 @@ test('fail when text node is not within <Text> component', t => {
 });
 
 test('remesure text dimensions on text change', t => {
-	const stdout = {
-		write: spy(),
-		columns: 100
-	};
+	const stdout = createStdout();
 
 	const {rerender} = render(
 		<Box>
@@ -309,10 +307,7 @@ test('static output', t => {
 });
 
 test('skip previous output when rendering new static output', t => {
-	const stdout = {
-		write: spy(),
-		columns: 100
-	};
+	const stdout = createStdout();
 
 	const Dynamic: FC<{items: string[]}> = ({items}) => (
 		<Static items={items}>{item => <Text key={item}>{item}</Text>}</Static>
@@ -337,10 +332,7 @@ test('ensure wrap-ansi doesn’t trim leading whitespace', t => {
 });
 
 test('replace child node with text', t => {
-	const stdout = {
-		write: spy(),
-		columns: 100
-	};
+	const stdout = createStdout();
 
 	const Dynamic = ({replace}) => (
 		<Text>{replace ? 'x' : <Text color="green">test</Text>}</Text>
@@ -359,10 +351,7 @@ test('replace child node with text', t => {
 
 // See https://github.com/vadimdemedes/ink/issues/145
 test('disable raw mode when all input components are unmounted', t => {
-	const stdout = {
-		write: spy(),
-		columns: 100
-	};
+	const stdout = createStdout();
 
 	const stdin = new EventEmitter();
 	stdin.setEncoding = () => {};
@@ -427,10 +416,7 @@ test('disable raw mode when all input components are unmounted', t => {
 });
 
 test('setRawMode() should throw if raw mode is not supported', t => {
-	const stdout = {
-		write: spy(),
-		columns: 100
-	};
+	const stdout = createStdout();
 
 	const stdin = new EventEmitter();
 	stdin.setEncoding = () => {};
@@ -486,10 +472,7 @@ test('setRawMode() should throw if raw mode is not supported', t => {
 });
 
 test('render different component based on whether stdin is a TTY or not', t => {
-	const stdout = {
-		write: spy(),
-		columns: 100
-	};
+	const stdout = createStdout();
 
 	const stdin = new EventEmitter();
 	stdin.setEncoding = () => {};
@@ -578,10 +561,7 @@ test('render all frames if CI environment variable equals false', async t => {
 });
 
 test('reset prop when it’s removed from the element', t => {
-	const stdout = {
-		write: spy(),
-		columns: 100
-	};
+	const stdout = createStdout();
 
 	const Dynamic = ({remove}) => (
 		<Box

--- a/test/errors.tsx
+++ b/test/errors.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable unicorn/string-content */
 import React from 'react';
 import test from 'ava';
-import {spy} from 'sinon';
 import patchConsole from 'patch-console';
 import stripAnsi from 'strip-ansi';
 import {render} from '../src';
+import createStdout from './helpers/create-stdout';
 
 let restore;
 
@@ -17,10 +17,7 @@ test.after(() => {
 });
 
 test('catch and display error', t => {
-	const stdout = {
-		columns: 100,
-		write: spy()
-	};
+	const stdout = createStdout();
 
 	const Test = () => {
 		throw new Error('Oh no');
@@ -34,17 +31,17 @@ test('catch and display error', t => {
 			'',
 			'  ERROR  Oh no',
 			'',
-			' test/errors.tsx:26:9',
+			' test/errors.tsx:23:9',
 			'',
-			' 23:   };',
-			' 24:',
-			' 25:   const Test = () => {',
-			" 26:     throw new Error('Oh no');",
-			' 27:   };',
-			' 28:',
-			' 29:   render(<Test />, {stdout});',
+			' 20:   const stdout = createStdout();',
+			' 21:',
+			' 22:   const Test = () => {',
+			" 23:     throw new Error('Oh no');",
+			' 24:   };',
+			' 25:',
+			' 26:   render(<Test />, {stdout});',
 			'',
-			' - Test (test/errors.tsx:26:9)'
+			' - Test (test/errors.tsx:23:9)'
 		]
 	);
 });

--- a/test/focus.tsx
+++ b/test/focus.tsx
@@ -5,11 +5,7 @@ import delay from 'delay';
 import test from 'ava';
 import {spy} from 'sinon';
 import {render, Box, Text, useFocus, useFocusManager} from '..';
-
-const createStdout = () => ({
-	write: spy(),
-	columns: 100
-});
+import createStdout from './helpers/create-stdout';
 
 const createStdin = () => {
 	const stdin = new EventEmitter();

--- a/test/helpers/create-stdout.ts
+++ b/test/helpers/create-stdout.ts
@@ -1,0 +1,19 @@
+import EventEmitter from 'events';
+import {spy} from 'sinon';
+
+// Fake process.stdout
+interface Stream extends EventEmitter {
+	output: string;
+	columns: number;
+	write(str: string): void;
+	get(): string;
+}
+
+export default (columns?: number): Stream => {
+	const stdout = new EventEmitter();
+	stdout.columns = columns ?? 100;
+	stdout.write = spy();
+	stdout.get = () => stdout.write.lastCall.args[0];
+
+	return stdout;
+};

--- a/test/helpers/render-to-string.ts
+++ b/test/helpers/render-to-string.ts
@@ -1,38 +1,17 @@
 import {render} from '../../src';
-
-// Fake process.stdout
-interface Stream {
-	output: string;
-	columns: number;
-	write(str: string): void;
-	get(): string;
-}
-
-const createStream: (options: {columns: number}) => Stream = ({columns}) => {
-	let output = '';
-	return {
-		output,
-		columns,
-		write(str: string) {
-			output = str;
-		},
-		get() {
-			return output;
-		}
-	};
-};
+import createStdout from './create-stdout';
 
 export const renderToString: (
 	node: JSX.Element,
 	options?: {columns: number}
 ) => string = (node, options = {columns: 100}) => {
-	const stream = createStream(options);
+	const stdout = createStdout(options.columns);
 
 	render(node, {
 		// @ts-ignore
-		stdout: stream,
+		stdout,
 		debug: true
 	});
 
-	return stream.get();
+	return stdout.get();
 };

--- a/test/reconciler.tsx
+++ b/test/reconciler.tsx
@@ -1,13 +1,8 @@
 import React, {Suspense} from 'react';
 import test from 'ava';
 import chalk from 'chalk';
-import {spy} from 'sinon';
 import {Box, Text, render} from '../src';
-
-const createStdout = () => ({
-	write: spy(),
-	columns: 100
-});
+import createStdout from './helpers/create-stdout';
 
 test('update child', t => {
 	const Test = ({update}) => <Text>{update ? 'B' : 'A'}</Text>;

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -1,3 +1,4 @@
+delete process.env.CI;
 import React from 'react';
 import {serial as test} from 'ava';
 import {spawn} from 'node-pty';
@@ -18,14 +19,11 @@ const term = (fixture: string, args: string[] = []) => {
 		reject = reject2;
 	});
 
-	const env = {...process.env};
-	delete env.CI;
-
 	const ps = spawn('ts-node', [`./fixtures/${fixture}.tsx`, ...args], {
 		name: 'xterm-color',
 		cols: 100,
 		cwd: __dirname,
-		env
+		env: process.env
 	});
 
 	const result = {

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -1,7 +1,12 @@
+import React from 'react';
 import {serial as test} from 'ava';
 import {spawn} from 'node-pty';
 import ansiEscapes from 'ansi-escapes';
 import stripAnsi from 'strip-ansi';
+import boxen from 'boxen';
+import delay from 'delay';
+import {render, Box, Text} from '../src';
+import createStdout from './helpers/create-stdout';
 
 const term = (fixture: string, args: string[] = []) => {
 	let resolve: (value?: unknown) => void;
@@ -107,4 +112,35 @@ test('intercept console methods and display result above output', async t => {
 		'Hello World\r\n',
 		'First log\r\nHello World\r\nSecond log\r\n'
 	]);
+});
+
+test('rerender on resize', async t => {
+	const stdout = createStdout(10);
+
+	const Test = () => (
+		<Box borderStyle="round">
+			<Text>Test</Text>
+		</Box>
+	);
+
+	const {unmount} = render(<Test />, {stdout});
+
+	t.is(
+		stripAnsi(stdout.write.firstCall.args[0]),
+		boxen('Test'.padEnd(8), {borderStyle: 'round'}) + '\n'
+	);
+
+	t.is(stdout.listeners('resize').length, 1);
+
+	stdout.columns = 8;
+	stdout.emit('resize');
+	await delay(100);
+
+	t.is(
+		stripAnsi(stdout.write.lastCall.args[0]),
+		boxen('Test'.padEnd(6), {borderStyle: 'round'}) + '\n'
+	);
+
+	unmount();
+	t.is(stdout.listeners('resize').length, 0);
 });


### PR DESCRIPTION
Fixes https://github.com/vadimdemedes/ink/issues/153.

It works well when resizing up, but not so much with resizing down. Previous output doesn't get erased correctly, because when terminal shrinks, it also shrinks previous output, so `log-update` no longer knows how many lines to erase. I'm going to accept this tradeoff for now, because resizing down rarely works in any CLI with full-width UI.