### PR TITLE
Add fallback for TS `moduleResolution: 'node'` users

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"url": "https://github.com/vadimdemedes"
 	},
 	"type": "module",
+	"types": "./build/index.d.ts",
 	"exports": {
 		"types": "./build/index.d.ts",
 		"default": "./build/index.js"


### PR DESCRIPTION
# Summary

Using the new major (which relies on `exports` field alone for `.d.ts`/`.js` resolution) with a TS project that's still using `"moduleResolution": "node"` (not `nodenext`) means TS doesn't leverage `exports` at all.

So using the new major like this results (during type-check / `tsc` build) in:
```
error TS2307: Cannot find module 'ink' or its corresponding type declarations.

  import { Box, render, Text } from "ink";
                                    ~~~~~
```