### PR TITLE
Fix undefined errors for focusing unmounted elements

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -215,7 +215,7 @@ export default class App extends PureComponent<Props, State> {
 
 	focusNext = (): void => {
 		this.setState(previousState => {
-			const firstFocusableId = previousState.focusables[0].id;
+			const firstFocusableId = previousState.focusables[0]?.id;
 			const nextFocusableId = this.findNextFocusable(previousState);
 
 			return {
@@ -227,8 +227,7 @@ export default class App extends PureComponent<Props, State> {
 	focusPrevious = (): void => {
 		this.setState(previousState => {
 			const lastFocusableId =
-				previousState.focusables[previousState.focusables.length - 1].id;
-
+				previousState.focusables[previousState.focusables.length - 1]?.id;
 			const previousFocusableId = this.findPreviousFocusable(previousState);
 
 			return {
@@ -314,7 +313,7 @@ export default class App extends PureComponent<Props, State> {
 			index < state.focusables.length;
 			index++
 		) {
-			if (state.focusables[index].isActive) {
+			if (state.focusables[index]?.isActive) {
 				return state.focusables[index].id;
 			}
 		}
@@ -328,7 +327,7 @@ export default class App extends PureComponent<Props, State> {
 		});
 
 		for (let index = activeIndex - 1; index >= 0; index--) {
-			if (state.focusables[index].isActive) {
+			if (state.focusables[index]?.isActive) {
 				return state.focusables[index].id;
 			}
 		}

--- a/test/focus.tsx
+++ b/test/focus.tsx
@@ -12,6 +12,7 @@ const createStdin = () => {
 	stdin.setRawMode = spy();
 	stdin.setEncoding = () => {};
 	stdin.resume = () => {};
+	stdin.pause = () => {};
 
 	return stdin;
 };
@@ -23,6 +24,7 @@ interface TestProps {
 	disabled?: boolean;
 	focusNext?: boolean;
 	focusPrevious?: boolean;
+	unmountChildren?: boolean;
 }
 
 const Test: FC<TestProps> = ({
@@ -31,7 +33,8 @@ const Test: FC<TestProps> = ({
 	autoFocus = false,
 	disabled = false,
 	focusNext = false,
-	focusPrevious = false
+	focusPrevious = false,
+	unmountChildren = false
 }) => {
 	const focusManager = useFocusManager();
 
@@ -54,6 +57,10 @@ const Test: FC<TestProps> = ({
 			focusManager.focusPrevious();
 		}
 	}, [focusPrevious]);
+
+	if (unmountChildren) {
+		return null;
+	}
 
 	return (
 		<Box flexDirection="column">
@@ -384,4 +391,36 @@ test('manually focus previous component', async t => {
 		stdout.write.lastCall.args[0],
 		['First', 'Second', 'Third ✔'].join('\n')
 	);
+});
+
+test('doesnt crash when focusing next on unmounted children', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	const {rerender} = render(<Test autoFocus />, {
+		stdout,
+		stdin,
+		debug: true
+	});
+
+	await delay(100);
+	rerender(<Test focusNext unmountChildren />);
+	await delay(100);
+
+	t.is(stdout.write.lastCall.args[0], '');
+});
+
+test('doesnt crash when focusing previous on unmounted children', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	const {rerender} = render(<Test autoFocus />, {
+		stdout,
+		stdin,
+		debug: true
+	});
+
+	await delay(100);
+	rerender(<Test focusPrevious unmountChildren />);
+	await delay(100);
+
+	t.is(stdout.write.lastCall.args[0], '');
 });


### PR DESCRIPTION
@vadimdemedes 

Ran into an issue where `focusNext` was called in a side-effect, but the focusables (children) were unmounted before it fired, resulting in this error. Just adding some undefined checks

```
error The above error occurred in the <InternalApp> component:
    in InternalApp

Consider adding an error boundary to your tree to customize error handling behavior.
Visit https://fb.me/react-error-boundaries to learn more about error boundaries.
/Users/milesj/Projects/packemon/node_modules/yoga-layout-prebuilt/yoga-layout/build/Release/nbind.js:53
        throw ex;
        ^

TypeError: Cannot read property 'id' of undefined
    at App.<anonymous> (/Users/milesj/Projects/packemon/node_modules/ink/build/components/App.js:119:70)
    at getStateFromUpdate (/Users/milesj/Projects/packemon/node_modules/react-reconciler/cjs/react-reconciler.development.js:3420:35)
    at processUpdateQueue (/Users/milesj/Projects/packemon/node_modules/react-reconciler/cjs/react-reconciler.development.js:3494:21)
    at updateClassInstance (/Users/milesj/Projects/packemon/node_modules/react-reconciler/cjs/react-reconciler.development.js:4297:5)
    at updateClassComponent (/Users/milesj/Projects/packemon/node_modules/react-reconciler/cjs/react-reconciler.development.js:8196:20)
    at beginWork$1 (/Users/milesj/Projects/packemon/node_modules/react-reconciler/cjs/react-reconciler.development.js:9962:16)
    at Object.invokeGuardedCallbackImpl (/Users/milesj/Projects/packemon/node_modules/react-reconciler/cjs/react-reconciler.development.js:11563:10)
    at invokeGuardedCallback (/Users/milesj/Projects/packemon/node_modules/react-reconciler/cjs/react-reconciler.development.js:11740:31)
    at beginWork$$1 (/Users/milesj/Projects/packemon/node_modules/react-reconciler/cjs/react-reconciler.development.js:15778:7)
    at performUnitOfWork (/Users/milesj/Projects/packemon/node_modules/react-reconciler/cjs/react-reconciler.development.js:14696:12)
```