### PR TITLE
Fix types and linting errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"@types/lodash": "^4.14.161",
 		"@types/node": "*",
 		"@types/react": "^17.0.27",
-		"@types/react-reconciler": "^0.26.4",
+		"@types/react-reconciler": "0.26.3",
 		"@types/scheduler": "^0.16.2",
 		"@types/signal-exit": "^3.0.0",
 		"@types/sinon": "^9.0.4",

--- a/test/fixtures/ci.tsx
+++ b/test/fixtures/ci.tsx
@@ -44,7 +44,7 @@ class Test extends React.Component<Record<string, unknown>, TestState> {
 	}
 
 	componentWillUnmount() {
-		clearTimeout(this.timer!);
+		clearTimeout(this.timer);
 	}
 }
 

--- a/test/fixtures/exit-on-exit-with-error.tsx
+++ b/test/fixtures/exit-on-exit-with-error.tsx
@@ -26,7 +26,7 @@ class Exit extends React.Component<
 	}
 
 	componentWillUnmount() {
-		clearInterval(this.timer!);
+		clearInterval(this.timer);
 	}
 }
 

--- a/test/fixtures/exit-on-exit.tsx
+++ b/test/fixtures/exit-on-exit.tsx
@@ -26,7 +26,7 @@ class Exit extends React.Component<
 	}
 
 	componentWillUnmount() {
-		clearInterval(this.timer!);
+		clearInterval(this.timer);
 	}
 }
 

--- a/test/fixtures/exit-on-finish.tsx
+++ b/test/fixtures/exit-on-finish.tsx
@@ -29,7 +29,7 @@ class Test extends React.Component<Record<string, unknown>, {counter: number}> {
 	}
 
 	componentWillUnmount() {
-		clearTimeout(this.timer!);
+		clearTimeout(this.timer);
 	}
 }
 

--- a/test/fixtures/exit-on-unmount.tsx
+++ b/test/fixtures/exit-on-unmount.tsx
@@ -21,7 +21,7 @@ class Test extends React.Component<Record<string, unknown>, {counter: number}> {
 	}
 
 	componentWillUnmount() {
-		clearInterval(this.timer!);
+		clearInterval(this.timer);
 	}
 }
 


### PR DESCRIPTION
The declaration of `createContainer` in `@types/react-reconciler` has been changed since 0.16.4.

You can find its history versions here:

- https://www.jsdelivr.com/package/npm/@types/react-reconciler
  - https://cdn.jsdelivr.net/npm/@types/react-reconciler@0.26.4/index.d.ts
  - https://cdn.jsdelivr.net/npm/@types/react-reconciler@0.26.3/index.d.ts