### PR TITLE
Add link to ink-syntax-highlight in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1748,7 +1748,7 @@ You can even inspect and change the props of components, and see the results imm
 - [ink-markdown](https://github.com/cameronhunter/ink-markdown) - Render syntax highlighted Markdown.
 - [ink-quicksearch-input](https://github.com/Eximchain/ink-quicksearch-input) - Select component with fast quicksearch-like navigation.
 - [ink-confirm-input](https://github.com/kevva/ink-confirm-input) - Yes/No confirmation input.
-- [ink-syntax-highlight](https://github.com/vsashyn/ink-syntax-highlight) - Code syntax highlight.
+- [ink-syntax-highlight](https://github.com/vsashyn/ink-syntax-highlight) - Code syntax highlighting.
 
 ## Useful Hooks
 

--- a/readme.md
+++ b/readme.md
@@ -1748,6 +1748,7 @@ You can even inspect and change the props of components, and see the results imm
 - [ink-markdown](https://github.com/cameronhunter/ink-markdown) - Render syntax highlighted Markdown.
 - [ink-quicksearch-input](https://github.com/Eximchain/ink-quicksearch-input) - Select component with fast quicksearch-like navigation.
 - [ink-confirm-input](https://github.com/kevva/ink-confirm-input) - Yes/No confirmation input.
+- [ink-syntax-highlight](https://github.com/vsashyn/ink-syntax-highlight) - Code syntax highlight.
 
 ## Useful Hooks
 


### PR DESCRIPTION
Add link to [ink-syntax-highlight](https://github.com/vsashyn/ink-syntax-highlight) component to readme.