### PR TITLE
Export DOMElement type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,3 +20,4 @@ export {default as useStderr} from './hooks/use-stderr';
 export {default as useFocus} from './hooks/use-focus';
 export {default as useFocusManager} from './hooks/use-focus-manager';
 export {default as measureElement} from './measure-element';
+export {DOMElement} from './dom';


### PR DESCRIPTION
Export `DOMElement` type to use `React.useRef<DOMElement>` (#350)
