### PR TITLE
Fix `Box` example in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -353,7 +353,7 @@ import {render, Box, Text} from 'ink';
 const Example = () => (
 	<Box margin={2}>
 		<Text>This is a box with margin</Text>
-	</Box>;
+	</Box>
 );
 
 render(<Example />);


### PR DESCRIPTION
This `;` will cause error in actual code.