### PR TITLE
Fix `borderColor` type

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -2,6 +2,7 @@
 import Yoga from 'yoga-layout-prebuilt';
 import type {YogaNode} from 'yoga-layout-prebuilt';
 import type {Boxes} from 'cli-boxes';
+import type {LiteralUnion} from 'type-fest';
 import type {ForegroundColor} from 'chalk';
 
 export interface Styles {
@@ -140,7 +141,7 @@ export interface Styles {
 	 * Change border color.
 	 * Accepts the same values as `color` in <Text> component.
 	 */
-	readonly borderColor?: typeof ForegroundColor;
+	readonly borderColor?: LiteralUnion<typeof ForegroundColor, string>;
 }
 
 const applyPositionStyles = (node: Yoga.YogaNode, style: Styles): void => {


### PR DESCRIPTION
Type of `borderColor` property in `Styles` interface can (and should) match the `color` property of `Text` component, but it did not. It was limited to basic foreground colors without the option use string values.