### PR TITLE
Free memory from unused Yoga nodes

### DIFF
--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -28,6 +28,7 @@ import './devtools';
 
 const cleanupYogaNode = (node?: Yoga.YogaNode): void => {
 	node?.unsetMeasureFunc();
+	node?.freeRecursive();
 };
 
 interface Props {


### PR DESCRIPTION
Did a `<Static>` benchmark and noticed that memory was steadily climbing, because removed Yoga nodes weren't deleted from memory. This PR fixes that.