### PR TITLE
Add Shopify CLI to "Who's Using Ink?"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -126,6 +126,7 @@ Feel free to play around with the code and fork this repl at [https://repl.it/@v
 - [mnswpr](https://github.com/mordv/mnswpr) - Minesweeper game.
 - [lrn](https://github.com/krychu/lrn) - Learning by repetition.
 - [turdle](https://github.com/mynameisankit/turdle) - Wordle game.
+- [Shopify CLI](https://github.com/Shopify/cli) - Build apps, themes, and hydrogen storefronts for Shopify.
 
 ## Contents
 


### PR DESCRIPTION
Hi,
We've added `ink` to Shopify CLI in order to display output in the `shopify app dev` command.

Thank you for the great project!