### PR TITLE
Fallback to 80 if number of columns isn't set

### DIFF
--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -115,9 +115,9 @@ export default class Ink {
 
 		const {output, outputHeight, staticOutput} = render(
 			this.rootNode,
-			// The 'columns' property can be undefined when not using a TTY.
+			// The 'columns' property can be undefined or 0 when not using a TTY.
 			// In that case we fall back to 80.
-			this.options.stdout.columns ?? 80
+			this.options.stdout.columns || 80
 		);
 
 		// If <Static> output isn't empty, it means new children have been added to it


### PR DESCRIPTION
Fixes #366. 

Side note: As I said in that issue, `node.yogaNode.getComputedWidth` returns `0`, but I didn't touch that. This single change solves my issue.

Related:

- #325
- #327

cc @bartlangelaan 