### PR TITLE
Allow React@17 in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,8 +99,8 @@
 		"xo": "^0.28.0"
 	},
 	"peerDependencies": {
-		"@types/react": ">=16.8.0",
-		"react": ">=16.8.0",
+		"@types/react": ">=16.8.0 || ^17.0.0",
+		"react": ">=16.8.0 || ^17.0.0",
 		"react-devtools-core": "^4.19.1"
 	},
 	"peerDependenciesMeta": {


### PR DESCRIPTION
As this package does support and use React@17 it would be great to extend the peer dependency version range with version 17.