### PR TITLE
Move shorthand `margin`, `padding` and `gap` props out of `Box`

### DIFF
--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -1,119 +1,24 @@
-/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 import React, {forwardRef, type PropsWithChildren} from 'react';
 import {type Except} from 'type-fest';
 import {type Styles} from '../styles.js';
 import {type DOMElement} from '../dom.js';
 
-export type Props = Except<Styles, 'textWrap'> & {
-	/**
-	 * Size of the gap between an element's columns.
-	 *
-	 * @default 0
-	 */
-	readonly columnGap?: number;
-
-	/**
-	 * Size of the gap between element's rows.
-	 *
-	 * @default 0
-	 */
-	readonly rowGap?: number;
-
-	/**
-	 * Size of the gap between an element's columns and rows. Shorthand for `columnGap` and `rowGap`.
-	 *
-	 * @default 0
-	 */
-	readonly gap?: number;
-
-	/**
-	 * Margin on all sides. Equivalent to setting `marginTop`, `marginBottom`, `marginLeft` and `marginRight`.
-	 *
-	 * @default 0
-	 */
-	readonly margin?: number;
-
-	/**
-	 * Horizontal margin. Equivalent to setting `marginLeft` and `marginRight`.
-	 *
-	 * @default 0
-	 */
-	readonly marginX?: number;
-
-	/**
-	 * Vertical margin. Equivalent to setting `marginTop` and `marginBottom`.
-	 *
-	 * @default 0
-	 */
-	readonly marginY?: number;
-
-	/**
-	 * Padding on all sides. Equivalent to setting `paddingTop`, `paddingBottom`, `paddingLeft` and `paddingRight`.
-	 *
-	 * @default 0
-	 */
-	readonly padding?: number;
-
-	/**
-	 * Horizontal padding. Equivalent to setting `paddingLeft` and `paddingRight`.
-	 *
-	 * @default 0
-	 */
-	readonly paddingX?: number;
-
-	/**
-	 * Vertical padding. Equivalent to setting `paddingTop` and `paddingBottom`.
-	 *
-	 * @default 0
-	 */
-	readonly paddingY?: number;
-
-	/**
-	 * Behavior for an element's overflow in both directions.
-	 *
-	 * @default 'visible'
-	 */
-	readonly overflow?: 'visible' | 'hidden';
-
-	/**
-	 * Behavior for an element's overflow in horizontal direction.
-	 *
-	 * @default 'visible'
-	 */
-	readonly overflowX?: 'visible' | 'hidden';
-
-	/**
-	 * Behavior for an element's overflow in vertical direction.
-	 *
-	 * @default 'visible'
-	 */
-	readonly overflowY?: 'visible' | 'hidden';
-};
+export type Props = Except<Styles, 'textWrap'>;
 
 /**
  * `<Box>` is an essential Ink component to build your layout. It's like `<div style="display: flex">` in the browser.
  */
 const Box = forwardRef<DOMElement, PropsWithChildren<Props>>(
 	({children, ...style}, ref) => {
-		const transformedStyle = {
-			...style,
-			columnGap: style.columnGap || style.gap || 0,
-			rowGap: style.rowGap || style.gap || 0,
-			marginLeft: style.marginLeft || style.marginX || style.margin || 0,
-			marginRight: style.marginRight || style.marginX || style.margin || 0,
-			marginTop: style.marginTop || style.marginY || style.margin || 0,
-			marginBottom: style.marginBottom || style.marginY || style.margin || 0,
-			paddingLeft: style.paddingLeft || style.paddingX || style.padding || 0,
-			paddingRight: style.paddingRight || style.paddingX || style.padding || 0,
-			paddingTop: style.paddingTop || style.paddingY || style.padding || 0,
-			paddingBottom:
-				style.paddingBottom || style.paddingY || style.padding || 0,
-			overflowX: style.overflowX || style.overflow || 'visible',
-			overflowY: style.overflowY || style.overflow || 'visible'
-		};
-
 		return (
-			<ink-box ref={ref} style={transformedStyle}>
+			<ink-box
+				ref={ref}
+				style={{
+					...style,
+					overflowX: style.overflowX ?? style.overflow ?? 'visible',
+					overflowY: style.overflowY ?? style.overflow ?? 'visible'
+				}}
+			>
 				{children}
 			</ink-box>
 		);

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -95,8 +95,10 @@ const renderNodeToOutput = (
 		if (node.nodeName === 'ink-box') {
 			renderBorder(x, y, node, output);
 
-			const clipHorizontally = node.style.overflowX === 'hidden';
-			const clipVertically = node.style.overflowY === 'hidden';
+			const clipHorizontally =
+				node.style.overflowX === 'hidden' || node.style.overflow === 'hidden';
+			const clipVertically =
+				node.style.overflowY === 'hidden' || node.style.overflow === 'hidden';
 
 			if (clipHorizontally || clipVertically) {
 				const x1 = clipHorizontally

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -18,14 +18,34 @@ export type Styles = {
 	readonly position?: 'absolute' | 'relative';
 
 	/**
-	 * Gap between element's columns.
+	 * Size of the gap between an element's columns.
 	 */
 	readonly columnGap?: number;
 
 	/**
-	 * Gap between element's rows.
+	 * Size of the gap between element's rows.
 	 */
 	readonly rowGap?: number;
+
+	/**
+	 * Size of the gap between an element's columns and rows. Shorthand for `columnGap` and `rowGap`.
+	 */
+	readonly gap?: number;
+
+	/**
+	 * Margin on all sides. Equivalent to setting `marginTop`, `marginBottom`, `marginLeft` and `marginRight`.
+	 */
+	readonly margin?: number;
+
+	/**
+	 * Horizontal margin. Equivalent to setting `marginLeft` and `marginRight`.
+	 */
+	readonly marginX?: number;
+
+	/**
+	 * Vertical margin. Equivalent to setting `marginTop` and `marginBottom`.
+	 */
+	readonly marginY?: number;
 
 	/**
 	 * Top margin.
@@ -46,6 +66,21 @@ export type Styles = {
 	 * Right margin.
 	 */
 	readonly marginRight?: number;
+
+	/**
+	 * Padding on all sides. Equivalent to setting `paddingTop`, `paddingBottom`, `paddingLeft` and `paddingRight`.
+	 */
+	readonly padding?: number;
+
+	/**
+	 * Horizontal padding. Equivalent to setting `paddingLeft` and `paddingRight`.
+	 */
+	readonly paddingX?: number;
+
+	/**
+	 * Vertical padding. Equivalent to setting `paddingTop` and `paddingBottom`.
+	 */
+	readonly paddingY?: number;
 
 	/**
 	 * Top padding.
@@ -160,12 +195,23 @@ export type Styles = {
 	readonly borderColor?: LiteralUnion<ForegroundColorName, string>;
 
 	/**
+	 * Behavior for an element's overflow in both directions.
+	 *
+	 * @default 'visible'
+	 */
+	readonly overflow?: 'visible' | 'hidden';
+
+	/**
 	 * Behavior for an element's overflow in horizontal direction.
+	 *
+	 * @default 'visible'
 	 */
 	readonly overflowX?: 'visible' | 'hidden';
 
 	/**
 	 * Behavior for an element's overflow in vertical direction.
+	 *
+	 * @default 'visible'
 	 */
 	readonly overflowY?: 'visible' | 'hidden';
 };
@@ -181,6 +227,18 @@ const applyPositionStyles = (node: YogaNode, style: Styles): void => {
 };
 
 const applyMarginStyles = (node: YogaNode, style: Styles): void => {
+	if ('margin' in style) {
+		node.setMargin(Yoga.EDGE_ALL, style.margin ?? 0);
+	}
+
+	if ('marginX' in style) {
+		node.setMargin(Yoga.EDGE_HORIZONTAL, style.marginX ?? 0);
+	}
+
+	if ('marginY' in style) {
+		node.setMargin(Yoga.EDGE_VERTICAL, style.marginY ?? 0);
+	}
+
 	if ('marginLeft' in style) {
 		node.setMargin(Yoga.EDGE_START, style.marginLeft || 0);
 	}
@@ -199,6 +257,18 @@ const applyMarginStyles = (node: YogaNode, style: Styles): void => {
 };
 
 const applyPaddingStyles = (node: YogaNode, style: Styles): void => {
+	if ('padding' in style) {
+		node.setPadding(Yoga.EDGE_ALL, style.padding ?? 0);
+	}
+
+	if ('paddingX' in style) {
+		node.setPadding(Yoga.EDGE_HORIZONTAL, style.paddingX ?? 0);
+	}
+
+	if ('paddingY' in style) {
+		node.setPadding(Yoga.EDGE_VERTICAL, style.paddingY ?? 0);
+	}
+
 	if ('paddingLeft' in style) {
 		node.setPadding(Yoga.EDGE_LEFT, style.paddingLeft || 0);
 	}
@@ -387,6 +457,10 @@ const applyBorderStyles = (node: YogaNode, style: Styles): void => {
 };
 
 const applyGapStyles = (node: YogaNode, style: Styles): void => {
+	if ('gap' in style) {
+		node.setGap(Yoga.GUTTER_ALL, style.gap ?? 0);
+	}
+
 	if ('columnGap' in style) {
 		node.setGap(Yoga.GUTTER_COLUMN, style.columnGap ?? 0);
 	}


### PR DESCRIPTION
This PR has no effect on the end user of Ink.

What it does is moves out `margin`, `padding` and `gap` props from being generated inside `Box` and into an `applyStyles` function that directly updates styles of a Yoga node.