### PR TITLE
Fix broken layout when emojis are used

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"cli-cursor": "^4.0.0",
 		"cli-truncate": "^3.1.0",
 		"code-excerpt": "^4.0.0",
+		"emoji-regex": "^10.2.1",
 		"indent-string": "^5.0.0",
 		"is-ci": "^3.0.1",
 		"lodash-es": "^4.17.21",

--- a/src/output.ts
+++ b/src/output.ts
@@ -187,6 +187,8 @@ export default class Output {
 						line = transformer(line);
 					}
 
+					// `slice-ansi` counts emojis as one character, not two, so
+					// indexes must be adjusted to subtract number of emojis
 					const emojiCount = currentLine.match(emojiRegex)?.length ?? 0;
 
 					output[y + offsetY] =

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,7 +1,10 @@
 import sliceAnsi from 'slice-ansi';
 import stringWidth from 'string-width';
 import widestLine from 'widest-line';
+import createEmojiRegex from 'emoji-regex';
 import {type OutputTransformer} from './render-node-to-output.js';
+
+const emojiRegex = createEmojiRegex();
 
 /**
  * "Virtual" output class
@@ -184,10 +187,12 @@ export default class Output {
 						line = transformer(line);
 					}
 
+					const emojiCount = currentLine.match(emojiRegex)?.length ?? 0;
+
 					output[y + offsetY] =
-						sliceAnsi(currentLine, 0, x) +
+						sliceAnsi(currentLine, 0, x - emojiCount) +
 						line +
-						sliceAnsi(currentLine, x + width);
+						sliceAnsi(currentLine, x - emojiCount + width);
 
 					offsetY++;
 				}

--- a/test/borders.tsx
+++ b/test/borders.tsx
@@ -289,6 +289,126 @@ test('nested boxes', t => {
 	);
 });
 
+test('nested boxes - fit-content box with wide characters on flex-direction row', t => {
+	const output = renderToString(
+		<Box borderStyle="round" alignSelf="flex-start">
+			<Box borderStyle="round">
+				<Text>ミスター</Text>
+			</Box>
+			<Box borderStyle="round">
+				<Text>スポック</Text>
+			</Box>
+			<Box borderStyle="round">
+				<Text>カーク船長</Text>
+			</Box>
+		</Box>
+	);
+
+	const box1 = boxen('ミスター', {borderStyle: 'round'});
+	const box2 = boxen('スポック', {borderStyle: 'round'});
+	const box3 = boxen('カーク船長', {borderStyle: 'round'});
+
+	const expected = boxen(
+		box1
+			.split('\n')
+			.map(
+				(line, index) =>
+					line + box2.split('\n')[index] + box3.split('\n')[index]
+			)
+			.join('\n'),
+		{borderStyle: 'round'}
+	);
+
+	t.is(output, expected);
+});
+
+test('nested boxes - fit-content box with emojis on flex-direction row', t => {
+	const output = renderToString(
+		<Box borderStyle="round" alignSelf="flex-start">
+			<Box borderStyle="round">
+				<Text>🦾</Text>
+			</Box>
+			<Box borderStyle="round">
+				<Text>🌏</Text>
+			</Box>
+			<Box borderStyle="round">
+				<Text>😋</Text>
+			</Box>
+		</Box>
+	);
+
+	const box1 = boxen('🦾', {borderStyle: 'round'});
+	const box2 = boxen('🌏', {borderStyle: 'round'});
+	const box3 = boxen('😋', {borderStyle: 'round'});
+
+	const expected = boxen(
+		box1
+			.split('\n')
+			.map(
+				(line, index) =>
+					line + box2.split('\n')[index] + box3.split('\n')[index]
+			)
+			.join('\n'),
+		{borderStyle: 'round'}
+	);
+
+	t.is(output, expected);
+});
+
+test('nested boxes - fit-content box with wide characters on flex-direction column', t => {
+	const output = renderToString(
+		<Box borderStyle="round" alignSelf="flex-start" flexDirection="column">
+			<Box borderStyle="round">
+				<Text>ミスター</Text>
+			</Box>
+			<Box borderStyle="round">
+				<Text>スポック</Text>
+			</Box>
+			<Box borderStyle="round">
+				<Text>カーク船長</Text>
+			</Box>
+		</Box>
+	);
+
+	const expected = boxen(
+		boxen('ミスター  ', {borderStyle: 'round'}) +
+			'\n' +
+			boxen('スポック  ', {borderStyle: 'round'}) +
+			'\n' +
+			boxen('カーク船長', {borderStyle: 'round'}),
+		{borderStyle: 'round'}
+	);
+
+	t.is(output, expected);
+});
+
+test('nested boxes - fit-content box with emojis on flex-direction column', t => {
+	const output = renderToString(
+		<Box borderStyle="round" alignSelf="flex-start" flexDirection="column">
+			<Box borderStyle="round">
+				<Text>🦾</Text>
+			</Box>
+			<Box borderStyle="round">
+				<Text>🌏</Text>
+			</Box>
+			<Box borderStyle="round">
+				<Text>😋</Text>
+			</Box>
+		</Box>
+	);
+
+	const expected = boxen(
+		boxen('🦾', {borderStyle: 'round'}) +
+			'\n' +
+			boxen('🌏', {borderStyle: 'round'}) +
+			'\n' +
+			boxen('😋', {borderStyle: 'round'}),
+		{borderStyle: 'round'}
+	);
+
+	t.is(output, expected);
+});
+
 test('render border after update', async t => {
 	const stdout = createStdout();
 

--- a/test/borders.tsx
+++ b/test/borders.tsx
@@ -3,6 +3,7 @@ import test from 'ava';
 import boxen, {type Options} from 'boxen';
 import indentString from 'indent-string';
 import delay from 'delay';
+import widestLine from 'widest-line';
 import {render, Box, Text} from '../src/index.js';
 import {renderToString} from './helpers/render-to-string.js';
 import createStdout from './helpers/create-stdout.js';
@@ -313,7 +314,7 @@ test('nested boxes - fit-content box with wide characters on flex-direction row'
 			.split('\n')
 			.map(
 				(line, index) =>
-					line + box2.split('\n')[index] + box3.split('\n')[index]
+					line + box2.split('\n')[index]! + box3.split('\n')[index]!
 			)
 			.join('\n'),
 		{borderStyle: 'round'}
@@ -346,7 +347,7 @@ test('nested boxes - fit-content box with emojis on flex-direction row', t => {
 			.split('\n')
 			.map(
 				(line, index) =>
-					line + box2.split('\n')[index] + box3.split('\n')[index]
+					line + box2.split('\n')[index]! + box3.split('\n')[index]!
 			)
 			.join('\n'),
 		{borderStyle: 'round'}


### PR DESCRIPTION
Fixes #505 

The problem is happening due to (I think) `yoga` and `slice-ansi` incompatibility on string indexes. `slice-ansi` counts emojis as 1 char and `yoga` counts it as 2 (again, I think).

Here I'm using `emoji-regex` (which was already pulled in by other dependencies so it doesn't add any real new package to the dependency tree) to count emojis on the current line. Then I'm substracting that amount to the `x` variable (starting offset on where to replace the string).

If you find a better way to fix this issue please let me know and I'll be happy to try it out and implement it here.

Before: 
![image](https://user-images.githubusercontent.com/12949236/193687599-15e153f7-bec8-4544-abba-691cfb1e275f.png)

After: 
![image](https://user-images.githubusercontent.com/12949236/193689095-d1fec81f-4acc-4603-a64d-a2f8d9e1d376.png)

