### PR TITLE
Fall back to 80 columns if the width of the terminal cannot be determined

### DIFF
--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -115,7 +115,9 @@ export default class Ink {
 
 		const {output, outputHeight, staticOutput} = render(
 			this.rootNode,
-			this.options.stdout.columns
+			// The 'columns' property can be undefined when not using a TTY.
+			// In that case we fall back to 80.
+			this.options.stdout.columns ?? 80
 		);
 
 		// If <Static> output isn't empty, it means new children have been added to it


### PR DESCRIPTION
Fixes #325 by using 80 columns if `process.stdout.columns` is `undefined`.