### PR TITLE
Make `patchConsole` option support a function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1576,14 +1576,14 @@ This is needed in case `process.stdin` is in [raw mode](https://nodejs.org/api/t
 
 ###### patchConsole
 
-Type: `boolean`\
+Type: `boolean | (callback: (stream: 'stdout' | 'stderr', data: string) => void) => () => void`\
 Default: `true`
 
 Patch console methods to ensure console output doesn't mix with Ink output.
 When any of `console.*` methods are called (like `console.log()`), Ink intercepts their output, clears main output, renders output from the console method and then rerenders main output again.
 That way both are visible and are not overlapping each other.
 
-This functionality is powered by [patch-console](https://github.com/vadimdemedes/patch-console), so if you need to disable Ink's interception of output but want to build something custom, you can use it.
+This functionality is powered by [patch-console](https://github.com/vadimdemedes/patch-console), so if you need to disable Ink's interception of output but want to build something custom, you can use it. You can also provide your own patch function to `patchConsole` with the same API.
 
 ###### debug
 

--- a/readme.md
+++ b/readme.md
@@ -1583,7 +1583,28 @@ Patch console methods to ensure console output doesn't mix with Ink output.
 When any of `console.*` methods are called (like `console.log()`), Ink intercepts their output, clears main output, renders output from the console method and then rerenders main output again.
 That way both are visible and are not overlapping each other.
 
-This functionality is powered by [patch-console](https://github.com/vadimdemedes/patch-console), so if you need to disable Ink's interception of output but want to build something custom, you can use it. You can also provide your own patch function to `patchConsole` with the same API.
+This functionality is powered by [patch-console](https://github.com/vadimdemedes/patch-console), so if you need to disable Ink's interception of output but want to build something custom, you can use it.
+
+You can also provide your own patch function to `patchConsole` using the same API.
+
+```jsx
+import {render} from 'ink';
+
+render(<Example />, {
+	// Turn all logs into errors as an example
+	patchConsole(callback) {
+		const oldLog = console.log;
+
+		console.log = message => {
+			callback('stderr', message);
+		};
+
+		return () => {
+			console.log = oldLog;
+		};
+	}
+});
+```
 
 ###### debug
 

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -22,7 +22,7 @@ export interface Options {
 	stderr: NodeJS.WriteStream;
 	debug: boolean;
 	exitOnCtrlC: boolean;
-	patchConsole: boolean;
+	patchConsole: boolean | typeof patchConsole;
 	waitUntilExit?: () => Promise<void>;
 }
 
@@ -282,7 +282,12 @@ export default class Ink {
 			return;
 		}
 
-		this.restoreConsole = patchConsole((stream, data) => {
+		const patch =
+			typeof this.options.patchConsole === 'function'
+				? this.options.patchConsole
+				: patchConsole;
+
+		this.restoreConsole = patch((stream, data) => {
 			if (stream === 'stdout') {
 				this.writeToStdout(data);
 			}

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,4 +1,5 @@
 import {ReactElement} from 'react';
+import patchConsole from 'patch-console';
 import Ink, {Options as InkOptions} from './ink';
 import instances from './instances';
 import {Stream} from 'stream';
@@ -39,7 +40,7 @@ export interface RenderOptions {
 	 *
 	 * @default true
 	 */
-	patchConsole?: boolean;
+	patchConsole?: boolean | typeof patchConsole;
 }
 
 export interface Instance {


### PR DESCRIPTION
This updates the `patchConsole` option to support a boolean (existing functionality) or a function.

I currently patch the console manually in my project, but it doesn't interweave correctly with Ink's output. But I can't use Ink's `patchConsole` because I need more control of the console overrides. However, if I use `patch-console` myself outside of Ink, I still have the same problems as before (I don't have access to Ink's stderr/stdout streams).

I feel like this is a nice compromise, as I can provide my own `patchConsole` function AND hook into Ink's rendering flow.