### PR TITLE
Move `react-devtools-core` to optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
 		"is-ci": "^2.0.0",
 		"lodash": "^4.17.20",
 		"patch-console": "^1.0.0",
-		"react-devtools-core": "^4.19.1",
 		"react-reconciler": "^0.26.2",
 		"scheduler": "^0.20.2",
 		"signal-exit": "^3.0.2",
@@ -100,10 +99,14 @@
 	},
 	"peerDependencies": {
 		"@types/react": ">=16.8.0",
-		"react": ">=16.8.0"
+		"react": ">=16.8.0",
+		"react-devtools-core": "^4.19.1"
 	},
 	"peerDependenciesMeta": {
 		"@types/react": {
+			"optional": true
+		},
+		"react-devtools-core": {
 			"optional": true
 		}
 	},

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
 		"p-queue": "^6.2.1",
 		"prettier": "^2.0.4",
 		"react": "^17.0.2",
+		"react-devtools-core": "^4.19.1",
 		"sinon": "^8.1.1",
 		"strip-ansi": "^6.0.0",
 		"ts-node": "7.0.0",

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -25,8 +25,22 @@ import {OutputTransformer} from './render-node-to-output';
 // accidentally breaking other third-party code.
 // See https://github.com/vadimdemedes/ink/issues/384
 if (process.env.DEV === 'true') {
-	// eslint-disable-next-line import/no-unassigned-import
-	require('./devtools');
+	try {
+		// eslint-disable-next-line import/no-unassigned-import
+		require('./devtools');
+	} catch (error) {
+		if (error.code === 'MODULE_NOT_FOUND') {
+			console.warn(
+				`
+Debugging with React Devtools requires \`react-devtools-core\` dependency to be installed.
+
+$ npm install --save-dev react-devtools-core
+				`.trim()
+			);
+		} else {
+			throw error;
+		}
+	}
 }
 
 const cleanupYogaNode = (node?: Yoga.YogaNode): void => {


### PR DESCRIPTION
Fixes #491.

Should possibly wrap https://github.com/vadimdemedes/ink/blob/763db800f6b93c0807b016c6dc1ac8cccef0a67b/src/reconciler.ts#L24-L30 into a more specific error as well?