### PR TITLE
Bump node-pty@0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
 		"eslint-plugin-react-hooks": "^2.3.0",
 		"import-jsx": "3.1.0",
 		"ms": "^2.1.1",
-		"node-pty": "^0.9.0",
+		"node-pty": "^0.10.0",
 		"p-queue": "^6.2.1",
 		"prettier": "^2.0.4",
 		"react": "^17.0.2",


### PR DESCRIPTION
My `npm install` always failed til I updated `node-pty` to `0.10.0`.

<details>
<summary>Here is my error log</summary>
<pre><code>
npm ERR! code 1
npm ERR! path /Users/litomore/Git/ink/node_modules/node-pty
npm ERR! command failed
npm ERR! command sh -c node scripts/install.js
npm ERR! CXX(target) Release/obj.target/pty/src/unix/pty.o
npm ERR! gyp info it worked if it ends with ok
npm ERR! gyp info using node-gyp@7.1.2
npm ERR! gyp info using node@16.10.0 | darwin | arm64
npm ERR! gyp info find Python using Python version 3.9.7 found at "/opt/homebrew/opt/python@3.9/bin/python3.9"
npm ERR! (node:29633) [DEP0150] DeprecationWarning: Setting process.config is deprecated. In the future the property will be read-only.
npm ERR! (Use `node --trace-deprecation ...` to show where the warning was created)
npm ERR! gyp info spawn /opt/homebrew/opt/python@3.9/bin/python3.9
npm ERR! gyp info spawn args [
npm ERR! gyp info spawn args   '/opt/homebrew/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
npm ERR! gyp info spawn args   'binding.gyp',
npm ERR! gyp info spawn args   '-f',
npm ERR! gyp info spawn args   'make',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/Users/litomore/Git/ink/node_modules/node-pty/build/config.gypi',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/opt/homebrew/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/Users/litomore/Library/Caches/node-gyp/16.10.0/include/node/common.gypi',
npm ERR! gyp info spawn args   '-Dlibrary=shared_library',
npm ERR! gyp info spawn args   '-Dvisibility=default',
npm ERR! gyp info spawn args   '-Dnode_root_dir=/Users/litomore/Library/Caches/node-gyp/16.10.0',
npm ERR! gyp info spawn args   '-Dnode_gyp_dir=/opt/homebrew/lib/node_modules/npm/node_modules/node-gyp',
npm ERR! gyp info spawn args   '-Dnode_lib_file=/Users/litomore/Library/Caches/node-gyp/16.10.0/<(target_arch)/node.lib',
npm ERR! gyp info spawn args   '-Dmodule_root_dir=/Users/litomore/Git/ink/node_modules/node-pty',
npm ERR! gyp info spawn args   '-Dnode_engine=v8',
npm ERR! gyp info spawn args   '--depth=.',
npm ERR! gyp info spawn args   '--no-parallel',
npm ERR! gyp info spawn args   '--generator-output',
npm ERR! gyp info spawn args   'build',
npm ERR! gyp info spawn args   '-Goutput_dir=.'
npm ERR! gyp info spawn args ]
npm ERR! gyp info spawn make
npm ERR! gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
npm ERR! In file included from ../src/unix/pty.cc:20:
npm ERR! In file included from ../../nan/nan.h:58:
npm ERR! In file included from /Users/litomore/Library/Caches/node-gyp/16.10.0/include/node/node.h:63:
npm ERR! In file included from /Users/litomore/Library/Caches/node-gyp/16.10.0/include/node/v8.h:30:
npm ERR! /Users/litomore/Library/Caches/node-gyp/16.10.0/include/node/v8-internal.h:489:38: error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv'?
npm ERR!             !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
npm ERR!                                 ~~~~~^~~~~~~~~~~
npm ERR!                                      remove_cv
npm ERR! /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/type_traits:776:50: note: 'remove_cv' declared here
npm ERR! template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_cv
npm ERR!                                                  ^
npm ERR! 1 error generated.
npm ERR! make: *** [Release/obj.target/pty/src/unix/pty.o] Error 1
npm ERR! gyp ERR! build error
npm ERR! gyp ERR! stack Error: `make` failed with exit code: 2
npm ERR! gyp ERR! stack     at ChildProcess.onExit (/opt/homebrew/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:194:23)
npm ERR! gyp ERR! stack     at ChildProcess.emit (node:events:390:28)
npm ERR! gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:290:12)
npm ERR! gyp ERR! System Darwin 21.1.0
npm ERR! gyp ERR! command "/opt/homebrew/Cellar/node/16.10.0/bin/node" "/opt/homebrew/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
npm ERR! gyp ERR! cwd /Users/litomore/Git/ink/node_modules/node-pty
npm ERR! gyp ERR! node -v v16.10.0
npm ERR! gyp ERR! node-gyp -v v7.1.2
npm ERR! gyp ERR! not ok

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/litomore/.npm/_logs/2021-10-09T10_59_14_741Z-debug.log
</code></pre>
</details>

**Operating System:** macOS Monterey\
**Node.js version:** v16.10.0

I'm not sure this is an OS-related bug or not. But I don't think the `node-pty` version change will ocurr some new errors.