### PR TITLE
Add `overflow` prop to `Box` component

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -785,6 +785,14 @@ Default: `flex`
 
 Set this property to `none` to hide the element.
 
+##### overflow
+
+Type: `string`\
+Allowed values: `visible` `hidden`\
+Default: `visible`
+
+Set this property to `hidden` to hide content that overflows this element.
+
 #### Borders
 
 ##### borderStyle

--- a/src/output.ts
+++ b/src/output.ts
@@ -100,7 +100,7 @@ export default class Output {
 					}
 
 					if (endX - startX < length) {
-						line = sliceAnsi(line, startX - x, endX - startX);
+						line = sliceAnsi(line, startX - x, endX - x);
 					}
 				}
 

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -189,7 +189,11 @@ export default createReconciler<
 						// Always include `borderColor` and `borderStyle` to ensure border is rendered,
 						// otherwise resulting `updatePayload` may not contain them
 						// if they weren't changed during this update
-						if (styleKey === 'borderStyle' || styleKey === 'borderColor') {
+						if (
+							styleKey === 'borderStyle' ||
+							styleKey === 'borderColor' ||
+							styleKey === 'overflow'
+						) {
 							if (typeof updatePayload.style !== 'object') {
 								// Linter didn't like `= {} as Style`
 								const style: Styles = {};
@@ -198,6 +202,7 @@ export default createReconciler<
 
 							(updatePayload.style as any).borderStyle = newStyle.borderStyle;
 							(updatePayload.style as any).borderColor = newStyle.borderColor;
+							(updatePayload.style as any).overflow = newStyle.overflow;
 						}
 
 						if (newStyle[styleKey] !== oldStyle[styleKey]) {

--- a/src/render-border.ts
+++ b/src/render-border.ts
@@ -2,8 +2,15 @@ import cliBoxes from 'cli-boxes';
 import colorize from './colorize';
 import {DOMNode} from './dom';
 import Output from './output';
+import {Bounds} from './render-node-to-output';
 
-export default (x: number, y: number, node: DOMNode, output: Output): void => {
+export default (
+	x: number,
+	y: number,
+	node: DOMNode,
+	output: Output,
+	bounds?: Bounds
+): void => {
 	if (typeof node.style.borderStyle === 'string') {
 		const width = node.yogaNode!.getComputedWidth();
 		const height = node.yogaNode!.getComputedHeight();
@@ -26,9 +33,21 @@ export default (x: number, y: number, node: DOMNode, output: Output): void => {
 			'foreground'
 		);
 
-		output.write(x, y, topBorder, {transformers: []});
-		output.write(x, y + 1, verticalBorder, {transformers: []});
-		output.write(x + width - 1, y + 1, verticalBorder, {transformers: []});
-		output.write(x, y + height - 1, bottomBorder, {transformers: []});
+		output.write(x, y, topBorder, {
+			transformers: [],
+			bounds
+		});
+		output.write(x, y + 1, verticalBorder, {
+			transformers: [],
+			bounds
+		});
+		output.write(x + width - 1, y + 1, verticalBorder, {
+			transformers: [],
+			bounds
+		});
+		output.write(x, y + height - 1, bottomBorder, {
+			transformers: [],
+			bounds
+		});
 	}
 };

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -141,6 +141,11 @@ export interface Styles {
 	 * Accepts the same values as `color` in <Text> component.
 	 */
 	readonly borderColor?: LiteralUnion<typeof ForegroundColor, string>;
+
+	/**
+	 * Set this property to `hidden` to hide content overflowing the box.
+	 */
+	readonly overflow?: 'hidden' | 'visible';
 }
 
 const applyPositionStyles = (node: Yoga.YogaNode, style: Styles): void => {

--- a/test/overflow.tsx
+++ b/test/overflow.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import test from 'ava';
+import {renderToString} from './helpers/render-to-string';
+import {Box, Text} from '../src';
+
+test('overflow y', t => {
+	const output = renderToString(
+		<Box overflow="hidden" height={1}>
+			<Text>Line 1{'\n'}Line 2</Text>
+		</Box>
+	);
+
+	t.is(output, 'Line 1');
+});
+
+test('overflow x', t => {
+	const output = renderToString(
+		<Box overflow="hidden" width={3}>
+			<Box marginRight={-3} width={6} height={1}>
+				<Text>123456</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, '123');
+});
+
+test('nested boxes with overflow hidden', t => {
+	const output = renderToString(
+		<Box overflow="hidden" width={3}>
+			<Box overflow="hidden" marginRight={-3} width={6} height={1}>
+				<Text>Line 1{'\n'}Line 2</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, 'Lin');
+});


### PR DESCRIPTION
Adds an `overflow` property to `<Box>` with values of `"visible"` (default) and `"hidden"`. When set to `"hidden"`, any content not inside the element's border will not be rendered.

This can be useful for making scrolling elements for arbitrary content such as the implementation posted in #222.
