### PR TITLE
Speed up generation of output

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
 		"text"
 	],
 	"dependencies": {
+		"@alcalzone/ansi-tokenize": "^0.1.0",
 		"ansi-escapes": "^6.0.0",
-		"ansi-tokenize": "github:AlCalzone/ansi-tokenize",
 		"auto-bind": "^5.0.1",
 		"chalk": "^5.2.0",
 		"cli-boxes": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 	],
 	"dependencies": {
 		"ansi-escapes": "^6.0.0",
+		"ansi-tokenize": "github:AlCalzone/ansi-tokenize",
 		"auto-bind": "^5.0.1",
 		"chalk": "^5.2.0",
 		"cli-boxes": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"text"
 	],
 	"dependencies": {
-		"@alcalzone/ansi-tokenize": "^0.1.0",
+		"@alcalzone/ansi-tokenize": "^0.1.1",
 		"ansi-escapes": "^6.0.0",
 		"auto-bind": "^5.0.1",
 		"chalk": "^5.2.0",

--- a/src/output.ts
+++ b/src/output.ts
@@ -198,12 +198,16 @@ export default class Output {
 					const chars = styledCharsFromTokens(tokenize(line));
 					let offsetX = x;
 					for (const char of chars) {
+						if (offsetX >= this.width) break;
+
 						currentLine[offsetX] = char;
 
 						// Some characters take up more than one column. In that case, the following
 						// pixels need to be cleared to avoid printing extra characters
 						const isWideChar = char.fullWidth || char.value.length > 1;
 						if (isWideChar) {
+							if (offsetX + 1 >= this.width) break;
+
 							currentLine[offsetX + 1] = {
 								type: 'char',
 								value: '',

--- a/src/output.ts
+++ b/src/output.ts
@@ -6,7 +6,7 @@ import {
 	styledCharsFromTokens,
 	styledCharsToString,
 	tokenize
-} from 'ansi-tokenize';
+} from '@alcalzone/ansi-tokenize';
 import {type OutputTransformer} from './render-node-to-output.js';
 
 /**

--- a/src/output.ts
+++ b/src/output.ts
@@ -98,7 +98,7 @@ export default class Output {
 
 	get(): {output: string; height: number} {
 		// Initialize output array with a specific set of rows, so that margin/padding at the bottom is preserved
-		const output: Array<StyledChar[]> = [];
+		const output: StyledChar[][] = [];
 
 		for (let y = 0; y < this.height; y++) {
 			const row: StyledChar[] = [];

--- a/src/output.ts
+++ b/src/output.ts
@@ -198,8 +198,6 @@ export default class Output {
 					const chars = styledCharsFromTokens(tokenize(line));
 					let offsetX = x;
 					for (const char of chars) {
-						if (offsetX >= this.width) break;
-
 						currentLine[offsetX] = char;
 
 						// Some characters take up more than one column. In that case, the following
@@ -225,7 +223,12 @@ export default class Output {
 		}
 
 		const generatedOutput = output
-			.map(line => styledCharsToString(line).trimEnd())
+			.map(line => {
+				// See https://github.com/vadimdemedes/ink/pull/564#issuecomment-1637022742
+				const lineWithoutEmptyItems = line.filter(item => item !== undefined);
+
+				return styledCharsToString(lineWithoutEmptyItems).trimEnd();
+			})
 			.join('\n');
 
 		return {

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,13 +1,13 @@
 import sliceAnsi from 'slice-ansi';
 import stringWidth from 'string-width';
 import widestLine from 'widest-line';
-import {type OutputTransformer} from './render-node-to-output.js';
 import {
-	StyledChar,
+	type StyledChar,
 	styledCharsFromTokens,
 	styledCharsToString,
 	tokenize
 } from 'ansi-tokenize';
+import {type OutputTransformer} from './render-node-to-output.js';
 
 /**
  * "Virtual" output class
@@ -110,6 +110,7 @@ export default class Output {
 					styles: []
 				});
 			}
+
 			output.push(row);
 		}
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -98,10 +98,11 @@ export default class Output {
 
 	get(): {output: string; height: number} {
 		// Initialize output array with a specific set of rows, so that margin/padding at the bottom is preserved
-		const output: StyledChar[][] = [];
+		const output: Array<StyledChar[]> = [];
 
 		for (let y = 0; y < this.height; y++) {
 			const row: StyledChar[] = [];
+
 			for (let x = 0; x < this.width; x++) {
 				row.push({
 					type: 'char',
@@ -188,33 +189,41 @@ export default class Output {
 
 				for (let line of lines) {
 					const currentLine = output[y + offsetY];
+
 					// Line can be missing if `text` is taller than height of pre-initialized `this.output`
-					if (!currentLine) continue;
+					if (!currentLine) {
+						continue;
+					}
 
 					for (const transformer of transformers) {
 						line = transformer(line);
 					}
 
-					const chars = styledCharsFromTokens(tokenize(line));
+					const characters = styledCharsFromTokens(tokenize(line));
 					let offsetX = x;
-					for (const char of chars) {
-						currentLine[offsetX] = char;
+
+					for (const character of characters) {
+						currentLine[offsetX] = character;
 
 						// Some characters take up more than one column. In that case, the following
 						// pixels need to be cleared to avoid printing extra characters
-						const isWideChar = char.fullWidth || char.value.length > 1;
-						if (isWideChar) {
-							if (offsetX + 1 >= this.width) break;
+						const isWideCharacter =
+							character.fullWidth || character.value.length > 1;
+
+						if (isWideCharacter) {
+							if (offsetX + 1 >= this.width) {
+								break;
+							}
 
 							currentLine[offsetX + 1] = {
 								type: 'char',
 								value: '',
 								fullWidth: false,
-								styles: char.styles
+								styles: character.styles
 							};
 						}
 
-						offsetX += isWideChar ? 2 : 1;
+						offsetX += isWideCharacter ? 2 : 1;
 					}
 
 					offsetY++;

--- a/src/output.ts
+++ b/src/output.ts
@@ -211,10 +211,6 @@ export default class Output {
 							character.fullWidth || character.value.length > 1;
 
 						if (isWideCharacter) {
-							if (offsetX + 1 >= this.width) {
-								break;
-							}
-
 							currentLine[offsetX + 1] = {
 								type: 'char',
 								value: '',

--- a/src/output.ts
+++ b/src/output.ts
@@ -202,9 +202,9 @@ export default class Output {
 
 						// Some characters take up more than one column. In that case, the following
 						// pixels need to be cleared to avoid printing extra characters
-						const charWidth = char.fullWidth ? 2 : char.value.length;
-						for (let dx = 1; dx < charWidth; dx++) {
-							currentLine[offsetX + dx] = {
+						const isWideChar = char.fullWidth || char.value.length > 1;
+						if (isWideChar) {
+							currentLine[offsetX + 1] = {
 								type: 'char',
 								value: '',
 								fullWidth: false,
@@ -212,7 +212,7 @@ export default class Output {
 							};
 						}
 
-						offsetX += charWidth;
+						offsetX += isWideChar ? 2 : 1;
 					}
 
 					offsetY++;

--- a/src/output.ts
+++ b/src/output.ts
@@ -205,12 +205,13 @@ export default class Output {
 						const charWidth = char.fullWidth ? 2 : char.value.length;
 						for (let dx = 1; dx < charWidth; dx++) {
 							currentLine[offsetX + dx] = {
-								"type": "char",
-								"value": "",
-								"fullWidth": false,
-								"styles": char.styles
+								type: 'char',
+								value: '',
+								fullWidth: false,
+								styles: char.styles
 							};
 						}
+
 						offsetX += charWidth;
 					}
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -196,7 +196,23 @@ export default class Output {
 					}
 
 					const chars = styledCharsFromTokens(tokenize(line));
-					currentLine.splice(x, chars.length, ...chars);
+					let offsetX = x;
+					for (const char of chars) {
+						currentLine[offsetX] = char;
+
+						// Some characters take up more than one column. In that case, the following
+						// pixels need to be cleared to avoid printing extra characters
+						const charWidth = char.fullWidth ? 2 : char.value.length;
+						for (let dx = 1; dx < charWidth; dx++) {
+							currentLine[offsetX + dx] = {
+								"type": "char",
+								"value": "",
+								"fullWidth": false,
+								"styles": char.styles
+							};
+						}
+						offsetX += charWidth;
+					}
 
 					offsetY++;
 				}

--- a/test/overflow.tsx
+++ b/test/overflow.tsx
@@ -502,19 +502,22 @@ test('nested overflow', t => {
 	t.is(output, 'AA\nBB\nXXXX\nYYYY\n');
 });
 
-test('out of bounds writes are truncated and do not crash', t => {
-	// To trigger this reliably, render a box with a border that is at least 2 columns too wide for the terminal
+// See https://github.com/vadimdemedes/ink/pull/564#issuecomment-1637022742
+test('out of bounds writes do not crash', t => {
 	const output = renderToString(
-		<Box width={12} height={10} borderStyle={'round'} flexDirection="row"></Box>,
+		<Box width={12} height={10} borderStyle="round" />,
 		{columns: 10}
 	);
+
 	const expected = boxen('', {
-		width: 11,
+		width: 12,
 		height: 10,
 		borderStyle: 'round'
 	})
 		.split('\n')
-		.map(line => line.slice(0, 10).trimEnd())
+		.map((line, index) => {
+			return index === 0 || index === 9 ? line : line.slice(0, 10) + line[11];
+		})
 		.join('\n');
 
 	t.is(output, expected);

--- a/test/overflow.tsx
+++ b/test/overflow.tsx
@@ -516,7 +516,9 @@ test('out of bounds writes do not crash', t => {
 	})
 		.split('\n')
 		.map((line, index) => {
-			return index === 0 || index === 9 ? line : line.slice(0, 10) + line[11];
+			return index === 0 || index === 9
+				? line
+				: `${line.slice(0, 10)}${line[11] ?? ''}`;
 		})
 		.join('\n');
 

--- a/test/overflow.tsx
+++ b/test/overflow.tsx
@@ -501,3 +501,21 @@ test('nested overflow', t => {
 
 	t.is(output, 'AA\nBB\nXXXX\nYYYY\n');
 });
+
+test('out of bounds writes are truncated and do not crash', t => {
+	// To trigger this reliably, render a box with a border that is at least 2 columns too wide for the terminal
+	const output = renderToString(
+		<Box width={12} height={10} borderStyle={'round'} flexDirection="row"></Box>,
+		{columns: 10}
+	);
+	const expected = boxen('', {
+		width: 11,
+		height: 10,
+		borderStyle: 'round'
+	})
+		.split('\n')
+		.map(line => line.slice(0, 10).trimEnd())
+		.join('\n');
+
+	t.is(output, expected);
+});


### PR DESCRIPTION
This is a proof of concept for a different rendering approach that does not rely on `sliceAnsi` as heavily.

I tried this with my test component from #560, but with 50 spinners. Without this change, 50 spinners put one core of my CPU at 100%, and rendering lags heavily. With this change, I'm looking at ~40% utilization of one core, which is still not ideal, but renders fluently.

The output for 10s of profiling now looks like this, is idle half the time and most of the work is done in `wasm`, which is probably from `yoga` internals:
![grafik](https://user-images.githubusercontent.com/17641229/226215080-f92d2d84-de67-4f71-92ab-7c95a1627099.png)

fixes: https://github.com/vadimdemedes/ink/issues/560

This will need some more testing with emojis and clipping, but I wanted to get this out for some early feedback.