### PR TITLE
Ignore <Text> and <Transform> components with falsy children

### DIFF
--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -46,7 +46,7 @@ export interface Props {
 	 * If `truncate-*` is passed, Ink will truncate text instead, which will result in one line of text with the rest cut off.
 	 */
 	readonly wrap?: Styles['textWrap'];
-	readonly children: ReactNode;
+	readonly children?: ReactNode;
 }
 
 /**
@@ -63,6 +63,10 @@ const Text: FC<Props> = ({
 	wrap,
 	children
 }) => {
+	if (children === undefined || children === null) {
+		return null;
+	}
+
 	const transform = (children: string): string => {
 		if (dimColor) {
 			children = chalk.dim(children);

--- a/src/components/Transform.tsx
+++ b/src/components/Transform.tsx
@@ -6,7 +6,7 @@ export interface Props {
 	 * Function which transforms children output. It accepts children and must return transformed children too.
 	 */
 	readonly transform: (children: string) => string;
-	readonly children: ReactNode;
+	readonly children?: ReactNode;
 }
 
 /**
@@ -15,14 +15,20 @@ export interface Props {
  * These use cases can't accept React nodes as input, they are expecting a string.
  * That's what <Transform> component does, it gives you an output string of its child components and lets you transform it in any way.
  */
-const Transform: FC<Props> = ({children, transform}) => (
-	<ink-text
-		style={{flexGrow: 0, flexShrink: 1, flexDirection: 'row'}}
-		internal_transform={transform}
-	>
-		{children}
-	</ink-text>
-);
+const Transform: FC<Props> = ({children, transform}) => {
+	if (children === undefined || children === null) {
+		return null;
+	}
+
+	return (
+		<ink-text
+			style={{flexGrow: 0, flexShrink: 1, flexDirection: 'row'}}
+			internal_transform={transform}
+		>
+			{children}
+		</ink-text>
+	);
+};
 
 Transform.displayName = 'Transform';
 

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -279,6 +279,16 @@ test('squash empty `<Text>` nodes', t => {
 	t.is(output, '');
 });
 
+test('<Transform> with undefined children', t => {
+	const output = renderToString(<Transform />);
+	t.is(output, '');
+});
+
+test('<Transform> with null children', t => {
+	const output = renderToString(<Transform />);
+	t.is(output, '');
+});
+
 test('hooks', t => {
 	const WithHooks = () => {
 		const [value] = useState('Hello');

--- a/test/text.tsx
+++ b/test/text.tsx
@@ -4,6 +4,16 @@ import chalk from 'chalk';
 import {renderToString} from './helpers/render-to-string';
 import {Text} from '../src';
 
+test('<Text> with undefined children', t => {
+	const output = renderToString(<Text />);
+	t.is(output, '');
+});
+
+test('<Text> with null children', t => {
+	const output = renderToString(<Text>{null}</Text>);
+	t.is(output, '');
+});
+
 test('text with standard color', t => {
 	const output = renderToString(<Text color="green">Test</Text>);
 	t.is(output, chalk.green('Test'));


### PR DESCRIPTION
I encountered a case where `<Text/>` would be updated to `<Text>X</Text>`, but layout would be broken. I traced it down to `undefined` and `null` not being handled by `<Text>` and `<Transform>`. This PR ensures that there are no nodes added when there's no children in these components.