### PR TITLE
fix: set correct peer dependency range for react

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,8 +99,8 @@
 		"xo": "^0.28.0"
 	},
 	"peerDependencies": {
-		"@types/react": ">=16.8.0",
-		"react": ">=16.8.0",
+		"@types/react": "^17.0.2",
+		"react": "^17.0.0",
 		"react-devtools-core": "^4.19.1"
 	},
 	"peerDependenciesMeta": {


### PR DESCRIPTION
Matches `react-reconciler`: https://www.runpkg.com/?react-reconciler@0.26.2/package.json#29