### PR TITLE
Fix type of `<Box>` to include `ref` prop

### DIFF
--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 import React, {forwardRef} from 'react';
-import type {FC} from 'react';
+import type {PropsWithChildren} from 'react';
 import type {Except} from 'type-fest';
 import type {Styles} from '../styles';
 import type {DOMElement} from '../dom';
@@ -52,7 +52,7 @@ export type Props = Except<Styles, 'textWrap'> & {
 /**
  * `<Box>` is an essential Ink component to build your layout. It's like `<div style="display: flex">` in the browser.
  */
-const Box: FC<Props> = forwardRef<DOMElement, Props>(
+const Box = forwardRef<DOMElement, PropsWithChildren<Props>>(
 	({children, ...style}, ref) => {
 		const transformedStyle = {
 			...style,


### PR DESCRIPTION
By explicitly typing `Box` as `React.FC` the `ref` prop is removed from typings. Instead let TypeScript infer the type from the return type of the `forwardRef()` function. (in this case `ForwardRefExoticComponent`)

To make sure `Box` still has the "children" prop, wrap `Props` in `PropsWithChildren<>`.

Fixes #329 