### PR TITLE
Fix CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
 					],
 					"unicorn/filename-case": "off",
 					"react/prop-types": "off",
+					"react/default-props-match-prop-types": "off",
 					"unicorn/prevent-abbreviations": "off",
 					"react/require-default-props": "warn",
 					"react/jsx-curly-brace-presence": "off",


### PR DESCRIPTION
it looks like **eslint** behaviour have changed lately and we are getting **react/default-props-match-prop-types** errors.
I would have fixed the lint errors, but turns out we need to change some boolean props names from **name** to **isName** which would be a breaking change. I decided to turn it off as we also have **react/prop-types** turned off.