### PR TITLE
Add support to `useInput` for Page Up and Page Down keys

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1167,8 +1167,8 @@ Delete key was pressed.
 Type: `boolean`\
 Default: `false`
 
-If PageUp or PageDown was pressed, the corresponding property will be `true`.
-For example, if user presses PageDown, `key.pageDown` equals `true`.
+If Page Up or Page Down key was pressed, the corresponding property will be `true`.
+For example, if user presses Page Down, `key.pageDown` equals `true`.
 
 ###### key.meta
 

--- a/readme.md
+++ b/readme.md
@@ -1111,6 +1111,16 @@ Default: `false`
 If an arrow key was pressed, the corresponding property will be `true`.
 For example, if user presses left arrow key, `key.leftArrow` equals `true`.
 
+###### key.pageDown
+
+###### key.pageUp
+
+Type: `boolean`\
+Default: `false`
+
+If PageUp or PageDown was pressed, the corresponding property will be `true`.
+For example, if user presses PageDown, `key.pageDown` equals `true`.
+
 ###### key.return
 
 Type: `boolean`\

--- a/readme.md
+++ b/readme.md
@@ -1111,16 +1111,6 @@ Default: `false`
 If an arrow key was pressed, the corresponding property will be `true`.
 For example, if user presses left arrow key, `key.leftArrow` equals `true`.
 
-###### key.pageDown
-
-###### key.pageUp
-
-Type: `boolean`\
-Default: `false`
-
-If PageUp or PageDown was pressed, the corresponding property will be `true`.
-For example, if user presses PageDown, `key.pageDown` equals `true`.
-
 ###### key.return
 
 Type: `boolean`\
@@ -1169,6 +1159,16 @@ Type: `boolean`\
 Default: `false`
 
 Delete key was pressed.
+
+###### key.pageDown
+
+###### key.pageUp
+
+Type: `boolean`\
+Default: `false`
+
+If PageUp or PageDown was pressed, the corresponding property will be `true`.
+For example, if user presses PageDown, `key.pageDown` equals `true`.
 
 ###### key.meta
 

--- a/src/hooks/use-input.ts
+++ b/src/hooks/use-input.ts
@@ -26,7 +26,7 @@ export interface Key {
 	rightArrow: boolean;
 
 	/**
-	 * Page Down key was pressed
+	 * Page Down key was pressed.
 	 */
 	pageDown: boolean;
 

--- a/src/hooks/use-input.ts
+++ b/src/hooks/use-input.ts
@@ -31,7 +31,7 @@ export interface Key {
 	pageDown: boolean;
 
 	/**
-	 * Page Up key was pressed
+	 * Page Up key was pressed.
 	 */
 	pageUp: boolean;
 

--- a/src/hooks/use-input.ts
+++ b/src/hooks/use-input.ts
@@ -26,6 +26,16 @@ export interface Key {
 	rightArrow: boolean;
 
 	/**
+	 * Page Down key was pressed
+	 */
+	pageDown: boolean;
+
+	/**
+	 * Page Up key was pressed
+	 */
+	pageUp: boolean;
+
+	/**
 	 * Return (Enter) key was pressed.
 	 */
 	return: boolean;
@@ -130,6 +140,8 @@ const useInput = (inputHandler: Handler, options: Options = {}) => {
 				downArrow: input === '\u001B[B',
 				leftArrow: input === '\u001B[D',
 				rightArrow: input === '\u001B[C',
+				pageDown: input === '\u001B[6~',
+				pageUp: input === '\u001B[5~',
 				return: input === '\r',
 				escape: input === '\u001B',
 				ctrl: false,

--- a/test/fixtures/use-input.tsx
+++ b/test/fixtures/use-input.tsx
@@ -50,6 +50,16 @@ const UserInput: FC<{test: string}> = ({test}) => {
 			return;
 		}
 
+		if (test === 'pageDown' && key.pageDown) {
+			exit();
+			return;
+		}
+
+		if (test === 'pageUp' && key.pageUp) {
+			exit();
+			return;
+		}
+
 		if (test === 'tab' && input === '' && key.tab) {
 			exit();
 			return;

--- a/test/hooks.tsx
+++ b/test/hooks.tsx
@@ -112,6 +112,20 @@ test('useInput - handle right arrow', async t => {
 	t.true(ps.output.includes('exited'));
 });
 
+test('useInput - handle page down', async t => {
+	const ps = term('use-input', ['pageDown']);
+	ps.write('\u001B[6~');
+	await ps.waitForExit();
+	t.true(ps.output.includes('exited'));
+});
+
+test('useInput - handle page up', async t => {
+	const ps = term('use-input', ['pageUp']);
+	ps.write('\u001B[5~');
+	await ps.waitForExit();
+	t.true(ps.output.includes('exited'));
+});
+
 test('useInput - handle Tab', async t => {
 	const ps = term('use-input', ['tab']);
 	ps.write('\t');


### PR DESCRIPTION
I'm working on a pager, and wanted to be able to check for page up / page down events, and thought it'd be a common enough thing to make a PR.