### PR TITLE
Fix error handler with non-existent file path in the stack

### DIFF
--- a/src/components/ErrorOverview.tsx
+++ b/src/components/ErrorOverview.tsx
@@ -21,7 +21,7 @@ const ErrorOverview: FC<Props> = ({error}) => {
 	let excerpt: ExcerptLine[] | undefined;
 	let lineWidth = 0;
 
-	if (origin?.file && origin?.line) {
+	if (origin?.file && origin?.line && fs.existsSync(origin.file)) {
 		const sourceCode = fs.readFileSync(origin.file, 'utf8');
 		excerpt = codeExcerpt(sourceCode, origin.line);
 


### PR DESCRIPTION
See https://github.com/vadimdemedes/ink/issues/311#issuecomment-647223222.

If source maps are enabled, error stack could point to a file that doesn't actually exist in the distributed code. This PR fixes that by checking if there's a file, before attempting to read it.