### PR TITLE
Fix the TypeScript type for the `backgroundColor` prop

### DIFF
--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -1,5 +1,5 @@
 import React, {FC, ReactNode} from 'react';
-import chalk, {ForegroundColor, BackgroundColor} from 'chalk';
+import chalk, {ForegroundColor} from 'chalk';
 import colorize from '../colorize';
 import {Styles} from '../styles';
 import {LiteralUnion} from 'type-fest';
@@ -13,7 +13,7 @@ export interface Props {
 	/**
 	 * Same as `color`, but for background.
 	 */
-	readonly backgroundColor?: LiteralUnion<typeof BackgroundColor, string>;
+	readonly backgroundColor?: LiteralUnion<typeof ForegroundColor, string>;
 
 	/**
 	 * Dim the color (emit a small amount of light).


### PR DESCRIPTION
Hello, 
I read the issue(#428) and would like to suggest a solution to this

![114594138-334df180-9c8d-11eb-8150-aef2cb6a6f96](https://user-images.githubusercontent.com/10302969/123554297-48c9b680-d7ba-11eb-838f-bbe4a65b81da.png)


Chalk's backgroundColor type is declared as follows.
https://github.com/chalk/chalk/blob/main/index.d.ts#L31-L49
```js
export type BackgroundColor =
	| 'bgBlack'
	| 'bgRed'
	| 'bgGreen'
	| 'bgYellow'
	| 'bgBlue'
	| 'bgMagenta'
	| 'bgCyan'
	| 'bgWhite'
	| 'bgGray'
	| 'bgGrey'
	| 'bgBlackBright'
	| 'bgRedBright'
	| 'bgGreenBright'
	| 'bgYellowBright'
	| 'bgBlueBright'
	| 'bgMagentaBright'
	| 'bgCyanBright'
	| 'bgWhiteBright';
```

However, in ink, there is a code to attach bg prefix (https://github.com/vadimdemedes/ink/blob/master/src/colorize.ts#L8-L14),
so there is no need to attach bg.
Therefore, I suggest to use chalk's `ForegroundColor` type as auto-complete.