### PR TITLE
Add git-contrib-calendar link on "Who's using Ink" section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,7 @@ Feel free to play around with the code and fork this repl at [https://repl.it/@v
 - [startd](https://github.com/mgrip/startd) - Turn your React component into a web app from the command-line.
 - [wiki-cli](https://github.com/hexrcs/wiki-cli) - Search Wikipedia and read summaries directly in your terminal.
 - [garson](https://github.com/goliney/garson) - Build interactive config-based command-line interfaces.
+- [git-contrib-calendar](https://github.com/giannisp/git-contrib-calendar) - Display a git contributions calendar for any local repository.
 
 ## Contents
 

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ Feel free to play around with the code and fork this repl at [https://repl.it/@v
 - [startd](https://github.com/mgrip/startd) - Turn your React component into a web app from the command-line.
 - [wiki-cli](https://github.com/hexrcs/wiki-cli) - Search Wikipedia and read summaries directly in your terminal.
 - [garson](https://github.com/goliney/garson) - Build interactive config-based command-line interfaces.
-- [git-contrib-calendar](https://github.com/giannisp/git-contrib-calendar) - Display a git contributions calendar for any local repository.
+- [git-contrib-calendar](https://github.com/giannisp/git-contrib-calendar) - Display a contributions calendar for any git repository.
 
 ## Contents
 


### PR DESCRIPTION
I have recently discovered Ink, and I was amazed by the concept, awesome work 👍

While experimenting with Ink, I have built a git contributions calendar for local repositories.  
Feel free to include it on the "Who's using Ink" README section if you wish.
