### PR TITLE
Fix border re-rendering

### DIFF
--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -178,6 +178,20 @@ export default createReconciler<
 					const styleKeys = Object.keys(newStyle) as Array<keyof Styles>;
 
 					for (const styleKey of styleKeys) {
+						// Always include `borderColor` and `borderStyle` to ensure border is rendered,
+						// otherwise resulting `updatePayload` may not contain them
+						// if they weren't changed during this update
+						if (styleKey === 'borderStyle' || styleKey === 'borderColor') {
+							if (typeof updatePayload.style !== 'object') {
+								// Linter didn't like `= {} as Style`
+								const style: Styles = {};
+								updatePayload.style = style;
+							}
+
+							(updatePayload.style as any).borderStyle = newStyle.borderStyle;
+							(updatePayload.style as any).borderColor = newStyle.borderColor;
+						}
+
 						if (newStyle[styleKey] !== oldStyle[styleKey]) {
 							if (typeof updatePayload.style !== 'object') {
 								// Linter didn't like `= {} as Style`

--- a/test/borders.tsx
+++ b/test/borders.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 import test from 'ava';
 import boxen from 'boxen';
 import type {Options} from 'boxen';
 import indentString from 'indent-string';
+import delay from 'delay';
 import {renderToString} from './helpers/render-to-string';
-import {Box, Text} from '../src';
+import createStdout from './helpers/create-stdout';
+import {render, Box, Text} from '../src';
 
 const box = (text: string, options?: Options): string => {
 	return boxen(text, {
@@ -226,4 +228,35 @@ test('nested boxes', t => {
 
 	const nestedBox = indentString(box('\n Hello World \n'), 1);
 	t.is(output, box(`${' '.repeat(38)}\n${nestedBox}\n`));
+});
+
+test('render border after update', async t => {
+	const stdout = createStdout();
+
+	const Test = () => {
+		const [borderColor, setBorderColor] = useState();
+
+		useEffect(() => {
+			setBorderColor('green');
+		}, []);
+
+		return (
+			<Box borderStyle="round" borderColor={borderColor}>
+				<Text>Hello World</Text>
+			</Box>
+		);
+	};
+
+	render(<Test />, {
+		stdout,
+		debug: true
+	});
+
+	t.is(stdout.write.lastCall.args[0], box('Hello World'.padEnd(98, ' ')));
+	await delay(100);
+
+	t.is(
+		stdout.write.lastCall.args[0],
+		box('Hello World'.padEnd(98, ' '), {borderColor: 'green'})
+	);
 });


### PR DESCRIPTION
Fixes https://github.com/vadimdemedes/ink/issues/340.

In the following scenario, border wouldn't be rendered after the update happens:

```jsx
const Test = () => {
	const [borderColor, setBorderColor] = useState();

	useEffect(() => {
		setBorderColor('green');
	}, []);

	return (
		<Box borderStyle="round" borderColor={borderColor}>
			<Text>Hello World</Text>
		</Box>
	);
};
```

It was happening because Ink's reconciler passes down only props that were changed during an update (https://github.com/vadimdemedes/ink/blob/master/src/reconciler.ts#L160) and in this case, `borderStyle` remained unchanged so it was missing when Ink drew a layout. If Ink doesn't see `borderStyle`, it's not going to render the border - https://github.com/vadimdemedes/ink/blob/master/src/render-border.ts#L7.

To fix it, I modified reconciler's `prepareUpdate` function to always include `borderStyle` and `borderColor` if at least one of them is present. Now if `borderStyle` stays unchanged, but `borderColor` changes, both props will be included in the update.