### PR TITLE
Let `useInput` handle Ctrl+C if `exitOnCtrlC` is disabled

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -73,7 +73,8 @@ export default class App extends PureComponent<Props, State> {
 					value={{
 						stdin: this.props.stdin,
 						setRawMode: this.handleSetRawMode,
-						isRawModeSupported: this.isRawModeSupported()
+						isRawModeSupported: this.isRawModeSupported(),
+						internal_exitOnCtrlC: this.props.exitOnCtrlC
 					}}
 				>
 					<StdoutContext.Provider

--- a/src/components/StdinContext.ts
+++ b/src/components/StdinContext.ts
@@ -16,6 +16,8 @@ export interface Props {
 	 * A boolean flag determining if the current `stdin` supports `setRawMode`. A component using `setRawMode` might want to use `isRawModeSupported` to nicely fall back in environments where raw mode is not supported.
 	 */
 	readonly isRawModeSupported: boolean;
+
+	readonly internal_exitOnCtrlC: boolean;
 }
 
 /**
@@ -24,7 +26,8 @@ export interface Props {
 const StdinContext = createContext<Props>({
 	stdin: undefined,
 	setRawMode: () => {},
-	isRawModeSupported: false
+	isRawModeSupported: false,
+	internal_exitOnCtrlC: true
 });
 
 StdinContext.displayName = 'InternalStdinContext';

--- a/src/hooks/use-input.ts
+++ b/src/hooks/use-input.ts
@@ -113,7 +113,7 @@ interface Options {
  * ```
  */
 const useInput = (inputHandler: Handler, options: Options = {}) => {
-	const {stdin, setRawMode} = useStdin();
+	const {stdin, setRawMode, internal_exitOnCtrlC} = useStdin();
 
 	useEffect(() => {
 		if (options.isActive === false) {
@@ -180,7 +180,8 @@ const useInput = (inputHandler: Handler, options: Options = {}) => {
 				input = '';
 			}
 
-			if (!(input === 'c' && key.ctrl)) {
+			// If app is not supposed to exit on Ctrl+C, then let input listener handle it
+			if (!(input === 'c' && key.ctrl) || !internal_exitOnCtrlC) {
 				inputHandler(input, key);
 			}
 		};
@@ -190,7 +191,7 @@ const useInput = (inputHandler: Handler, options: Options = {}) => {
 		return () => {
 			stdin?.off('data', handleData);
 		};
-	}, [options.isActive, stdin, inputHandler]);
+	}, [options.isActive, stdin, internal_exitOnCtrlC, inputHandler]);
 };
 
 export default useInput;

--- a/test/fixtures/use-input-ctrl-c.tsx
+++ b/test/fixtures/use-input-ctrl-c.tsx
@@ -1,0 +1,24 @@
+import React, {FC} from 'react';
+import {render, useInput, useApp} from '../..';
+
+const UserInput: FC = () => {
+	const {exit} = useApp();
+
+	useInput((input, key) => {
+		if (input === 'c' && key.ctrl) {
+			exit();
+			return;
+		}
+
+		throw new Error('Crash');
+	});
+
+	return null;
+};
+
+const app = render(<UserInput />, {exitOnCtrlC: false});
+
+(async () => {
+	await app.waitUntilExit();
+	console.log('exited');
+})();

--- a/test/hooks.tsx
+++ b/test/hooks.tsx
@@ -163,6 +163,13 @@ test('useInput - ignore input if not active', async t => {
 	t.true(ps.output.includes('exited'));
 });
 
+test('useInput - handle Ctrl+C when `exitOnCtrlC` is `false`', async t => {
+	const ps = term('use-input-ctrl-c');
+	ps.write('\u0003');
+	await ps.waitForExit();
+	t.true(ps.output.includes('exited'));
+});
+
 test('useStdout - write to stdout', async t => {
 	const ps = term('use-stdout');
 	await ps.waitForExit();

--- a/test/hooks.tsx
+++ b/test/hooks.tsx
@@ -28,7 +28,7 @@ const term = (fixture: string, args: string[] = []) => {
 			// TODO: Send a signal from the Ink process when it's ready to accept input instead
 			setTimeout(() => {
 				ps.write(input);
-			}, 2000);
+			}, 3000);
 		},
 		output: '',
 		waitForExit: () => exitPromise

--- a/test/hooks.tsx
+++ b/test/hooks.tsx
@@ -25,9 +25,10 @@ const term = (fixture: string, args: string[] = []) => {
 	const result = {
 		write: (input: string) => {
 			// Give TS and Ink time to start up and render UI
+			// TODO: Send a signal from the Ink process when it's ready to accept input instead
 			setTimeout(() => {
 				ps.write(input);
-			}, 1000);
+			}, 2000);
 		},
 		output: '',
 		waitForExit: () => exitPromise


### PR DESCRIPTION
Fixes https://github.com/vadimdemedes/ink/issues/349.

Issue was caused by https://github.com/vadimdemedes/ink/blob/373db19bdbbbab0e7fedf11dc2285cbe6cd3bd45/src/hooks/use-input.ts#L183-L185, where Ctrl + C sequence was ignored by [`useInput`](https://github.com/vadimdemedes/ink#useinputinputhandler-options). However, if [`exitOnCtrlC`](https://github.com/vadimdemedes/ink#exitonctrlc) is disabled, that means developer wants to handle exiting manually, so `useInput` should no longer suppress it.