### PR TITLE
Add measureElement() API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1598,6 +1598,7 @@ This function is useful when your component needs to know the amount of availabl
 Type: `MutableRef`
 
 Reference to `<Box>` element captured via `ref` property.
+See [Refs](https://reactjs.org/docs/refs-and-the-dom.html) for more information on how to capture references.
 
 ```jsx
 import {Box, measureElement} from 'ink';

--- a/readme.md
+++ b/readme.md
@@ -1587,11 +1587,11 @@ clear();
 
 #### measureElement(ref)
 
-Measure dimensions of a particular `<Box>` element.
+Measure the dimensions of a particular `<Box>` element.
 It returns an object with `width` and `height` properties.
 This function is useful when your component needs to know the amount of available space it has before it can start rendering or when you need to change your layout based on the length of the content.
 
-**Note:** `measureElement()` returns correct results after initial render, when layout has been calculated.
+**Note:** `measureElement()` returns correct results only after the initial render, when layout has been calculated. Until then, `width` and `height` equal to zero. It's recommended to call `measureElement()` in a `useEffect` hook, which fires after component has rendered.
 
 ##### ref
 

--- a/readme.md
+++ b/readme.md
@@ -1601,7 +1601,7 @@ Reference to `<Box>` element captured via `ref` property.
 See [Refs](https://reactjs.org/docs/refs-and-the-dom.html) for more information on how to capture references.
 
 ```jsx
-import {Box, measureElement} from 'ink';
+import {render, measureElement, Box} from 'ink';
 
 const Example = () => {
 	const ref = useRef();
@@ -1616,6 +1616,8 @@ const Example = () => {
 		</Box>
 	);
 };
+
+render(<Example />);
 ```
 
 ## Testing

--- a/readme.md
+++ b/readme.md
@@ -1591,7 +1591,7 @@ Measure the dimensions of a particular `<Box>` element.
 It returns an object with `width` and `height` properties.
 This function is useful when your component needs to know the amount of available space it has before it can start rendering or when you need to change your layout based on the length of the content.
 
-**Note:** `measureElement()` returns correct results only after the initial render, when layout has been calculated. Until then, `width` and `height` equal to zero. It's recommended to call `measureElement()` in a `useEffect` hook, which fires after component has rendered.
+**Note:** `measureElement()` returns correct results only after the initial render, when layout has been calculated. Until then, `width` and `height` equal to zero. It's recommended to call `measureElement()` in a `useEffect` hook, which fires after the component has rendered.
 
 ##### ref
 

--- a/readme.md
+++ b/readme.md
@@ -1597,7 +1597,7 @@ This function is useful when your component needs to know the amount of availabl
 
 Type: `MutableRef`
 
-Reference to `<Box>` element captured via `ref` property.
+A reference to a `<Box>` element captured with a `ref` property.
 See [Refs](https://reactjs.org/docs/refs-and-the-dom.html) for more information on how to capture references.
 
 ```jsx

--- a/readme.md
+++ b/readme.md
@@ -1601,18 +1601,21 @@ A reference to a `<Box>` element captured with a `ref` property.
 See [Refs](https://reactjs.org/docs/refs-and-the-dom.html) for more information on how to capture references.
 
 ```jsx
-import {render, measureElement, Box} from 'ink';
+import {render, measureElement, Box, Text} from 'ink';
 
 const Example = () => {
 	const ref = useRef();
 
 	useEffect(() => {
-		const {width} = measureElement(ref.current);
+		const {width, height} = measureElement(ref.current);
+		// width = 100, height = 1
 	}, []);
 
 	return (
 		<Box width={100}>
-			<Box ref={ref}>{/* This box will stretch to 100 width */}</Box>
+			<Box ref={ref}>
+				<Text>This box will stretch to 100 width</Text>
+			</Box>
 		</Box>
 	);
 };

--- a/readme.md
+++ b/readme.md
@@ -1585,6 +1585,38 @@ const {clear} = render(<MyApp />);
 clear();
 ```
 
+#### measureElement(ref)
+
+Measure dimensions of a particular `<Box>` element.
+It returns an object with `width` and `height` properties.
+This function is useful when your component needs to know the amount of available space it has before it can start rendering or when you need to change your layout based on the length of the content.
+
+**Note:** `measureElement()` returns correct results after initial render, when layout has been calculated.
+
+##### ref
+
+Type: `MutableRef`
+
+Reference to `<Box>` element captured via `ref` property.
+
+```jsx
+import {Box, measureElement} from 'ink';
+
+const Example = () => {
+	const ref = useRef();
+
+	useEffect(() => {
+		const {width} = measureElement(ref.current);
+	}, []);
+
+	return (
+		<Box width={100}>
+			<Box ref={ref}>{/* This box will stretch to 100 width */}</Box>
+		</Box>
+	);
+};
+```
+
 ## Testing
 
 Ink components are simple to test with [ink-testing-library](https://github.com/vadimdemedes/ink-testing-library).

--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
-import React from 'react';
+import React, {forwardRef} from 'react';
 import type {FC} from 'react';
 import type {Except} from 'type-fest';
 import type {Styles} from '../styles';
+import type {DOMElement} from '../dom';
 
 export type Props = Except<Styles, 'textWrap'> & {
 	/**
@@ -51,21 +52,27 @@ export type Props = Except<Styles, 'textWrap'> & {
 /**
  * `<Box>` is an essential Ink component to build your layout. It's like `<div style="display: flex">` in the browser.
  */
-const Box: FC<Props> = ({children, ...style}) => {
-	const transformedStyle = {
-		...style,
-		marginLeft: style.marginLeft || style.marginX || style.margin || 0,
-		marginRight: style.marginRight || style.marginX || style.margin || 0,
-		marginTop: style.marginTop || style.marginY || style.margin || 0,
-		marginBottom: style.marginBottom || style.marginY || style.margin || 0,
-		paddingLeft: style.paddingLeft || style.paddingX || style.padding || 0,
-		paddingRight: style.paddingRight || style.paddingX || style.padding || 0,
-		paddingTop: style.paddingTop || style.paddingY || style.padding || 0,
-		paddingBottom: style.paddingBottom || style.paddingY || style.padding || 0
-	};
+const Box: FC<Props> = forwardRef<DOMElement, Props>(
+	({children, ...style}, ref) => {
+		const transformedStyle = {
+			...style,
+			marginLeft: style.marginLeft || style.marginX || style.margin || 0,
+			marginRight: style.marginRight || style.marginX || style.margin || 0,
+			marginTop: style.marginTop || style.marginY || style.margin || 0,
+			marginBottom: style.marginBottom || style.marginY || style.margin || 0,
+			paddingLeft: style.paddingLeft || style.paddingX || style.padding || 0,
+			paddingRight: style.paddingRight || style.paddingX || style.padding || 0,
+			paddingTop: style.paddingTop || style.paddingY || style.padding || 0,
+			paddingBottom: style.paddingBottom || style.paddingY || style.padding || 0
+		};
 
-	return <ink-box style={transformedStyle}>{children}</ink-box>;
-};
+		return (
+			<ink-box ref={ref} style={transformedStyle}>
+				{children}
+			</ink-box>
+		);
+	}
+);
 
 Box.displayName = 'Box';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,4 @@ export {default as useStdout} from './hooks/use-stdout';
 export {default as useStderr} from './hooks/use-stderr';
 export {default as useFocus} from './hooks/use-focus';
 export {default as useFocusManager} from './hooks/use-focus-manager';
+export {default as measureElement} from './measure-element';

--- a/src/measure-element.ts
+++ b/src/measure-element.ts
@@ -2,18 +2,18 @@ import type {DOMElement} from './dom';
 
 interface Output {
 	/**
-	 * Element width
+	 * Element width.
 	 */
 	width: number;
 
 	/**
-	 * Element height
+	 * Element height.
 	 */
 	height: number;
 }
 
 /**
- * Measure dimensions of a particular `<Box>` element.
+ * Measure the dimensions of a particular `<Box>` element.
  */
 export default (node: DOMElement): Output => ({
 	width: node.yogaNode?.getComputedWidth() ?? 0,

--- a/src/measure-element.ts
+++ b/src/measure-element.ts
@@ -1,0 +1,21 @@
+import type {DOMElement} from './dom';
+
+interface Output {
+	/**
+	 * Element width
+	 */
+	width: number;
+
+	/**
+	 * Element height
+	 */
+	height: number;
+}
+
+/**
+ * Measure dimensions of a particular `<Box>` element.
+ */
+export default (node: DOMElement): Output => ({
+	width: node.yogaNode?.getComputedWidth() ?? 0,
+	height: node.yogaNode?.getComputedHeight() ?? 0
+});

--- a/test/measure-element.tsx
+++ b/test/measure-element.tsx
@@ -1,0 +1,29 @@
+import React, {useState, useRef, useEffect, FC} from 'react';
+import test from 'ava';
+import delay from 'delay';
+import {Box, Text, render, measureElement} from '..';
+import createStdout from './helpers/create-stdout';
+
+test('measure element', async t => {
+	const stdout = createStdout();
+
+	const Test: FC = () => {
+		const [width, setWidth] = useState(0);
+		const ref = useRef();
+
+		useEffect(() => {
+			setWidth(measureElement(ref.current).width);
+		}, []);
+
+		return (
+			<Box ref={ref}>
+				<Text>Width: {width}</Text>
+			</Box>
+		);
+	};
+
+	render(<Test />, {stdout, debug: true});
+	t.is(stdout.write.firstCall.args[0], 'Width: 0');
+	await delay(100);
+	t.is(stdout.write.lastCall.args[0], 'Width: 100');
+});


### PR DESCRIPTION
Fixes https://github.com/vadimdemedes/ink/issues/168. cc @maticzav 

From readme:

> Use `measureElement()` function if you need to measure dimensions of a particular `<Box>` element.
It returns an object with `width` and `height` properties.
This function is useful when your component needs to know the amount of available space it has before it can start rendering or when you need to change your layout based on the length of the content.

```jsx
import {Box, measureElement} from 'ink';

const Example = () => {
	const ref = useRef();

	useEffect(() => {
		const {width} = measureElement(ref.current);
	}, []);

	return (
		<Box width={100}>
			<Box ref={ref}>{/* This box will stretch to 100 width */}</Box>
		</Box>
	);
};
```