### PR TITLE
Tailwind-like props for margin and padding

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -459,12 +459,20 @@ Default: `0`
 
 Top padding.
 
+##### pt
+
+Shorthand for `paddingTop`.
+
 ##### paddingBottom
 
 Type: `number`\
 Default: `0`
 
 Bottom padding.
+
+##### pb
+
+Shorthand for `paddingBottom`.
 
 ##### paddingLeft
 
@@ -473,12 +481,20 @@ Default: `0`
 
 Left padding.
 
+##### pl
+
+Shorthand for `paddingLeft`.
+
 ##### paddingRight
 
 Type: `number`\
 Default: `0`
 
 Right padding.
+
+##### pr
+
+Shorthand for `paddingRight`.
 
 ##### paddingX
 
@@ -487,12 +503,20 @@ Default: `0`
 
 Horizontal padding. Equivalent to setting `paddingLeft` and `paddingRight`.
 
+##### px
+
+Shorthand for `paddingX`.
+
 ##### paddingY
 
 Type: `number`\
 Default: `0`
 
 Vertical padding. Equivalent to setting `paddingTop` and `paddingBottom`.
+
+##### py
+
+Shorthand for `paddingY`.
 
 ##### padding
 
@@ -501,14 +525,31 @@ Default: `0`
 
 Padding on all sides. Equivalent to setting `paddingTop`, `paddingBottom`, `paddingLeft` and `paddingRight`.
 
+##### p
+
+Shorthand for `padding`.
+
 ```jsx
 <Box paddingTop={2}>Top</Box>
+<Box pt={2}>Top</Box>
+
 <Box paddingBottom={2}>Bottom</Box>
+<Box pb={2}>Bottom</Box>
+
 <Box paddingLeft={2}>Left</Box>
+<Box pl={2}>Left</Box>
+
 <Box paddingRight={2}>Right</Box>
+<Box pr={2}>Right</Box>
+
 <Box paddingX={2}>Left and right</Box>
+<Box px={2}>Left and right</Box>
+
 <Box paddingY={2}>Top and bottom</Box>
+<Box py={2}>Top and bottom</Box>
+
 <Box padding={2}>Top, bottom, left and right</Box>
+<Box p={2}>Top, bottom, left and right</Box>
 ```
 
 #### Margin
@@ -520,12 +561,20 @@ Default: `0`
 
 Top margin.
 
+##### mt
+
+Shorthand for `marginTop`.
+
 ##### marginBottom
 
 Type: `number`\
 Default: `0`
 
 Bottom margin.
+
+##### mb
+
+Shorthand for `marginBottom`.
 
 ##### marginLeft
 
@@ -534,12 +583,20 @@ Default: `0`
 
 Left margin.
 
+##### ml
+
+Shorthand for `marginLeft`.
+
 ##### marginRight
 
 Type: `number`\
 Default: `0`
 
 Right margin.
+
+##### mr
+
+Shorthand for `marginRight`.
 
 ##### marginX
 
@@ -548,12 +605,20 @@ Default: `0`
 
 Horizontal margin. Equivalent to setting `marginLeft` and `marginRight`.
 
+##### mx
+
+Shorthand for `marginX`.
+
 ##### marginY
 
 Type: `number`\
 Default: `0`
 
 Vertical margin. Equivalent to setting `marginTop` and `marginBottom`.
+
+##### my
+
+Shorthand for `marginY`.
 
 ##### margin
 
@@ -562,14 +627,31 @@ Default: `0`
 
 Margin on all sides. Equivalent to setting `marginTop`, `marginBottom`, `marginLeft` and `marginRight`.
 
