### PR TITLE
Add top-level `types` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"url": "https://github.com/vadimdemedes"
 	},
 	"type": "module",
+	"types": "./build/index.d.ts",
 	"exports": {
 		"types": "./build/index.d.ts",
 		"default": "./build/index.js"


### PR DESCRIPTION
Typescript doesn't support `exports.types` in `package.json`, yet.
So, I added the supported top-level property.