### PR TITLE
Update `create-ink-app` guide

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,8 +123,11 @@ Use [create-ink-app](https://github.com/vadimdemedes/create-ink-app) to quickly 
 $ mkdir my-ink-cli
 $ cd my-ink-cli
 $ npx create-ink-app
+```
 
-# Or create with TypeScript React
+Alternatively, create a TypeScript project:
+
+```
 $ npx create-ink-app --typescript
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,9 @@ Use [create-ink-app](https://github.com/vadimdemedes/create-ink-app) to quickly 
 $ mkdir my-ink-cli
 $ cd my-ink-cli
 $ npx create-ink-app
+
+# Or create with TypeScript React
+$ npx create-ink-app --typescript
 ```
 
 <details><summary>Manual setup</summary>


### PR DESCRIPTION
Now we can also create a TypeScript project by passing a `--typescript` option.

Related to https://github.com/vadimdemedes/create-ink-app/pull/5