+##### m
+
+Shorthand for `margin`.
+
 ```jsx
 <Box marginTop={2}>Top</Box>
+<Box mt={2}>Top</Box>
+
 <Box marginBottom={2}>Bottom</Box>
+<Box mb={2}>Bottom</Box>
+
 <Box marginLeft={2}>Left</Box>
+<Box ml={2}>Left</Box>
+
 <Box marginRight={2}>Right</Box>
+<Box mr={2}>Right</Box>
+
 <Box marginX={2}>Left and right</Box>
+<Box mx={2}>Left and right</Box>
+
 <Box marginY={2}>Top and bottom</Box>
+<Box my={2}>Top and bottom</Box>
+
 <Box margin={2}>Top, bottom, left and right</Box>
+<Box m={2}>Top, bottom, left and right</Box>
 ```
 
 #### Gap

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 import {type Boxes, type BoxStyle} from 'cli-boxes';
 import {type LiteralUnion} from 'type-fest';
 import {type ForegroundColorName} from 'chalk';
@@ -38,9 +37,21 @@ export type Styles = {
 	readonly margin?: number;
 
 	/**
+	 * Margin on all sides.
+	 * Shorthand for `margin`.
+	 */
+	readonly m?: number;
+
+	/**
 	 * Horizontal margin. Equivalent to setting `marginLeft` and `marginRight`.
 	 */
 	readonly marginX?: number;
+
+	/**
+	 * Horizontal margin.
+	 * Shorthand for `marginX`.
+	 */
+	readonly mx?: number;
 
 	/**
 	 * Vertical margin. Equivalent to setting `marginTop` and `marginBottom`.
@@ -48,9 +59,21 @@ export type Styles = {
 	readonly marginY?: number;
 
 	/**
+	 * Vertical margin.
+	 * Shorthand for `marginY`.
+	 */
+	readonly my?: number;
+
+	/**
 	 * Top margin.
 	 */
 	readonly marginTop?: number;
+
+	/**
+	 * Top margin.
+	 * Shorthand for `marginTop`.
+	 */
+	readonly mt?: number;
 
 	/**
 	 * Bottom margin.
@@ -58,9 +81,21 @@ export type Styles = {
 	readonly marginBottom?: number;
 
 	/**
+	 * Bottom margin.
+	 * Shorthand for `marginBottom`.
+	 */
+	readonly mb?: number;
+
+	/**
 	 * Left margin.
 	 */
 	readonly marginLeft?: number;
+
+	/**
+	 * Left margin.
+	 * Shorthand for `marginLeft`.
+	 */
+	readonly ml?: number;
 
 	/**
 	 * Right margin.
@@ -68,9 +103,21 @@ export type Styles = {
 	readonly marginRight?: number;
 
 	/**
+	 * Right margin.
+	 * Shorthand for `marginRight`.
+	 */
+	readonly mr?: number;
+
+	/**
 	 * Padding on all sides. Equivalent to setting `paddingTop`, `paddingBottom`, `paddingLeft` and `paddingRight`.
 	 */
 	readonly padding?: number;
+
+	/**
+	 * Padding on all sides.
+	 * Shorthand for `padding`.
+	 */
+	readonly p?: number;
 
 	/**
 	 * Horizontal padding. Equivalent to setting `paddingLeft` and `paddingRight`.
@@ -78,9 +125,21 @@ export type Styles = {
 	readonly paddingX?: number;
 
 	/**
+	 * Horizontal padding.
+	 * Shorthand for `paddingX`.
+	 */
+	readonly px?: number;
+
+	/**
 	 * Vertical padding. Equivalent to setting `paddingTop` and `paddingBottom`.
 	 */
 	readonly paddingY?: number;
+
+	/**
+	 * Vertical padding.
+	 * Shorthand for `paddingY`.
+	 */
+	readonly py?: number;
 
 	/**
 	 * Top padding.
@@ -88,9 +147,21 @@ export type Styles = {
 	readonly paddingTop?: number;
 
 	/**
+	 * Top padding.
+	 * Shorthand for `paddingTop`.
+	 */
+	readonly pt?: number;
+
+	/**
 	 * Bottom padding.
 	 */
 	readonly paddingBottom?: number;
+
+	/**
+	 * Bottom padding.
+	 * Shorthand for `paddingBottom`.
+	 */
+	readonly pb?: number;
 
 	/**
 	 * Left padding.
@@ -98,9 +169,21 @@ export type Styles = {
 	readonly paddingLeft?: number;
 
 	/**
+	 * Left padding.
+	 * Shorthand for `paddingLeft`.
+	 */
+	readonly pl?: number;
+
+	/**
 	 * Right padding.
 	 */
 	readonly paddingRight?: number;
+
+	/**
+	 * Right padding.
+	 * Shorthand for `paddingRight`.
+	 */
+	readonly pr?: number;
 
 	/**
 	 * This property defines the ability for a flex item to grow if necessary.
@@ -315,62 +398,62 @@ const applyPositionStyles = (node: YogaNode, style: Styles): void => {
 };
 
 const applyMarginStyles = (node: YogaNode, style: Styles): void => {
-	if ('margin' in style) {
-		node.setMargin(Yoga.EDGE_ALL, style.margin ?? 0);
+	if ('margin' in style || 'm' in style) {
+		node.setMargin(Yoga.EDGE_ALL, style.margin ?? style.m ?? 0);
 	}
 
-	if ('marginX' in style) {
-		node.setMargin(Yoga.EDGE_HORIZONTAL, style.marginX ?? 0);
+	if ('marginX' in style || 'mx' in style) {
+		node.setMargin(Yoga.EDGE_HORIZONTAL, style.marginX ?? style.mx ?? 0);
 	}
 
-	if ('marginY' in style) {
-		node.setMargin(Yoga.EDGE_VERTICAL, style.marginY ?? 0);
+	if ('marginY' in style || 'my' in style) {
+		node.setMargin(Yoga.EDGE_VERTICAL, style.marginY ?? style.my ?? 0);
 	}
 
-	if ('marginLeft' in style) {
-		node.setMargin(Yoga.EDGE_START, style.marginLeft || 0);
+	if ('marginLeft' in style || 'ml' in style) {
+		node.setMargin(Yoga.EDGE_START, style.marginLeft ?? style.ml ?? 0);
 	}
 
-	if ('marginRight' in style) {
-		node.setMargin(Yoga.EDGE_END, style.marginRight || 0);
+	if ('marginRight' in style || 'mr' in style) {
+		node.setMargin(Yoga.EDGE_END, style.marginRight ?? style.mr ?? 0);
 	}
 
-	if ('marginTop' in style) {
-		node.setMargin(Yoga.EDGE_TOP, style.marginTop || 0);
+	if ('marginTop' in style || 'mt' in style) {
+		node.setMargin(Yoga.EDGE_TOP, style.marginTop ?? style.mt ?? 0);
 	}
 
-	if ('marginBottom' in style) {
-		node.setMargin(Yoga.EDGE_BOTTOM, style.marginBottom || 0);
+	if ('marginBottom' in style || 'mb' in style) {
+		node.setMargin(Yoga.EDGE_BOTTOM, style.marginBottom ?? style.mb ?? 0);
 	}
 };
 
 const applyPaddingStyles = (node: YogaNode, style: Styles): void => {
-	if ('padding' in style) {
-		node.setPadding(Yoga.EDGE_ALL, style.padding ?? 0);
+	if ('padding' in style || 'p' in style) {
+		node.setPadding(Yoga.EDGE_ALL, style.padding ?? style.p ?? 0);
 	}
 
-	if ('paddingX' in style) {
-		node.setPadding(Yoga.EDGE_HORIZONTAL, style.paddingX ?? 0);
+	if ('paddingX' in style || 'px' in style) {
+		node.setPadding(Yoga.EDGE_HORIZONTAL, style.paddingX ?? style.px ?? 0);
 	}
 
-	if ('paddingY' in style) {
-		node.setPadding(Yoga.EDGE_VERTICAL, style.paddingY ?? 0);
+	if ('paddingY' in style || 'py' in style) {
+		node.setPadding(Yoga.EDGE_VERTICAL, style.paddingY ?? style.py ?? 0);
 	}
 
-	if ('paddingLeft' in style) {
-		node.setPadding(Yoga.EDGE_LEFT, style.paddingLeft || 0);
+	if ('paddingLeft' in style || 'pl' in style) {
+		node.setPadding(Yoga.EDGE_LEFT, style.paddingLeft ?? style.pl ?? 0);
 	}
 
-	if ('paddingRight' in style) {
-		node.setPadding(Yoga.EDGE_RIGHT, style.paddingRight || 0);
+	if ('paddingRight' in style || 'pr' in style) {
+		node.setPadding(Yoga.EDGE_RIGHT, style.paddingRight ?? style.pr ?? 0);
 	}
 
-	if ('paddingTop' in style) {
-		node.setPadding(Yoga.EDGE_TOP, style.paddingTop || 0);
+	if ('paddingTop' in style || 'pt' in style) {
+		node.setPadding(Yoga.EDGE_TOP, style.paddingTop ?? style.pt ?? 0);
 	}
 
-	if ('paddingBottom' in style) {
-		node.setPadding(Yoga.EDGE_BOTTOM, style.paddingBottom || 0);
+	if ('paddingBottom' in style || 'pb' in style) {
+		node.setPadding(Yoga.EDGE_BOTTOM, style.paddingBottom ?? style.pb ?? 0);
 	}
 };
 

--- a/test/margin.tsx
+++ b/test/margin.tsx
@@ -13,10 +13,33 @@ test('margin', t => {
 	t.is(output, '\n\n  X\n\n');
 });
 
+test('margin shorthand', t => {
+	const output = renderToString(
+		<Box m={2}>
+			<Text>X</Text>
+		</Box>
+	);
+
+	t.is(output, '\n\n  X\n\n');
+});
+
 test('margin X', t => {
 	const output = renderToString(
 		<Box>
 			<Box marginX={2}>
+				<Text>X</Text>
+			</Box>
+			<Text>Y</Text>
+		</Box>
+	);
+
+	t.is(output, '  X  Y');
+});
+
+test('margin X shorthand', t => {
+	const output = renderToString(
+		<Box>
+			<Box mx={2}>
 				<Text>X</Text>
 			</Box>
 			<Text>Y</Text>
@@ -36,9 +59,29 @@ test('margin Y', t => {
 	t.is(output, '\n\nX\n\n');
 });
 
+test('margin Y shorthand', t => {
+	const output = renderToString(
+		<Box my={2}>
+			<Text>X</Text>
+		</Box>
+	);
+
+	t.is(output, '\n\nX\n\n');
+});
+
 test('margin top', t => {
 	const output = renderToString(
 		<Box marginTop={2}>
+			<Text>X</Text>
+		</Box>
+	);
+
+	t.is(output, '\n\nX');
+});
+
+test('margin top shorthand', t => {
+	const output = renderToString(
+		<Box mt={2}>
 			<Text>X</Text>
 		</Box>
 	);
@@ -56,9 +99,29 @@ test('margin bottom', t => {
 	t.is(output, 'X\n\n');
 });
 
+test('margin bottom shorthand', t => {
+	const output = renderToString(
+		<Box mb={2}>
+			<Text>X</Text>
+		</Box>
+	);
+
+	t.is(output, 'X\n\n');
+});
+
 test('margin left', t => {
 	const output = renderToString(
 		<Box marginLeft={2}>
+			<Text>X</Text>
+		</Box>
+	);
+
+	t.is(output, '  X');
+});
+
+test('margin left shorthand', t => {
+	const output = renderToString(
+		<Box ml={2}>
 			<Text>X</Text>
 		</Box>
 	);
@@ -70,6 +133,19 @@ test('margin right', t => {
 	const output = renderToString(
 		<Box>
 			<Box marginRight={2}>
+				<Text>X</Text>
+			</Box>
+			<Text>Y</Text>
+		</Box>
+	);
+
+	t.is(output, 'X  Y');
+});
+
+test('margin right shorthand', t => {
+	const output = renderToString(
+		<Box>
+			<Box mr={2}>
 				<Text>X</Text>
 			</Box>
 			<Text>Y</Text>

--- a/test/padding.tsx
+++ b/test/padding.tsx
@@ -13,10 +13,33 @@ test('padding', t => {
 	t.is(output, '\n\n  X\n\n');
 });
 
+test('padding shorthand', t => {
+	const output = renderToString(
+		<Box p={2}>
+			<Text>X</Text>
+		</Box>
+	);
+
+	t.is(output, '\n\n  X\n\n');
+});
+
 test('padding X', t => {
 	const output = renderToString(
 		<Box>
 			<Box paddingX={2}>
+				<Text>X</Text>
+			</Box>
+			<Text>Y</Text>
+		</Box>
+	);
+
+	t.is(output, '  X  Y');
+});
+
+test('padding X shorthand', t => {
+	const output = renderToString(
+		<Box>
+			<Box px={2}>
 				<Text>X</Text>
 			</Box>
 			<Text>Y</Text>
@@ -36,9 +59,29 @@ test('padding Y', t => {
 	t.is(output, '\n\nX\n\n');
 });
 
+test('padding Y shorthand', t => {
+	const output = renderToString(
+		<Box py={2}>
+			<Text>X</Text>
+		</Box>
+	);
+
+	t.is(output, '\n\nX\n\n');
+});
+
 test('padding top', t => {
 	const output = renderToString(
 		<Box paddingTop={2}>
+			<Text>X</Text>
+		</Box>
+	);
+
+	t.is(output, '\n\nX');
+});
+
+test('padding top shorthand', t => {
+	const output = renderToString(
+		<Box pt={2}>
 			<Text>X</Text>
 		</Box>
 	);
@@ -56,9 +99,29 @@ test('padding bottom', t => {
 	t.is(output, 'X\n\n');
 });
 
+test('padding bottom shorthand', t => {
+	const output = renderToString(
+		<Box pb={2}>
+			<Text>X</Text>
+		</Box>
+	);
+
+	t.is(output, 'X\n\n');
+});
+
 test('padding left', t => {
 	const output = renderToString(
 		<Box paddingLeft={2}>
+			<Text>X</Text>
+		</Box>
+	);
+
+	t.is(output, '  X');
+});
+
+test('padding left shorthand', t => {
+	const output = renderToString(
+		<Box pl={2}>
 			<Text>X</Text>
 		</Box>
 	);
@@ -70,6 +133,19 @@ test('padding right', t => {
 	const output = renderToString(
 		<Box>
 			<Box paddingRight={2}>
+				<Text>X</Text>
+			</Box>
+			<Text>Y</Text>
+		</Box>
+	);
+
+	t.is(output, 'X  Y');
+});
+
+test('padding right shorthand', t => {
+	const output = renderToString(
+		<Box>
+			<Box pr={2}>
 				<Text>X</Text>
 			</Box>
 			<Text>Y</Text>


### PR DESCRIPTION
This PR adds shorthand props for margin and padding that are similar to Tailwind:

- `margin` → `m`
- `marginX` → `mx`
- `marginY` → `my`
- `marginTop` → `mt`
- `marginBottom` → `mb`
- `marginLeft` → `ml`
- `marginRight` → `mr`

```jsx
<Box mt={2}>Top</Box>
<Box mb={2}>Bottom</Box>
<Box ml={2}>Left</Box>
<Box mr={2}>Right</Box>
<Box mx={2}>Left and right</Box>
<Box my={2}>Top and bottom</Box>
<Box m={2}>Top, bottom, left and right</Box>
```

- `padding` → `p`
- `paddingX` → `px`
- `paddingY` → `py`
- `paddingTop` → `pt`
- `paddingBottom` → `pb`
- `paddingLeft` → `pl`
- `paddingRight` → `pr`

```jsx
<Box pt={2}>Top</Box>
<Box pb={2}>Bottom</Box>
<Box pl={2}>Left</Box>
<Box pr={2}>Right</Box>
<Box px={2}>Left and right</Box>
<Box py={2}>Top and bottom</Box>
<Box p={2}>Top, bottom, left and right</Box>
```

I think margin and padding-related props are among the most used ones and these shorthands should make it more convenient to use them.