### PR TITLE
Remove usage of <div> and <span>

### DIFF
--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
-import React, {PureComponent} from 'react';
-import type {YogaNode} from 'yoga-layout-prebuilt';
+import React from 'react';
+import type {FC} from 'react';
 import type {Except} from 'type-fest';
 import type {Styles} from '../styles';
 
@@ -16,40 +16,28 @@ export type Props = Except<Styles, 'textWrap'> & {
 /**
  * `<Box>` it's an essential Ink component to build your layout. It's like a `<div style="display: flex">` in a browser.
  */
-export default class Box extends PureComponent<Props> {
-	static displayName = 'Box';
-
-	static defaultProps = {
-		flexDirection: 'row',
-		flexGrow: 0,
-		flexShrink: 1
+const Box: FC<Props> = ({children, ...style}) => {
+	const transformedStyle = {
+		...style,
+		marginLeft: style.marginLeft || style.marginX || style.margin || 0,
+		marginRight: style.marginRight || style.marginX || style.margin || 0,
+		marginTop: style.marginTop || style.marginY || style.margin || 0,
+		marginBottom: style.marginBottom || style.marginY || style.margin || 0,
+		paddingLeft: style.paddingLeft || style.paddingX || style.padding || 0,
+		paddingRight: style.paddingRight || style.paddingX || style.padding || 0,
+		paddingTop: style.paddingTop || style.paddingY || style.padding || 0,
+		paddingBottom: style.paddingBottom || style.paddingY || style.padding || 0
 	};
 
-	nodeRef = React.createRef<{yogaNode: YogaNode} & HTMLDivElement>();
+	return <ink-box style={transformedStyle}>{children}</ink-box>;
+};
 
-	render() {
-		const {children, ...style} = this.props;
+Box.displayName = 'Box';
 
-		const transformedStyle = {
-			...style,
-			marginLeft: style.marginLeft || style.marginX || style.margin || 0,
-			marginRight: style.marginRight || style.marginX || style.margin || 0,
-			marginTop: style.marginTop || style.marginY || style.margin || 0,
-			marginBottom: style.marginBottom || style.marginY || style.margin || 0,
-			paddingLeft: style.paddingLeft || style.paddingX || style.padding || 0,
-			paddingRight: style.paddingRight || style.paddingX || style.padding || 0,
-			paddingTop: style.paddingTop || style.paddingY || style.padding || 0,
-			paddingBottom: style.paddingBottom || style.paddingY || style.padding || 0
-		};
+Box.defaultProps = {
+	flexDirection: 'row',
+	flexGrow: 0,
+	flexShrink: 1
+};
 
-		return (
-			<div ref={this.nodeRef} style={transformedStyle}>
-				{children}
-			</div>
-		);
-	}
-
-	unstable__getComputedWidth(): number | undefined {
-		return this.nodeRef.current?.yogaNode.getComputedWidth();
-	}
-}
+export default Box;

--- a/src/components/Newline.tsx
+++ b/src/components/Newline.tsx
@@ -6,7 +6,9 @@ export interface Props {
 }
 
 // Add a newline
-const Newline: FC<Props> = ({count = 1}) => <span>{'\n'.repeat(count)}</span>;
+const Newline: FC<Props> = ({count = 1}) => (
+	<ink-text>{'\n'.repeat(count)}</ink-text>
+);
 
 Newline.displayName = 'Newline';
 

--- a/src/components/Static.tsx
+++ b/src/components/Static.tsx
@@ -46,13 +46,13 @@ const Static = <T,>(props: Props<T>) => {
 	);
 
 	return (
-		<div
+		<ink-box
 			// @ts-ignore
 			internal_static
 			style={style}
 		>
 			{children}
-		</div>
+		</ink-box>
 	);
 };
 

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -63,14 +63,12 @@ const Text: FC<Props> = ({
 	};
 
 	return (
-		<span
-			// @ts-ignore
+		<ink-text
 			style={{flexGrow: 0, flexShrink: 1, flexDirection: 'row', textWrap: wrap}}
-			// @ts-ignore
 			internal_transform={transform}
 		>
 			{children}
-		</span>
+		</ink-text>
 	);
 };
 

--- a/src/components/Transform.tsx
+++ b/src/components/Transform.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type {FC, ReactNode} from 'react';
 
 export interface Props {
-	readonly transform: (children: ReactNode) => ReactNode;
+	readonly transform: (children: string) => string;
 	readonly children: ReactNode;
 }
 
@@ -10,13 +10,12 @@ export interface Props {
  * Transform a string representation of React components before they are written to output.
  */
 const Transform: FC<Props> = ({children, transform}) => (
-	<span
+	<ink-text
 		style={{flexGrow: 0, flexShrink: 1, flexDirection: 'row'}}
-		// @ts-ignore
 		internal_transform={transform}
 	>
 		{children}
-	</span>
+	</ink-text>
 );
 
 Transform.displayName = 'Transform';

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -17,14 +17,11 @@ interface InkNode {
 export const TEXT_NAME = '#text';
 export type TextName = '#text';
 export type ElementNames =
-	| 'root'
-	| 'div'
-	| 'span'
-	| 'virtual-span'
-	| 'ROOT'
-	| 'DIV'
-	| 'SPAN'
-	| 'VIRTUAL-SPAN';
+	| 'ink-root'
+	| 'ink-box'
+	| 'ink-text'
+	| 'ink-virtual-text';
+
 export type NodeNames = ElementNames | TextName;
 
 export type DOMElement = {
@@ -59,15 +56,15 @@ export type DOMNodeAttribute = boolean | string | number;
 
 export const createNode = (nodeName: ElementNames): DOMElement => {
 	const node: DOMElement = {
-		nodeName: nodeName.toUpperCase() as ElementNames,
+		nodeName,
 		style: {},
 		attributes: {},
 		childNodes: [],
 		parentNode: null,
-		yogaNode: nodeName === 'virtual-span' ? undefined : Yoga.Node.create()
+		yogaNode: nodeName === 'ink-virtual-text' ? undefined : Yoga.Node.create()
 	};
 
-	if (nodeName === 'span') {
+	if (nodeName === 'ink-text') {
 		node.yogaNode?.setMeasureFunc(measureTextNode.bind(null, node));
 	}
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,29 @@
+import type {ReactNode, Key, LegacyRef} from 'react';
+import type {Except} from 'type-fest';
+import type {DOMElement} from './dom';
+import type {Styles} from './styles';
+
+declare global {
+	namespace JSX {
+		interface IntrinsicElements {
+			'ink-box': Ink.Box;
+			'ink-text': Ink.Text;
+		}
+	}
+}
+
+declare namespace Ink {
+	interface Box {
+		children?: ReactNode;
+		key?: Key;
+		ref?: LegacyRef<DOMElement>;
+		style?: Except<Styles, 'textWrap'>;
+	}
+
+	interface Text {
+		children?: ReactNode;
+		key?: Key;
+		style?: Styles;
+		internal_transform?: (children: string) => string;
+	}
+}

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -48,7 +48,7 @@ export default class Ink {
 		autoBind(this);
 
 		this.options = options;
-		this.rootNode = dom.createNode('root');
+		this.rootNode = dom.createNode('ink-root');
 
 		this.rootNode.onRender = options.debug
 			? this.onRender

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -79,7 +79,7 @@ export default createReconciler<
 	},
 	getChildHostContext: (parentHostContext, type) => {
 		const previousIsInsideText = parentHostContext.isInsideText;
-		const isInsideText = type === 'span' || type === 'virtual-span';
+		const isInsideText = type === 'ink-text' || type === 'ink-virtual-text';
 
 		if (previousIsInsideText === isInsideText) {
 			return parentHostContext;
@@ -90,8 +90,8 @@ export default createReconciler<
 	shouldSetTextContent: () => false,
 	createInstance: (originalType, newProps, _root, hostContext) => {
 		const type =
-			originalType === 'span' && hostContext.isInsideText
-				? 'virtual-span'
+			originalType === 'ink-text' && hostContext.isInsideText
+				? 'ink-virtual-text'
 				: originalType;
 
 		const node = createNode(type);

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -69,7 +69,7 @@ const renderNodeToOutput = (
 			newTransformers = [node.internal_transform, ...transformers];
 		}
 
-		if (node.nodeName === 'SPAN') {
+		if (node.nodeName === 'ink-text') {
 			let text = squashTextNodes(node);
 
 			if (text.length > 0) {
@@ -88,11 +88,11 @@ const renderNodeToOutput = (
 			return;
 		}
 
-		if (node.nodeName === 'DIV') {
+		if (node.nodeName === 'ink-box') {
 			renderBorder(x, y, node, output);
 		}
 
-		if (node.nodeName === 'ROOT' || node.nodeName === 'DIV') {
+		if (node.nodeName === 'ink-root' || node.nodeName === 'ink-box') {
 			for (const childNode of node.childNodes) {
 				renderNodeToOutput(childNode as DOMElement, output, {
 					offsetX: x,

--- a/src/squash-text-nodes.ts
+++ b/src/squash-text-nodes.ts
@@ -17,8 +17,8 @@ const squashTextNodes = (node: DOMElement): string => {
 				nodeText = childNode.nodeValue;
 			} else {
 				if (
-					childNode.nodeName === 'SPAN' ||
-					childNode.nodeName === 'VIRTUAL-SPAN'
+					childNode.nodeName === 'ink-text' ||
+					childNode.nodeName === 'ink-virtual-text'
 				) {
 					nodeText = squashTextNodes(childNode);
 				}

--- a/test/fixtures/ci.tsx
+++ b/test/fixtures/ci.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, Static, Text} from '../../src';
+import {render, Static, Text} from '../..';
 
 interface TestState {
 	counter: number;

--- a/test/fixtures/clear.tsx
+++ b/test/fixtures/clear.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Box, Text, render} from '../../src';
+import {Box, Text, render} from '../..';
 
 const Clear = () => (
 	<Box flexDirection="column">

--- a/test/fixtures/console.tsx
+++ b/test/fixtures/console.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect} from 'react';
-import {Text, render} from '../../src';
+import {Text, render} from '../..';
 
 const App = () => {
 	useEffect(() => {

--- a/test/fixtures/erase-with-static.tsx
+++ b/test/fixtures/erase-with-static.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Static, Box, Text, render} from '../../src';
+import {Static, Box, Text, render} from '../..';
 
 const EraseWithStatic = () => (
 	<>

--- a/test/fixtures/erase.tsx
+++ b/test/fixtures/erase.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Box, Text, render} from '../../src';
+import {Box, Text, render} from '../..';
 
 const Erase = () => (
 	<Box flexDirection="column">

--- a/test/fixtures/exit-double-raw-mode.tsx
+++ b/test/fixtures/exit-double-raw-mode.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Text, render, useStdin} from '../../src';
+import {Text, render, useStdin} from '../..';
 
 class ExitDoubleRawMode extends React.Component<{
 	setRawMode: (value: boolean) => void;

--- a/test/fixtures/exit-normally.tsx
+++ b/test/fixtures/exit-normally.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Text, render} from '../../src';
+import {Text, render} from '../..';
 
 const {waitUntilExit} = render(<Text>Hello World</Text>);
 waitUntilExit().then(() => console.log('exited'));

--- a/test/fixtures/exit-on-exit-with-error.tsx
+++ b/test/fixtures/exit-on-exit-with-error.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, Text, useApp} from '../../src';
+import {render, Text, useApp} from '../..';
 
 class Exit extends React.Component<
 	{onExit: (error: Error) => void},

--- a/test/fixtures/exit-on-exit.tsx
+++ b/test/fixtures/exit-on-exit.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, Text, useApp} from '../../src';
+import {render, Text, useApp} from '../..';
 
 class Exit extends React.Component<
 	{onExit: (error: Error) => void},

--- a/test/fixtures/exit-on-finish.tsx
+++ b/test/fixtures/exit-on-finish.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, Text} from '../../src';
+import {render, Text} from '../..';
 
 class Test extends React.Component<Record<string, unknown>, {counter: number}> {
 	timer?: NodeJS.Timeout;

--- a/test/fixtures/exit-on-unmount.tsx
+++ b/test/fixtures/exit-on-unmount.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, Text} from '../../src';
+import {render, Text} from '../..';
 
 class Test extends React.Component<Record<string, unknown>, {counter: number}> {
 	timer?: NodeJS.Timeout;

--- a/test/fixtures/exit-raw-on-exit-with-error.tsx
+++ b/test/fixtures/exit-raw-on-exit-with-error.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, Text, useApp, useStdin} from '../../src';
+import {render, Text, useApp, useStdin} from '../..';
 
 class Exit extends React.Component<{
 	onSetRawMode: (value: boolean) => void;

--- a/test/fixtures/exit-raw-on-exit.tsx
+++ b/test/fixtures/exit-raw-on-exit.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, Text, useApp, useStdin} from '../../src';
+import {render, Text, useApp, useStdin} from '../..';
 
 class Exit extends React.Component<{
 	onSetRawMode: (value: boolean) => void;

--- a/test/fixtures/exit-raw-on-unmount.tsx
+++ b/test/fixtures/exit-raw-on-unmount.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, Text, useStdin} from '../../src';
+import {render, Text, useStdin} from '../..';
 
 class Exit extends React.Component<{
 	onSetRawMode: (value: boolean) => void;

--- a/test/fixtures/exit-with-thrown-error.tsx
+++ b/test/fixtures/exit-with-thrown-error.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render} from '../../src';
+import {render} from '../..';
 
 const Test = () => {
 	throw new Error('errored');

--- a/test/fixtures/use-input-multiple.tsx
+++ b/test/fixtures/use-input-multiple.tsx
@@ -1,5 +1,5 @@
 import React, {FC, useState, useCallback, useEffect} from 'react';
-import {render, useInput, useApp, Text} from '../../src';
+import {render, useInput, useApp, Text} from '../..';
 
 const App: FC = () => {
 	const {exit} = useApp();

--- a/test/fixtures/use-input.tsx
+++ b/test/fixtures/use-input.tsx
@@ -1,5 +1,5 @@
 import React, {FC} from 'react';
-import {render, useInput, useApp} from '../../src';
+import {render, useInput, useApp} from '../..';
 
 const UserInput: FC<{test: string}> = ({test}) => {
 	const {exit} = useApp();

--- a/test/fixtures/use-stdout.tsx
+++ b/test/fixtures/use-stdout.tsx
@@ -1,5 +1,5 @@
 import React, {FC, useEffect} from 'react';
-import {render, useStdout, Text} from '../../src';
+import {render, useStdout, Text} from '../..';
 
 const WriteToStdout: FC = () => {
 	const {write} = useStdout();


### PR DESCRIPTION
Fixes https://github.com/vadimdemedes/ink/issues/164.

Ink now uses custom `<ink-box>` and `<ink-text>` tags to ensure no one uses `<div>` or `<span>`, which are leftovers from Ink 1.x. However, you still mustn't use those, they are reserved for internal use only.