### PR TITLE
Allow configuring overflow behavior in `Box` component

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -822,6 +822,30 @@ Default: `flex`
 
 Set this property to `none` to hide the element.
 
+##### overflowX
+
+Type: `string`\
+Allowed values: `visible` `hidden`\
+Default: `visible`
+
+Behavior for an element's overflow in horizontal direction.
+
+##### overflowY
+
+Type: `string`\
+Allowed values: `visible` `hidden`\
+Default: `visible`
+
+Behavior for an element's overflow in vertical direction.
+
+##### overflow
+
+Type: `string`\
+Allowed values: `visible` `hidden`\
+Default: `visible`
+
+Shortcut for setting `overflowX` and `overflowY` at the same time.
+
 #### Borders
 
 ##### borderStyle

--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -46,6 +46,27 @@ export type Props = Except<Styles, 'textWrap'> & {
 	 * @default 0
 	 */
 	readonly paddingY?: number;
+
+	/**
+	 * Behavior for an element's overflow in both directions.
+	 *
+	 * @default 'visible'
+	 */
+	readonly overflow?: 'visible' | 'hidden';
+
+	/**
+	 * Behavior for an element's overflow in horizontal direction.
+	 *
+	 * @default 'visible'
+	 */
+	readonly overflowX?: 'visible' | 'hidden';
+
+	/**
+	 * Behavior for an element's overflow in vertical direction.
+	 *
+	 * @default 'visible'
+	 */
+	readonly overflowY?: 'visible' | 'hidden';
 };
 
 /**
@@ -62,7 +83,10 @@ const Box = forwardRef<DOMElement, PropsWithChildren<Props>>(
 			paddingLeft: style.paddingLeft || style.paddingX || style.padding || 0,
 			paddingRight: style.paddingRight || style.paddingX || style.padding || 0,
 			paddingTop: style.paddingTop || style.paddingY || style.padding || 0,
-			paddingBottom: style.paddingBottom || style.paddingY || style.padding || 0
+			paddingBottom:
+				style.paddingBottom || style.paddingY || style.padding || 0,
+			overflowX: style.overflowX || style.overflow || 'visible',
+			overflowY: style.overflowY || style.overflow || 'visible'
 		};
 
 		return (

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,5 +1,6 @@
 import sliceAnsi from 'slice-ansi';
 import stringWidth from 'string-width';
+import widestLine from 'widest-line';
 import {type OutputTransformer} from './render-node-to-output.js';
 
 /**
@@ -16,19 +17,37 @@ type Options = {
 	height: number;
 };
 
-type Writes = {
+type Operation = WriteOperation | ClipOperation | UnclipOperation;
+
+interface WriteOperation {
+	type: 'write';
 	x: number;
 	y: number;
 	text: string;
 	transformers: OutputTransformer[];
-};
+}
+
+interface ClipOperation {
+	type: 'clip';
+	clip: Clip;
+}
+
+interface Clip {
+	x1: number | undefined;
+	x2: number | undefined;
+	y1: number | undefined;
+	y2: number | undefined;
+}
+
+interface UnclipOperation {
+	type: 'unclip';
+}
 
 export default class Output {
 	width: number;
 	height: number;
 
-	// Initialize output array with a specific set of rows, so that margin/padding at the bottom is preserved
-	private readonly writes: Writes[] = [];
+	private readonly operations: Operation[] = [];
 
 	constructor(options: Options) {
 		const {width, height} = options;
@@ -49,41 +68,129 @@ export default class Output {
 			return;
 		}
 
-		this.writes.push({x, y, text, transformers});
+		this.operations.push({
+			type: 'write',
+			x,
+			y,
+			text,
+			transformers
+		});
+	}
+
+	clip(clip: Clip) {
+		this.operations.push({
+			type: 'clip',
+			clip
+		});
+	}
+
+	unclip() {
+		this.operations.push({
+			type: 'unclip'
+		});
 	}
 
 	get(): {output: string; height: number} {
+		// Initialize output array with a specific set of rows, so that margin/padding at the bottom is preserved
 		const output: string[] = [];
 
 		for (let y = 0; y < this.height; y++) {
 			output.push(' '.repeat(this.width));
 		}
 
-		for (const write of this.writes) {
-			const {x, y, text, transformers} = write;
-			const lines = text.split('\n');
-			let offsetY = 0;
+		const clips: Clip[] = [];
 
-			for (let line of lines) {
-				const currentLine = output[y + offsetY];
+		for (const operation of this.operations) {
+			if (operation.type === 'clip') {
+				clips.push(operation.clip);
+			}
 
-				// Line can be missing if `text` is taller than height of pre-initialized `this.output`
-				if (!currentLine) {
-					continue;
+			if (operation.type === 'unclip') {
+				clips.pop();
+			}
+
+			if (operation.type === 'write') {
+				const {text, transformers} = operation;
+				let {x, y} = operation;
+				let lines = text.split('\n');
+
+				const clip = clips[clips.length - 1];
+
+				if (clip) {
+					const clipHorizontally =
+						typeof clip?.x1 === 'number' && typeof clip?.x2 === 'number';
+
+					const clipVertically =
+						typeof clip?.y1 === 'number' && typeof clip?.y2 === 'number';
+
+					// If text is positioned outside of clipping area altogether,
+					// skip to the next operation to avoid unnecessary calculations
+					if (clipHorizontally) {
+						const width = widestLine(text);
+
+						if (x + width < clip.x1! || x > clip.x2!) {
+							continue;
+						}
+					}
+
+					if (clipVertically) {
+						const height = lines.length;
+
+						if (y + height < clip.y1! || y > clip.y2!) {
+							continue;
+						}
+					}
+
+					if (clipHorizontally) {
+						lines = lines.map(line => {
+							const from = x < clip.x1! ? clip.x1! - x : 0;
+							const width = stringWidth(line);
+							const to = x + width > clip.x2! ? clip.x2! - x : width;
+
+							return sliceAnsi(line, from, to);
+						});
+
+						if (x < clip.x1!) {
+							x = clip.x1!;
+						}
+					}
+
+					if (clipVertically) {
+						const from = y < clip.y1! ? clip.y1! - y : 0;
+						const height = lines.length;
+						const to = y + height > clip.y2! ? clip.y2! - y : height;
+
+						lines = lines.slice(from, to);
+
+						if (y < clip.y1!) {
+							y = clip.y1!;
+						}
+					}
 				}
 
-				const width = stringWidth(line);
+				let offsetY = 0;
 
-				for (const transformer of transformers) {
-					line = transformer(line);
+				for (let line of lines) {
+					const currentLine = output[y + offsetY];
+
+					// Line can be missing if `text` is taller than height of pre-initialized `this.output`
+					if (!currentLine) {
+						continue;
+					}
+
+					const width = stringWidth(line);
+
+					for (const transformer of transformers) {
+						line = transformer(line);
+					}
+
+					output[y + offsetY] =
+						sliceAnsi(currentLine, 0, x) +
+						line +
+						sliceAnsi(currentLine, x + width);
+
+					offsetY++;
 				}
-
-				output[y + offsetY] =
-					sliceAnsi(currentLine, 0, x) +
-					line +
-					sliceAnsi(currentLine, x + width);
-
-				offsetY++;
 			}
 		}
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -19,29 +19,29 @@ type Options = {
 
 type Operation = WriteOperation | ClipOperation | UnclipOperation;
 
-interface WriteOperation {
+type WriteOperation = {
 	type: 'write';
 	x: number;
 	y: number;
 	text: string;
 	transformers: OutputTransformer[];
-}
+};
 
-interface ClipOperation {
+type ClipOperation = {
 	type: 'clip';
 	clip: Clip;
-}
+};
 
-interface Clip {
+type Clip = {
 	x1: number | undefined;
 	x2: number | undefined;
 	y1: number | undefined;
 	y2: number | undefined;
-}
+};
 
-interface UnclipOperation {
+type UnclipOperation = {
 	type: 'unclip';
-}
+};
 
 export default class Output {
 	width: number;

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -218,6 +218,7 @@ export default createReconciler<
 
 					for (const styleKey of styleKeys) {
 						// Always include `borderColor` and `borderStyle` to ensure border is rendered,
+						// and `overflowX` and `overflowY` to ensure content is clipped,
 						// otherwise resulting `updatePayload` may not contain them
 						// if they weren't changed during this update
 						if (styleKey === 'borderStyle' || styleKey === 'borderColor') {
@@ -231,6 +232,8 @@ export default createReconciler<
 								newStyle.borderStyle;
 							(updatePayload['style'] as any).borderColor =
 								newStyle.borderColor;
+							(updatePayload['style'] as any).overflowX = newStyle.overflowX;
+							(updatePayload['style'] as any).overflowY = newStyle.overflowY;
 						}
 
 						if (newStyle[styleKey] !== oldStyle[styleKey]) {

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -82,14 +82,45 @@ const renderNodeToOutput = (
 				}
 
 				text = applyPaddingToText(node, text);
+
 				output.write(x, y, text, {transformers: newTransformers});
 			}
 
 			return;
 		}
 
+		let clipped = false;
+
 		if (node.nodeName === 'ink-box') {
 			renderBorder(x, y, node, output);
+
+			const clipHorizontally = node.style.overflowX === 'hidden';
+			const clipVertically = node.style.overflowY === 'hidden';
+
+			if (clipHorizontally || clipVertically) {
+				const x1 = clipHorizontally
+					? x + yogaNode.getComputedBorder(Yoga.EDGE_LEFT)
+					: undefined;
+
+				const x2 = clipHorizontally
+					? x +
+					  yogaNode.getComputedWidth() -
+					  yogaNode.getComputedBorder(Yoga.EDGE_RIGHT)
+					: undefined;
+
+				const y1 = clipVertically
+					? y + yogaNode.getComputedBorder(Yoga.EDGE_TOP)
+					: undefined;
+
+				const y2 = clipVertically
+					? y +
+					  yogaNode.getComputedHeight() -
+					  yogaNode.getComputedBorder(Yoga.EDGE_BOTTOM)
+					: undefined;
+
+				output.clip({x1, x2, y1, y2});
+				clipped = true;
+			}
 		}
 
 		if (node.nodeName === 'ink-root' || node.nodeName === 'ink-box') {
@@ -100,6 +131,10 @@ const renderNodeToOutput = (
 					transformers: newTransformers,
 					skipStaticElements
 				});
+			}
+
+			if (clipped) {
+				output.unclip();
 			}
 		}
 	}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -141,6 +141,16 @@ export type Styles = {
 	 * Accepts the same values as `color` in <Text> component.
 	 */
 	readonly borderColor?: LiteralUnion<ForegroundColorName, string>;
