### PR TITLE
Import devtools only when DEV=true

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -1,6 +1,8 @@
 // Ignoring missing types error to avoid adding another dependency for this hack to work
 // @ts-ignore
 import ws from 'ws';
+// @ts-ignore
+import {connectToDevTools} from 'react-devtools-core';
 
 const customGlobal = global as any;
 
@@ -69,10 +71,4 @@ customGlobal.window.__REACT_DEVTOOLS_COMPONENT_FILTERS__ = [
 	}
 ];
 
-// Ignoring missing types error to avoid adding another dependency for this hack to work
-// @ts-ignore
-import {connectToDevTools} from 'react-devtools-core';
-
-if (process.env.DEV === 'true') {
-	connectToDevTools();
-}
+connectToDevTools();

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -29,7 +29,7 @@ import type {OutputTransformer} from './render-node-to-output';
 // See https://github.com/vadimdemedes/ink/issues/384
 
 if (process.env.DEV === 'true') {
-	// eslint-disable-next-line @typescript-eslint/no-var-requires
+	// eslint-disable-next-line import/no-unassigned-import
 	require('./devtools');
 }
 

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -23,8 +23,15 @@ import type {
 } from './dom';
 import type {Styles} from './styles';
 import type {OutputTransformer} from './render-node-to-output';
-// eslint-disable-next-line import/no-unassigned-import
-import './devtools';
+
+// We need to conditionally perform devtools connection to avoid
+// accidentally breaking other third party code.
+// See https://github.com/vadimdemedes/ink/issues/384
+
+if (process.env.DEV === 'true') {
+	// eslint-disable-next-line @typescript-eslint/no-var-requires
+	require('./devtools');
+}
 
 const cleanupYogaNode = (node?: Yoga.YogaNode): void => {
 	node?.unsetMeasureFunc();

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -25,9 +25,8 @@ import type {Styles} from './styles';
 import type {OutputTransformer} from './render-node-to-output';
 
 // We need to conditionally perform devtools connection to avoid
-// accidentally breaking other third party code.
+// accidentally breaking other third-party code.
 // See https://github.com/vadimdemedes/ink/issues/384
-
 if (process.env.DEV === 'true') {
 	// eslint-disable-next-line import/no-unassigned-import
 	require('./devtools');


### PR DESCRIPTION
As discussed in #384.

However, after also converting the `ws` module import to `require()` to avoid loading unused code, I basically had the whole `devtools.ts` wrapped in an `if` block. At that point, I decided to roll back my changes to that file and just go for conditionally importing the whole devtools file.

Fixes #384 