### PR TITLE
Fix `Static` example code

### DIFF
--- a/examples/static/static.js
+++ b/examples/static/static.js
@@ -19,7 +19,7 @@ const Example = () => {
 					}
 				]);
 
-				setTimeout(run, 100);
+				timer = setTimeout(run, 100);
 			}
 		};
 


### PR DESCRIPTION
Variable `timer` is undefined.
Variable `timer` should get the setTimeout return in order to be used in clear timeout on clean up function.