### PR TITLE
Don't override existing global.window or global.WebSocket

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -5,8 +5,12 @@ import ws from 'ws';
 const customGlobal = global as any;
 
 // These things must exist before importing `react-devtools-core`
-customGlobal.WebSocket = ws;
-customGlobal.window = global;
+if (!customGlobal.WebSocket) {
+	customGlobal.WebSocket = ws;
+}
+if (!customGlobal.window) {
+	customGlobal.window = global;
+}
 
 // Filter out Ink's internal components from devtools for a cleaner view.
 // Also, ince `react-devtools-shared` package isn't published on npm, we can't


### PR DESCRIPTION
I found import ink will override the global.window provided by my jsdom setup.  It would be nice to check first before set it globally.