### PR TITLE
Improve auto-complete for `color` and `backgroundColor` props for `Text`

### DIFF
--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -3,17 +3,19 @@ import type {FC, ReactNode} from 'react';
 import chalk from 'chalk';
 import colorize from '../colorize';
 import type {Styles} from '../styles';
+import type {LiteralUnion} from 'type-fest';
+import type {ForegroundColor, BackgroundColor} from 'chalk';
 
 export interface Props {
 	/**
 	 * Change text color. Ink uses chalk under the hood, so all its functionality is supported.
 	 */
-	readonly color?: typeof chalk.ForegroundColor | string;
+	readonly color?: LiteralUnion<typeof ForegroundColor, string>;
 
 	/**
 	 * Same as `color`, but for background.
 	 */
-	readonly backgroundColor?: typeof chalk.BackgroundColor | string;
+	readonly backgroundColor?: LiteralUnion<typeof BackgroundColor, string>;
 
 	/**
 	 * Dim the color (emit a small amount of light).

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -8,12 +8,12 @@ export interface Props {
 	/**
 	 * Change text color. Ink uses chalk under the hood, so all its functionality is supported.
 	 */
-	readonly color?: string;
+	readonly color?: typeof chalk.ForegroundColor | string;
 
 	/**
 	 * Same as `color`, but for background.
 	 */
-	readonly backgroundColor?: string;
+	readonly backgroundColor?: typeof chalk.BackgroundColor | string;
 
 	/**
 	 * Dim the color (emit a small amount of light).


### PR DESCRIPTION
# Changes

![image](https://user-images.githubusercontent.com/357619/88611816-d68db500-d0c4-11ea-8c80-8e9b8c2887fc.png)

In the JetBrains IDEs would suggest colors like the above image.

![image](https://user-images.githubusercontent.com/357619/88612210-a561b480-d0c5-11ea-96f8-54c759bda4ce.png)

But, in VSCode it does not work. 😨

This may not be complete, but it would help JetBrains IDE users.

