### PR TITLE
POC: Incremental rendering

### DIFF
--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -1,7 +1,6 @@
 import React, {ReactNode} from 'react';
 import {throttle, DebouncedFunc} from 'lodash';
 import logUpdate, {LogUpdate} from './log-update';
-import ansiEscapes from 'ansi-escapes';
 import originalIsCI from 'is-ci';
 import autoBind from 'auto-bind';
 import reconciler from './reconciler';
@@ -60,7 +59,7 @@ export default class Ink {
 		this.throttledLog = options.debug
 			? this.log
 			: throttle(this.log, undefined, {
-					leading: true,
+					leading: false,
 					trailing: true
 			  });
 
@@ -111,7 +110,7 @@ export default class Ink {
 			return;
 		}
 
-		const {output, outputHeight, staticOutput} = render(
+		const {output, staticOutput} = render(
 			this.rootNode,
 			// The 'columns' property can be undefined or 0 when not using a TTY.
 			// In that case we fall back to 80.
@@ -143,13 +142,13 @@ export default class Ink {
 			this.fullStaticOutput += staticOutput;
 		}
 
-		if (outputHeight >= this.options.stdout.rows) {
+		/* 		if (outputHeight >= this.options.stdout.rows) {
 			this.options.stdout.write(
 				ansiEscapes.clearTerminal + this.fullStaticOutput + output
 			);
 			this.lastOutput = output;
 			return;
-		}
+		} */
 
 		// To ensure static output is cleanly rendered before main output, clear main output first
 		if (hasStaticOutput) {

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -11,6 +11,7 @@ import * as dom from './dom';
 import {FiberRoot} from 'react-reconciler';
 import instances from './instances';
 import App from './components/App';
+import ansiEscapes from 'ansi-escapes';
 
 const isCI = process.env.CI === 'false' ? false : originalIsCI;
 const noop = () => {};
@@ -110,7 +111,7 @@ export default class Ink {
 			return;
 		}
 
-		const {output, staticOutput} = render(
+		const {output, outputHeight, staticOutput} = render(
 			this.rootNode,
 			// The 'columns' property can be undefined or 0 when not using a TTY.
 			// In that case we fall back to 80.
@@ -142,13 +143,13 @@ export default class Ink {
 			this.fullStaticOutput += staticOutput;
 		}
 
-		/* 		if (outputHeight >= this.options.stdout.rows) {
+		if (outputHeight > this.options.stdout.rows) {
 			this.options.stdout.write(
 				ansiEscapes.clearTerminal + this.fullStaticOutput + output
 			);
 			this.lastOutput = output;
 			return;
-		} */
+		}
 
 		// To ensure static output is cleanly rendered before main output, clear main output first
 		if (hasStaticOutput) {

--- a/src/log-update.ts
+++ b/src/log-update.ts
@@ -26,7 +26,7 @@ const create = (stream: Writable, {showCursor = false} = {}): LogUpdate => {
 
 		const previousLines = previousOutput.split('\n');
 		const newLines = output.split('\n');
-		let updateSequence = ansiEscapes.cursorUp(previousLineCount) + 'h';
+		let updateSequence = ansiEscapes.cursorUp(previousLineCount);
 
 		newLines.forEach((line, index) => {
 			const isPotentialUpdate = index < previousLines.length;

--- a/src/log-update.ts
+++ b/src/log-update.ts
@@ -24,25 +24,18 @@ const create = (stream: Writable, {showCursor = false} = {}): LogUpdate => {
 			return;
 		}
 
-		const previousLines = previousOutput.split('\n');
 		const newLines = output.split('\n');
 		let updateSequence = ansiEscapes.cursorUp(previousLineCount);
 
-		newLines.forEach((line, index) => {
-			const isPotentialUpdate = index < previousLines.length;
-			if (isPotentialUpdate) {
-				if (line !== previousLines[index]) {
-					updateSequence += ansiEscapes.eraseLine + line;
-				}
-			} else {
-				updateSequence += line;
-			}
-
+		newLines.forEach(line => {
+			updateSequence += ansiEscapes.eraseLine + line;
 			updateSequence += ansiEscapes.cursorDown() + ansiEscapes.cursorTo(0);
 		});
 
 		if (previousLineCount > newLines.length) {
-			updateSequence += ansiEscapes.eraseDown;
+			updateSequence += ansiEscapes.eraseLines(
+				previousLineCount - newLines.length
+			);
 		}
 
 		stream.write(updateSequence);

--- a/src/log-update.ts
+++ b/src/log-update.ts
@@ -26,35 +26,19 @@ const create = (stream: Writable, {showCursor = false} = {}): LogUpdate => {
 
 		const previousLines = previousOutput.split('\n');
 		const newLines = output.split('\n');
-		let updateSequence = ansiEscapes.cursorUp(previousLineCount);
+		let updateSequence = ansiEscapes.cursorUp(previousLineCount) + 'h';
 
 		newLines.forEach((line, index) => {
-			const isPotentialRowUpdate = index < previousLines.length;
-			if (isPotentialRowUpdate) {
-				const previousChars = previousLines[index].split('');
-				const newChars = line.split('');
-				let cursor = 0;
-				let i = 0;
-				while (i < newChars.length) {
-					const isNewChar = i < previousChars.length;
-					const char = newChars[i];
-					if (isNewChar) {
-						updateSequence += char;
-						cursor += 1;
-					} else {
-						const isSameChar = newChars[i] === previousChars[i];
-						if (!isSameChar) {
-							updateSequence += ansiEscapes.cursorMove(i - cursor);
-							cursor = i;
-						}
-					}
-					i++;
+			const isPotentialUpdate = index < previousLines.length;
+			if (isPotentialUpdate) {
+				if (line !== previousLines[index]) {
+					updateSequence += ansiEscapes.eraseLine + line;
 				}
 			} else {
 				updateSequence += line;
 			}
 
-			updateSequence += ansiEscapes.cursorDown() + ansiEscapes.cursorLeft;
+			updateSequence += ansiEscapes.cursorDown() + ansiEscapes.cursorTo(0);
 		});
 
 		if (previousLineCount > newLines.length) {


### PR DESCRIPTION
Did some digging on the following issue:
https://github.com/vadimdemedes/ink/issues/359

Found that what's causing the flickering on iTerm2 is that the whole terminal window is erased and then rewritten. IMO iTerm does the right thing, which is to show an empty terminal and then add back the content -> boom we have a flickering. Another approach for updating the terminal would be what I have in this POC PR, which is to update only the rows that have been changed. Tested in my cli, but with some bugs such that React console messages are displayed in the top and stuck there forever. This is the same approach as other terminal packages seem to do as well.

Needs some improvements, of course, just a POC!