### PR TITLE
Skip unparseable error lines

### DIFF
--- a/src/components/ErrorOverview.tsx
+++ b/src/components/ErrorOverview.tsx
@@ -85,6 +85,8 @@ const ErrorOverview: FC<Props> = ({error}) => {
 						.map(line => {
 							const parsedLine = stackUtils.parseLine(line);
 
+							if (!parsedLine) return null;
+
 							// If the line from the stack cannot be parsed, we print out the unparsed line.
 							if (!parsedLine) {
 								return (


### PR DESCRIPTION
The `stack-utils` library doesn't support React error traces which caused a further error within `ErrorOverview`, masking the true cause

Before:
![Screenshot 2020-07-14 at 23 46 03](https://user-images.githubusercontent.com/864612/87480011-c8ec2000-c62c-11ea-9ee2-f242b7517ab0.png)

After:
![Screenshot 2020-07-14 at 23 45 40](https://user-images.githubusercontent.com/864612/87480023-d0abc480-c62c-11ea-91ca-b3eaddeec937.png)

