### PR TITLE
Fix box border rendering containing emojis and wide characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"signal-exit": "^3.0.2",
 		"slice-ansi": "^3.0.0",
 		"stack-utils": "^2.0.2",
-		"string-length": "^3.1.0",
+		"string-width": "^4.2.2",
 		"type-fest": "^0.12.0",
 		"widest-line": "^3.1.0",
 		"wrap-ansi": "^6.2.0",

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,5 +1,5 @@
 import sliceAnsi from 'slice-ansi';
-import stringLength from 'string-length';
+import stringWidth from 'string-width';
 import {OutputTransformer} from './render-node-to-output';
 
 /**
@@ -72,7 +72,7 @@ export default class Output {
 					continue;
 				}
 
-				const length = stringLength(line);
+				const width = stringWidth(line);
 
 				for (const transformer of transformers) {
 					line = transformer(line);
@@ -81,7 +81,7 @@ export default class Output {
 				output[y + offsetY] =
 					sliceAnsi(currentLine, 0, x) +
 					line +
-					sliceAnsi(currentLine, x + length);
+					sliceAnsi(currentLine, x + width);
 
 				offsetY++;
 			}

--- a/test/borders.tsx
+++ b/test/borders.tsx
@@ -44,6 +44,26 @@ test('single node - fit-content box', t => {
 	t.is(output, box('Hello World'));
 });
 
+test('single node - fit-content box with wide characters', t => {
+	const output = renderToString(
+		<Box borderStyle="round" alignSelf="flex-start">
+			<Text>こんにちは</Text>
+		</Box>
+	);
+
+	t.is(output, box('こんにちは'));
+});
+
+test('single node - fit-content box with emojis', t => {
+	const output = renderToString(
+		<Box borderStyle="round" alignSelf="flex-start">
+			<Text>🌊🌊</Text>
+		</Box>
+	);
+
+	t.is(output, box('🌊🌊'));
+});
+
 test('single node - fixed width box', t => {
 	const output = renderToString(
 		<Box borderStyle="round" width={20}>


### PR DESCRIPTION
Fixes #443
Fixes #369

Turns out the issue was that border rendering uses `string-length` which measures number of codepoints. In the case of wide character or emoji the length returns 1, which is incorrect because it occupies 2 cells. The fix is by replacing the measurement with `string-width` which measures number of cells (and it is already transitively used in other places where text is measured).

Notes:
- `string-length` was not used elsewhere, I removed it from package.json
- `string-width` is already pulled in transitively by other packages, so it does not increase dependencies when added as top-level entry

![image](https://user-images.githubusercontent.com/755611/119222049-f8d44180-bae1-11eb-9823-73000309eec5.png)
