### PR TITLE
Make sure that stack lines that cannot be parsed don't break the ErrorOverview

### DIFF
--- a/src/components/ErrorOverview.tsx
+++ b/src/components/ErrorOverview.tsx
@@ -83,7 +83,19 @@ const ErrorOverview: FC<Props> = ({error}) => {
 						.split('\n')
 						.slice(1)
 						.map(line => {
-							const parsedLine = stackUtils.parseLine(line)!;
+							const parsedLine = stackUtils.parseLine(line);
+
+							// If the line from the stack cannot be parsed, we print out the unparsed line.
+							if (!parsedLine) {
+								return (
+									<Box key={line}>
+										<Text dimColor>- </Text>
+										<Text dimColor bold>
+											{line}
+										</Text>
+									</Box>
+								);
+							}
 
 							return (
 								<Box key={line}>


### PR DESCRIPTION
I was testing Ink 3.0.0-4 and I had an error in my application. However, instead of showing the new ErrorOverview it showed an Ink error:

![image](https://user-images.githubusercontent.com/1851670/86570318-063b1880-bf70-11ea-9179-53255645cb14.png)

(TypeError: Cannot read property 'function' of null at ink/build/components/ErrorOverview.js:78:106)

Looking at the source code, it seems that a parseLine() function can return null, but that null values are not handled.

After this MR, it shows the line unparsed if it cannot be parsed - which makes sure that no error data gets lost.

![image](https://user-images.githubusercontent.com/1851670/86570751-b3ae2c00-bf70-11ea-81a5-087288432b42.png)

Looks like that there is still some stuff that can be done to handle React errors better (and also parse Component data). But at least this handles the case where parseLine returns null, which should be handled either way.