### PR TITLE
Improve diffing of styles

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line n/file-extension-in-import
 import Yoga, {type Node as YogaNode} from 'yoga-wasm-web/auto';
 import measureText from './measure-text.js';
-import applyStyles, {type Styles} from './styles.js';
+import {type Styles} from './styles.js';
 import wrapText from './wrap-text.js';
 import squashTextNodes from './squash-text-nodes.js';
 import {type OutputTransformer} from './render-node-to-output.js';
@@ -159,10 +159,6 @@ export const setAttribute = (
 
 export const setStyle = (node: DOMNode, style: Styles): void => {
 	node.style = style;
-
-	if (node.yogaNode) {
-		applyStyles(node.yogaNode, style);
-	}
 };
 
 export const createTextNode = (text: string): TextNode => {

--- a/test/borders.tsx
+++ b/test/borders.tsx
@@ -410,16 +410,10 @@ test('nested boxes - fit-content box with emojis on flex-direction column', t =>
 	t.is(output, expected);
 });
 
-test('render border after update', async t => {
+test('render border after update', t => {
 	const stdout = createStdout();
 
-	function Test() {
-		const [borderColor, setBorderColor] = useState<string | undefined>();
-
-		useEffect(() => {
-			setBorderColor('green');
-		}, []);
-
+	function Test({borderColor}: {borderColor?: string}) {
 		return (
 			<Box borderStyle="round" borderColor={borderColor}>
 				<Text>Hello World</Text>
@@ -427,7 +421,7 @@ test('render border after update', async t => {
 		);
 	}
 
-	render(<Test />, {
+	const {rerender} = render(<Test />, {
 		stdout,
 		debug: true
 	});
@@ -437,7 +431,7 @@ test('render border after update', async t => {
 		boxen('Hello World', {width: 100, borderStyle: 'round'})
 	);
 
-	await delay(100);
+	rerender(<Test borderColor="green" />);
 
 	t.is(
 		(stdout.write as any).lastCall.args[0],
@@ -445,6 +439,16 @@ test('render border after update', async t => {
 			width: 100,
 			borderStyle: 'round',
 			borderColor: 'green'
+		})
+	);
+
+	rerender(<Test />);
+
+	t.is(
+		(stdout.write as any).lastCall.args[0],
+		boxen('Hello World', {
+			width: 100,
+			borderStyle: 'round'
 		})
 	);
 });


### PR DESCRIPTION
## Problem

[`style`](https://github.com/vadimdemedes/ink/blob/2a67354222affbc1728fd55f2faaede8ddd899c0/src/dom.ts#L13) property of Ink nodes contains the changed fields of `style` object, rather than a full `style` object itself. As a result, `style` in internal representation of an Ink node is inconsistent what's actually passed via a [`style`](https://github.com/vadimdemedes/ink/blob/2a67354222affbc1728fd55f2faaede8ddd899c0/src/components/Box.tsx#L116) prop to `ink-box` (rendered by `Box`) or `ink-text` (rendered by `Text`).

Here's example code demonstrating the problem:

```jsx
const {rerender} = render(<Box borderStyle="round" borderColor="green"/>);
// Box's style = { borderStyle: 'round', borderColor: 'green' }
// Ink node's style = { borderStyle: 'round', borderColor: 'green' }

rerender(<Box borderStyle="round" borderColor="blue"/>);
// Box's style = { borderStyle: 'round', borderColor: 'blue' }
// Ink node's style = { borderColor: 'blue' }
```

`borderStyle` hasn't been changed between renders, so it's no longer present in the internal `style` object. This led to https://github.com/vadimdemedes/ink/pull/345, which actually didn't have a proper solution to the root problem (`style` being out of sync), but rather a workaround that special-cased props like `borderStyle` to always be present in the `style` object.

## Solution

This PR does several things to remove this workaround I shipped before:

1. Make `setStyle` function responsible for only setting styles and not updating Yoga node.
2. Change reconciler's `prepareUpdate` to diff `props` and `props.style` prop separately.
3. Skip update entirely if `props` or `props.style` hasn't changed. It's actually unrelated to this PR, but still a nice improvement.
4. Reconciler is now the one who updates styles of a Yoga node, not `setStyle` function.

With this update, `style` is always consistent between an internal representation of an Ink node and what's passed via `style` prop to a React component. At the same time, reconciler still updates Yoga node with styles that were changed since last render.