+
+	/**
+	 * Behavior for an element's overflow in horizontal direction.
+	 */
+	readonly overflowX?: 'visible' | 'hidden';
+
+	/**
+	 * Behavior for an element's overflow in vertical direction.
+	 */
+	readonly overflowY?: 'visible' | 'hidden';
 };
 
 const applyPositionStyles = (node: Yoga.YogaNode, style: Styles): void => {

--- a/test/overflow.tsx
+++ b/test/overflow.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import test from 'ava';
-import boxen, {Options} from 'boxen';
-import {renderToString} from './helpers/render-to-string.js';
+import boxen, {type Options} from 'boxen';
 import {Box, Text} from '../src/index.js';
+import {renderToString} from './helpers/render-to-string.js';
 
 const box = (text: string, options?: Options): string => {
 	return boxen(text, {

--- a/test/overflow.tsx
+++ b/test/overflow.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import test from 'ava';
 import boxen, {type Options} from 'boxen';
+import sliceAnsi from 'slice-ansi';
 import {Box, Text} from '../src/index.js';
 import {renderToString} from './helpers/render-to-string.js';
 
@@ -11,10 +12,17 @@ const box = (text: string, options?: Options): string => {
 	});
 };
 
-test('overflowX - single text node', t => {
+const clipX = (text: string, columns: number): string => {
+	return text
+		.split('\n')
+		.map(line => sliceAnsi(line, 0, columns).trim())
+		.join('\n');
+};
+
+test('overflowX - single text node in a box inside overflow container', t => {
 	const output = renderToString(
 		<Box width={6} overflowX="hidden">
-			<Box width={12} flexShrink={0}>
+			<Box width={16} flexShrink={0}>
 				<Text>Hello World</Text>
 			</Box>
 		</Box>
@@ -23,10 +31,10 @@ test('overflowX - single text node', t => {
 	t.is(output, 'Hello');
 });
 
-test('overflowX  - single text node inside a box with border', t => {
+test('overflowX - single text node inside overflow container with border', t => {
 	const output = renderToString(
 		<Box width={6} overflowX="hidden" borderStyle="round">
-			<Box width={12} flexShrink={0}>
+			<Box width={16} flexShrink={0}>
 				<Text>Hello World</Text>
 			</Box>
 		</Box>
@@ -35,7 +43,19 @@ test('overflowX  - single text node inside a box with border', t => {
 	t.is(output, box('Hell'));
 });
 
-test('overflowX - multiple text nodes', t => {
+test('overflowX - single text node in a box with border inside overflow container', t => {
+	const output = renderToString(
+		<Box width={6} overflowX="hidden">
+			<Box width={16} flexShrink={0} borderStyle="round">
+				<Text>Hello World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, clipX(box('Hello'), 6));
+});
+
+test('overflowX - multiple text nodes in a box inside overflow container', t => {
 	const output = renderToString(
 		<Box width={6} overflowX="hidden">
 			<Box width={12} flexShrink={0}>
@@ -48,7 +68,7 @@ test('overflowX - multiple text nodes', t => {
 	t.is(output, 'Hello');
 });
 
-test('overflowX - multiple text nodes inside a box with border', t => {
+test('overflowX - multiple text nodes in a box inside overflow container with border', t => {
 	const output = renderToString(
 		<Box width={8} overflowX="hidden" borderStyle="round">
 			<Box width={12} flexShrink={0}>
@@ -61,7 +81,20 @@ test('overflowX - multiple text nodes inside a box with border', t => {
 	t.is(output, box('Hello '));
 });
 
-test('overflowX - multiple boxes', t => {
+test('overflowX - multiple text nodes in a box with border inside overflow container', t => {
+	const output = renderToString(
+		<Box width={8} overflowX="hidden">
+			<Box width={12} flexShrink={0} borderStyle="round">
+				<Text>Hello </Text>
+				<Text>World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, clipX(box('HelloWo\n'), 8));
+});
+
+test('overflowX - multiple boxes inside overflow container', t => {
 	const output = renderToString(
 		<Box width={6} overflowX="hidden">
 			<Box width={6} flexShrink={0}>
@@ -76,7 +109,7 @@ test('overflowX - multiple boxes', t => {
 	t.is(output, 'Hello');
 });
 
-test('overflowX - multiple boxes inside a box with border', t => {
+test('overflowX - multiple boxes inside overflow container with border', t => {
 	const output = renderToString(
 		<Box width={8} overflowX="hidden" borderStyle="round">
 			<Box width={6} flexShrink={0}>
@@ -91,7 +124,7 @@ test('overflowX - multiple boxes inside a box with border', t => {
 	t.is(output, box('Hello '));
 });
 
-test('overflowX - box before left edge of container', t => {
+test('overflowX - box before left edge of overflow container', t => {
 	const output = renderToString(
 		<Box width={6} overflowX="hidden">
 			<Box marginLeft={-12} width={6} flexShrink={0}>
@@ -103,7 +136,7 @@ test('overflowX - box before left edge of container', t => {
 	t.is(output, '');
 });
 
-test('overflowX - box before left edge of container with border', t => {
+test('overflowX - box before left edge of overflow container with border', t => {
 	const output = renderToString(
 		<Box width={6} overflowX="hidden" borderStyle="round">
 			<Box marginLeft={-12} width={6} flexShrink={0}>
@@ -115,7 +148,7 @@ test('overflowX - box before left edge of container with border', t => {
 	t.is(output, box(' '.repeat(4)));
 });
 
-test('overflowX - box intersecting with left edge of container', t => {
+test('overflowX - box intersecting with left edge of overflow container', t => {
 	const output = renderToString(
 		<Box width={6} overflowX="hidden">
 			<Box marginLeft={-3} width={12} flexShrink={0}>
@@ -127,7 +160,7 @@ test('overflowX - box intersecting with left edge of container', t => {
 	t.is(output, 'lo Wor');
 });
 
-test('overflowX - box intersecting with left edge of container with border', t => {
+test('overflowX - box intersecting with left edge of overflow container with border', t => {
 	const output = renderToString(
 		<Box width={8} overflowX="hidden" borderStyle="round">
 			<Box marginLeft={-3} width={12} flexShrink={0}>
@@ -139,7 +172,7 @@ test('overflowX - box intersecting with left edge of container with border', t =
 	t.is(output, box('lo Wor'));
 });
 
-test('overflowX - box after right container edge', t => {
+test('overflowX - box after right edge of overflow container', t => {
 	const output = renderToString(
 		<Box width={6} overflowX="hidden">
 			<Box marginLeft={6} width={6} flexShrink={0}>
@@ -151,7 +184,7 @@ test('overflowX - box after right container edge', t => {
 	t.is(output, '');
 });
 
-test('overflowX - box intersecting with right container edge', t => {
+test('overflowX - box intersecting with right edge of overflow container', t => {
 	const output = renderToString(
 		<Box width={6} overflowX="hidden">
 			<Box marginLeft={3} width={6} flexShrink={0}>
@@ -163,7 +196,7 @@ test('overflowX - box intersecting with right container edge', t => {
 	t.is(output, '   Hel');
 });
 
-test('overflowY - single text node', t => {
+test('overflowY - single text node inside overflow container', t => {
 	const output = renderToString(
 		<Box height={1} overflowY="hidden">
 			<Text>Hello{'\n'}World</Text>
@@ -173,7 +206,7 @@ test('overflowY - single text node', t => {
 	t.is(output, 'Hello');
 });
 
-test('overflowY - single text node inside a box with border', t => {
+test('overflowY - single text node inside overflow container with border', t => {
 	const output = renderToString(
 		<Box width={20} height={3} overflowY="hidden" borderStyle="round">
 			<Text>Hello{'\n'}World</Text>
@@ -183,7 +216,7 @@ test('overflowY - single text node inside a box with border', t => {
 	t.is(output, box('Hello'.padEnd(18, ' ')));
 });
 
-test('overflowY - multiple boxes', t => {
+test('overflowY - multiple boxes inside overflow container', t => {
 	const output = renderToString(
 		<Box height={2} overflowY="hidden" flexDirection="column">
 			<Box flexShrink={0}>
@@ -204,7 +237,7 @@ test('overflowY - multiple boxes', t => {
 	t.is(output, 'Line #1\nLine #2');
 });
 
-test('overflowY - multiple boxes inside a box with border', t => {
+test('overflowY - multiple boxes inside overflow container with border', t => {
 	const output = renderToString(
 		<Box
 			width={9}
@@ -231,7 +264,7 @@ test('overflowY - multiple boxes inside a box with border', t => {
 	t.is(output, box('Line #1\nLine #2'));
 });
 
-test('overflowY - box above top edge of container', t => {
+test('overflowY - box above top edge of overflow container', t => {
 	const output = renderToString(
 		<Box height={1} overflowY="hidden">
 			<Box marginTop={-2} height={2} flexShrink={0}>
@@ -243,7 +276,7 @@ test('overflowY - box above top edge of container', t => {
 	t.is(output, '');
 });
 
-test('overflowY - box above top edge of container with border', t => {
+test('overflowY - box above top edge of overflow container with border', t => {
 	const output = renderToString(
 		<Box width={7} height={3} overflowY="hidden" borderStyle="round">
 			<Box marginTop={-3} height={2} flexShrink={0}>
@@ -255,7 +288,7 @@ test('overflowY - box above top edge of container with border', t => {
 	t.is(output, box(' '.repeat(5)));
 });
 
-test('overflowY - box intersecting with top edge of container', t => {
+test('overflowY - box intersecting with top edge of overflow container', t => {
 	const output = renderToString(
 		<Box height={1} overflowY="hidden">
 			<Box marginTop={-1} height={2} flexShrink={0}>
@@ -267,7 +300,7 @@ test('overflowY - box intersecting with top edge of container', t => {
 	t.is(output, 'World');
 });
 
-test('overflowY - box intersecting with top edge of container with border', t => {
+test('overflowY - box intersecting with top edge of overflow container with border', t => {
 	const output = renderToString(
 		<Box width={7} height={3} overflowY="hidden" borderStyle="round">
 			<Box marginTop={-1} height={2} flexShrink={0}>
@@ -279,7 +312,7 @@ test('overflowY - box intersecting with top edge of container with border', t =>
 	t.is(output, box('World'));
 });
 
-test('overflowY - box below bottom edge of container', t => {
+test('overflowY - box below bottom edge of overflow container', t => {
 	const output = renderToString(
 		<Box height={1} overflowY="hidden">
 			<Box marginTop={1} height={2} flexShrink={0}>
@@ -291,7 +324,7 @@ test('overflowY - box below bottom edge of container', t => {
 	t.is(output, '');
 });
 
-test('overflowY - box below bottom edge of container with border', t => {
+test('overflowY - box below bottom edge of overflow container with border', t => {
 	const output = renderToString(
 		<Box width={7} height={3} overflowY="hidden" borderStyle="round">
 			<Box marginTop={2} height={2} flexShrink={0}>
@@ -303,7 +336,7 @@ test('overflowY - box below bottom edge of container with border', t => {
 	t.is(output, box(' '.repeat(5)));
 });
 
-test('overflowY - box intersecting with bottom edge of container', t => {
+test('overflowY - box intersecting with bottom edge of overflow container', t => {
 	const output = renderToString(
 		<Box height={1} overflowY="hidden">
 			<Box height={2} flexShrink={0}>
@@ -315,7 +348,7 @@ test('overflowY - box intersecting with bottom edge of container', t => {
 	t.is(output, 'Hello');
 });
 
-test('overflowY - box intersecting with bottom edge of container with border', t => {
+test('overflowY - box intersecting with bottom edge of overflow container with border', t => {
 	const output = renderToString(
 		<Box width={7} height={3} overflowY="hidden" borderStyle="round">
 			<Box height={2} flexShrink={0}>
@@ -327,7 +360,7 @@ test('overflowY - box intersecting with bottom edge of container with border', t
 	t.is(output, box('Hello'));
 });
 
-test('overflow - single text node', t => {
+test('overflow - single text node inside overflow container', t => {
 	const output = renderToString(
 		<Box paddingBottom={1}>
 			<Box width={6} height={1} overflow="hidden">
@@ -341,7 +374,7 @@ test('overflow - single text node', t => {
 	t.is(output, 'Hello\n');
 });
 
-test('overflow - single text node inside container with border', t => {
+test('overflow - single text node inside overflow container with border', t => {
 	const output = renderToString(
 		<Box paddingBottom={1}>
 			<Box width={8} height={3} overflow="hidden" borderStyle="round">
@@ -355,7 +388,7 @@ test('overflow - single text node inside container with border', t => {
 	t.is(output, `${box('Hello ')}\n`);
 });
 
-test('overflow - multiple boxes', t => {
+test('overflow - multiple boxes inside overflow container', t => {
 	const output = renderToString(
 		<Box paddingBottom={1}>
 			<Box width={4} height={1} overflow="hidden">
@@ -372,7 +405,7 @@ test('overflow - multiple boxes', t => {
 	t.is(output, 'TLTR\n');
 });
 
-test('overflow - multiple boxes inside container with border', t => {
+test('overflow - multiple boxes inside overflow container with border', t => {
 	const output = renderToString(
 		<Box paddingBottom={1}>
 			<Box width={6} height={3} overflow="hidden" borderStyle="round">
@@ -389,7 +422,7 @@ test('overflow - multiple boxes inside container with border', t => {
 	t.is(output, `${box('TLTR')}\n`);
 });
 
-test('overflow - box intersecting with top left edge of container', t => {
+test('overflow - box intersecting with top left edge of overflow container', t => {
 	const output = renderToString(
 		<Box width={4} height={4} overflow="hidden">
 			<Box marginTop={-2} marginLeft={-2} width={4} height={4} flexShrink={0}>
@@ -403,7 +436,7 @@ test('overflow - box intersecting with top left edge of container', t => {
 	t.is(output, 'CC\nDD\n\n');
 });
 
-test('overflow - box intersecting with top right edge of container', t => {
+test('overflow - box intersecting with top right edge of overflow container', t => {
 	const output = renderToString(
 		<Box width={4} height={4} overflow="hidden">
 			<Box marginTop={-2} marginLeft={2} width={4} height={4} flexShrink={0}>
@@ -417,7 +450,7 @@ test('overflow - box intersecting with top right edge of container', t => {
 	t.is(output, '  CC\n  DD\n\n');
 });
 
-test('overflow - box intersecting with bottom left edge of container', t => {
+test('overflow - box intersecting with bottom left edge of overflow container', t => {
 	const output = renderToString(
 		<Box width={4} height={4} overflow="hidden">
 			<Box marginTop={2} marginLeft={-2} width={4} height={4} flexShrink={0}>
@@ -431,7 +464,7 @@ test('overflow - box intersecting with bottom left edge of container', t => {
 	t.is(output, '\n\nAA\nBB');
 });
 
-test('overflow - box intersecting with bottom right edge of container', t => {
+test('overflow - box intersecting with bottom right edge of overflow container', t => {
 	const output = renderToString(
 		<Box width={4} height={4} overflow="hidden">
 			<Box marginTop={2} marginLeft={2} width={4} height={4} flexShrink={0}>

--- a/test/overflow.tsx
+++ b/test/overflow.tsx
@@ -1,0 +1,470 @@
+import React from 'react';
+import test from 'ava';
+import boxen, {Options} from 'boxen';
+import {renderToString} from './helpers/render-to-string.js';
+import {Box, Text} from '../src/index.js';
+
+const box = (text: string, options?: Options): string => {
+	return boxen(text, {
+		...options,
+		borderStyle: 'round'
+	});
+};
+
+test('overflowX - single text node', t => {
+	const output = renderToString(
+		<Box width={6} overflowX="hidden">
+			<Box width={12} flexShrink={0}>
+				<Text>Hello World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, 'Hello');
+});
+
+test('overflowX  - single text node inside a box with border', t => {
+	const output = renderToString(
+		<Box width={6} overflowX="hidden" borderStyle="round">
+			<Box width={12} flexShrink={0}>
+				<Text>Hello World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, box('Hell'));
+});
+
+test('overflowX - multiple text nodes', t => {
+	const output = renderToString(
+		<Box width={6} overflowX="hidden">
+			<Box width={12} flexShrink={0}>
+				<Text>Hello </Text>
+				<Text>World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, 'Hello');
+});
+
+test('overflowX - multiple text nodes inside a box with border', t => {
+	const output = renderToString(
+		<Box width={8} overflowX="hidden" borderStyle="round">
+			<Box width={12} flexShrink={0}>
+				<Text>Hello </Text>
+				<Text>World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, box('Hello '));
+});
+
+test('overflowX - multiple boxes', t => {
+	const output = renderToString(
+		<Box width={6} overflowX="hidden">
+			<Box width={6} flexShrink={0}>
+				<Text>Hello </Text>
+			</Box>
+			<Box width={6} flexShrink={0}>
+				<Text>World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, 'Hello');
+});
+
+test('overflowX - multiple boxes inside a box with border', t => {
+	const output = renderToString(
+		<Box width={8} overflowX="hidden" borderStyle="round">
+			<Box width={6} flexShrink={0}>
+				<Text>Hello </Text>
+			</Box>
+			<Box width={6} flexShrink={0}>
+				<Text>World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, box('Hello '));
+});
+
+test('overflowX - box before left edge of container', t => {
+	const output = renderToString(
+		<Box width={6} overflowX="hidden">
+			<Box marginLeft={-12} width={6} flexShrink={0}>
+				<Text>Hello</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, '');
+});
+
+test('overflowX - box before left edge of container with border', t => {
+	const output = renderToString(
+		<Box width={6} overflowX="hidden" borderStyle="round">
+			<Box marginLeft={-12} width={6} flexShrink={0}>
+				<Text>Hello</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, box(' '.repeat(4)));
+});
+
+test('overflowX - box intersecting with left edge of container', t => {
+	const output = renderToString(
+		<Box width={6} overflowX="hidden">
+			<Box marginLeft={-3} width={12} flexShrink={0}>
+				<Text>Hello World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, 'lo Wor');
+});
+
+test('overflowX - box intersecting with left edge of container with border', t => {
+	const output = renderToString(
+		<Box width={8} overflowX="hidden" borderStyle="round">
+			<Box marginLeft={-3} width={12} flexShrink={0}>
+				<Text>Hello World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, box('lo Wor'));
+});
+
+test('overflowX - box after right container edge', t => {
+	const output = renderToString(
+		<Box width={6} overflowX="hidden">
+			<Box marginLeft={6} width={6} flexShrink={0}>
+				<Text>Hello</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, '');
+});
+
+test('overflowX - box intersecting with right container edge', t => {
+	const output = renderToString(
+		<Box width={6} overflowX="hidden">
+			<Box marginLeft={3} width={6} flexShrink={0}>
+				<Text>Hello</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, '   Hel');
+});
+
+test('overflowY - single text node', t => {
+	const output = renderToString(
+		<Box height={1} overflowY="hidden">
+			<Text>Hello{'\n'}World</Text>
+		</Box>
+	);
+
+	t.is(output, 'Hello');
+});
+
+test('overflowY - single text node inside a box with border', t => {
+	const output = renderToString(
+		<Box width={20} height={3} overflowY="hidden" borderStyle="round">
+			<Text>Hello{'\n'}World</Text>
+		</Box>
+	);
+
+	t.is(output, box('Hello'.padEnd(18, ' ')));
+});
+
+test('overflowY - multiple boxes', t => {
+	const output = renderToString(
+		<Box height={2} overflowY="hidden" flexDirection="column">
+			<Box flexShrink={0}>
+				<Text>Line #1</Text>
+			</Box>
+			<Box flexShrink={0}>
+				<Text>Line #2</Text>
+			</Box>
+			<Box flexShrink={0}>
+				<Text>Line #3</Text>
+			</Box>
+			<Box flexShrink={0}>
+				<Text>Line #4</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, 'Line #1\nLine #2');
+});
+
+test('overflowY - multiple boxes inside a box with border', t => {
+	const output = renderToString(
+		<Box
+			width={9}
+			height={4}
+			overflowY="hidden"
+			flexDirection="column"
+			borderStyle="round"
+		>
+			<Box flexShrink={0}>
+				<Text>Line #1</Text>
+			</Box>
+			<Box flexShrink={0}>
+				<Text>Line #2</Text>
+			</Box>
+			<Box flexShrink={0}>
+				<Text>Line #3</Text>
+			</Box>
+			<Box flexShrink={0}>
+				<Text>Line #4</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, box('Line #1\nLine #2'));
+});
+
+test('overflowY - box above top edge of container', t => {
+	const output = renderToString(
+		<Box height={1} overflowY="hidden">
+			<Box marginTop={-2} height={2} flexShrink={0}>
+				<Text>Hello{'\n'}World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, '');
+});
+
+test('overflowY - box above top edge of container with border', t => {
+	const output = renderToString(
+		<Box width={7} height={3} overflowY="hidden" borderStyle="round">
+			<Box marginTop={-3} height={2} flexShrink={0}>
+				<Text>Hello{'\n'}World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, box(' '.repeat(5)));
+});
+
+test('overflowY - box intersecting with top edge of container', t => {
+	const output = renderToString(
+		<Box height={1} overflowY="hidden">
+			<Box marginTop={-1} height={2} flexShrink={0}>
+				<Text>Hello{'\n'}World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, 'World');
+});
+
+test('overflowY - box intersecting with top edge of container with border', t => {
+	const output = renderToString(
+		<Box width={7} height={3} overflowY="hidden" borderStyle="round">
+			<Box marginTop={-1} height={2} flexShrink={0}>
+				<Text>Hello{'\n'}World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, box('World'));
+});
+
+test('overflowY - box below bottom edge of container', t => {
+	const output = renderToString(
+		<Box height={1} overflowY="hidden">
+			<Box marginTop={1} height={2} flexShrink={0}>
+				<Text>Hello{'\n'}World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, '');
+});
+
+test('overflowY - box below bottom edge of container with border', t => {
+	const output = renderToString(
+		<Box width={7} height={3} overflowY="hidden" borderStyle="round">
+			<Box marginTop={2} height={2} flexShrink={0}>
+				<Text>Hello{'\n'}World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, box(' '.repeat(5)));
+});
+
+test('overflowY - box intersecting with bottom edge of container', t => {
+	const output = renderToString(
+		<Box height={1} overflowY="hidden">
+			<Box height={2} flexShrink={0}>
+				<Text>Hello{'\n'}World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, 'Hello');
+});
+
+test('overflowY - box intersecting with bottom edge of container with border', t => {
+	const output = renderToString(
+		<Box width={7} height={3} overflowY="hidden" borderStyle="round">
+			<Box height={2} flexShrink={0}>
+				<Text>Hello{'\n'}World</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, box('Hello'));
+});
+
+test('overflow - single text node', t => {
+	const output = renderToString(
+		<Box paddingBottom={1}>
+			<Box width={6} height={1} overflow="hidden">
+				<Box width={12} height={2} flexShrink={0}>
+					<Text>Hello{'\n'}World</Text>
+				</Box>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, 'Hello\n');
+});
+
+test('overflow - single text node inside container with border', t => {
+	const output = renderToString(
+		<Box paddingBottom={1}>
+			<Box width={8} height={3} overflow="hidden" borderStyle="round">
+				<Box width={12} height={2} flexShrink={0}>
+					<Text>Hello{'\n'}World</Text>
+				</Box>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, `${box('Hello ')}\n`);
+});
+
+test('overflow - multiple boxes', t => {
+	const output = renderToString(
+		<Box paddingBottom={1}>
+			<Box width={4} height={1} overflow="hidden">
+				<Box width={2} height={2} flexShrink={0}>
+					<Text>TL{'\n'}BL</Text>
+				</Box>
+				<Box width={2} height={2} flexShrink={0}>
+					<Text>TR{'\n'}BR</Text>
+				</Box>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, 'TLTR\n');
+});
+
+test('overflow - multiple boxes inside container with border', t => {
+	const output = renderToString(
+		<Box paddingBottom={1}>
+			<Box width={6} height={3} overflow="hidden" borderStyle="round">
+				<Box width={2} height={2} flexShrink={0}>
+					<Text>TL{'\n'}BL</Text>
+				</Box>
+				<Box width={2} height={2} flexShrink={0}>
+					<Text>TR{'\n'}BR</Text>
+				</Box>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, `${box('TLTR')}\n`);
+});
+
+test('overflow - box intersecting with top left edge of container', t => {
+	const output = renderToString(
+		<Box width={4} height={4} overflow="hidden">
+			<Box marginTop={-2} marginLeft={-2} width={4} height={4} flexShrink={0}>
+				<Text>
+					AAAA{'\n'}BBBB{'\n'}CCCC{'\n'}DDDD
+				</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, 'CC\nDD\n\n');
+});
+
+test('overflow - box intersecting with top right edge of container', t => {
+	const output = renderToString(
+		<Box width={4} height={4} overflow="hidden">
+			<Box marginTop={-2} marginLeft={2} width={4} height={4} flexShrink={0}>
+				<Text>
+					AAAA{'\n'}BBBB{'\n'}CCCC{'\n'}DDDD
+				</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, '  CC\n  DD\n\n');
+});
+
+test('overflow - box intersecting with bottom left edge of container', t => {
+	const output = renderToString(
+		<Box width={4} height={4} overflow="hidden">
+			<Box marginTop={2} marginLeft={-2} width={4} height={4} flexShrink={0}>
+				<Text>
+					AAAA{'\n'}BBBB{'\n'}CCCC{'\n'}DDDD
+				</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, '\n\nAA\nBB');
+});
+
+test('overflow - box intersecting with bottom right edge of container', t => {
+	const output = renderToString(
+		<Box width={4} height={4} overflow="hidden">
+			<Box marginTop={2} marginLeft={2} width={4} height={4} flexShrink={0}>
+				<Text>
+					AAAA{'\n'}BBBB{'\n'}CCCC{'\n'}DDDD
+				</Text>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, '\n\n  AA\n  BB');
+});
+
+test('nested overflow', t => {
+	const output = renderToString(
+		<Box paddingBottom={1}>
+			<Box width={4} height={4} overflow="hidden" flexDirection="column">
+				<Box width={2} height={2} overflow="hidden">
+					<Box width={4} height={4} flexShrink={0}>
+						<Text>
+							AAAA{'\n'}BBBB{'\n'}CCCC{'\n'}DDDD
+						</Text>
+					</Box>
+				</Box>
+
+				<Box width={4} height={3}>
+					<Text>
+						XXXX{'\n'}YYYY{'\n'}ZZZZ
+					</Text>
+				</Box>
+			</Box>
+		</Box>
+	);
+
+	t.is(output, 'AA\nBB\nXXXX\nYYYY\n');
+});


### PR DESCRIPTION
This PR adds `overflowX`, `overflowY` and `overflow` props to `Box` component to hide any content overflowing the element's bounds. Allowed values are `visible` (default) and `hidden`.

This is a follow up PR to https://github.com/vadimdemedes/ink/pull/393. Credit to @tin-t for submitting an initial implementation of this feature, which this PR is based on!

Everyone is welcome to try it out!