### PR TITLE
fill in absolute positioning support

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -17,6 +17,26 @@ export interface Styles {
 	readonly position?: 'absolute' | 'relative';
 
 	/**
+	 * Top offset.
+	 */
+	readonly top?: number;
+
+	/**
+	 * Bottom offset.
+	 */
+	readonly bottom?: number;
+
+	/**
+	 * Left offset.
+	 */
+	readonly left?: number;
+
+	/**
+	 * Right offset.
+	 */
+	readonly right?: number;
+
+	/**
 	 * Top margin.
 	 */
 	readonly marginTop?: number;
@@ -150,6 +170,22 @@ const applyPositionStyles = (node: Yoga.YogaNode, style: Styles): void => {
 				? Yoga.POSITION_TYPE_ABSOLUTE
 				: Yoga.POSITION_TYPE_RELATIVE
 		);
+	}
+
+	if ('top' in style) {
+		node.setPosition(Yoga.EDGE_TOP, style.top || 0);
+	}
+
+	if ('bottom' in style) {
+		node.setPosition(Yoga.EDGE_BOTTOM, style.bottom || 0);
+	}
+
+	if ('left' in style) {
+		node.setPosition(Yoga.EDGE_LEFT, style.left || 0);
+	}
+
+	if ('right' in style) {
+		node.setPosition(Yoga.EDGE_RIGHT, style.right || 0);
 	}
 };
 


### PR DESCRIPTION
Adds position style props so the existing `position="absolute"` prop can be used effectively.