### PR TITLE
Fix rendering when terminal is erased on first render

### DIFF
--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -175,8 +175,10 @@ export default class Ink {
 
 		if (outputHeight >= this.options.stdout.rows) {
 			this.options.stdout.write(
-				ansiEscapes.clearTerminal + this.fullStaticOutput + output
+				ansiEscapes.clearTerminal + this.fullStaticOutput
 			);
+
+			this.log(output, {force: true, erase: false});
 			this.lastOutput = output;
 			return;
 		}

--- a/src/log-update.ts
+++ b/src/log-update.ts
@@ -5,7 +5,7 @@ import cliCursor from 'cli-cursor';
 export type LogUpdate = {
 	clear: () => void;
 	done: () => void;
-	(str: string): void;
+	(str: string, options?: {force?: boolean; erase?: boolean}): void;
 };
 
 const create = (stream: Writable, {showCursor = false} = {}): LogUpdate => {
@@ -13,19 +13,25 @@ const create = (stream: Writable, {showCursor = false} = {}): LogUpdate => {
 	let previousOutput = '';
 	let hasHiddenCursor = false;
 
-	const render = (str: string) => {
+	const render = (
+		str: string,
+		{force = false, erase = true}: {force?: boolean; erase?: boolean} = {}
+	) => {
 		if (!showCursor && !hasHiddenCursor) {
 			cliCursor.hide();
 			hasHiddenCursor = true;
 		}
 
 		const output = str + '\n';
-		if (output === previousOutput) {
+		if (output === previousOutput && !force) {
 			return;
 		}
 
 		previousOutput = output;
-		stream.write(ansiEscapes.eraseLines(previousLineCount) + output);
+
+		const eraser = erase ? ansiEscapes.eraseLines(previousLineCount) : '';
+		stream.write(eraser + output);
+
 		previousLineCount = output.split('\n').length;
 	};
 

--- a/test/fixtures/erase-once-with-static.tsx
+++ b/test/fixtures/erase-once-with-static.tsx
@@ -1,0 +1,33 @@
+import process from 'node:process';
+import React, {useState} from 'react';
+import {Box, Static, Text, render, useInput} from '../../src/index.js';
+
+function Test() {
+	const [fullHeight, setFullHeight] = useState(true);
+
+	useInput(
+		input => {
+			if (input === 'x') {
+				setFullHeight(false);
+			}
+		},
+		{isActive: fullHeight}
+	);
+
+	return (
+		<>
+			<Static items={['X', 'Y', 'Z']}>
+				{item => <Text key={item}>{item}</Text>}
+			</Static>
+
+			<Box flexDirection="column">
+				<Text>A</Text>
+				<Text>B</Text>
+				{fullHeight && <Text>C</Text>}
+			</Box>
+		</>
+	);
+}
+
+process.stdout.rows = Number(process.argv[2]);
+render(<Test />);

--- a/test/fixtures/erase-once-with-static.tsx
+++ b/test/fixtures/erase-once-with-static.tsx
@@ -1,4 +1,3 @@
-import process from 'node:process';
 import React, {useState} from 'react';
 import {Box, Static, Text, render, useInput} from '../../src/index.js';
 
@@ -29,5 +28,4 @@ function Test() {
 	);
 }
 
-process.stdout.rows = Number(process.argv[2]);
 render(<Test />);

--- a/test/fixtures/erase-once.tsx
+++ b/test/fixtures/erase-once.tsx
@@ -1,4 +1,3 @@
-import process from 'node:process';
 import React, {useState} from 'react';
 import {Box, Text, render, useInput} from '../../src/index.js';
 
@@ -23,5 +22,4 @@ function Test() {
 	);
 }
 
-process.stdout.rows = Number(process.argv[2]);
 render(<Test />);

--- a/test/fixtures/erase-once.tsx
+++ b/test/fixtures/erase-once.tsx
@@ -1,0 +1,27 @@
+import process from 'node:process';
+import React, {useState} from 'react';
+import {Box, Text, render, useInput} from '../../src/index.js';
+
+function Test() {
+	const [fullHeight, setFullHeight] = useState(true);
+
+	useInput(
+		input => {
+			if (input === 'x') {
+				setFullHeight(false);
+			}
+		},
+		{isActive: fullHeight}
+	);
+
+	return (
+		<Box flexDirection="column">
+			<Text>A</Text>
+			<Text>B</Text>
+			{fullHeight && <Text>C</Text>}
+		</Box>
+	);
+}
+
+process.stdout.rows = Number(process.argv[2]);
+render(<Test />);

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -106,6 +106,54 @@ test.serial('erase screen', async t => {
 	}
 });
 
+test.serial('erase screen once then continue rendering as usual', async t => {
+	const ps = term('erase-once', ['3']);
+	await delay(1000);
+
+	t.true(ps.output.includes(ansiEscapes.clearTerminal));
+	t.true(ps.output.includes('A'));
+	t.true(ps.output.includes('B'));
+	t.true(ps.output.includes('C'));
+
+	ps.output = '';
+	ps.write('x');
+
+	await ps.waitForExit();
+
+	t.false(ps.output.includes(ansiEscapes.clearTerminal));
+	t.true(ps.output.includes(ansiEscapes.eraseLines(3)));
+	t.true(ps.output.includes('A'));
+	t.true(ps.output.includes('B'));
+	t.false(ps.output.includes('C'));
+});
+
+test.serial(
+	'erase screen once then continue rendering as usual with <Static> present',
+	async t => {
+		const ps = term('erase-once-with-static', ['3']);
+		await delay(1000);
+
+		t.true(ps.output.includes(ansiEscapes.clearTerminal));
+		t.true(ps.output.includes('X'));
+		t.true(ps.output.includes('Y'));
+		t.true(ps.output.includes('Z'));
+		t.true(ps.output.includes('A'));
+		t.true(ps.output.includes('B'));
+		t.true(ps.output.includes('C'));
+
+		ps.output = '';
+		ps.write('x');
+
+		await ps.waitForExit();
+
+		t.false(ps.output.includes(ansiEscapes.clearTerminal));
+		t.true(ps.output.includes(ansiEscapes.eraseLines(2)));
+		t.true(ps.output.includes('A'));
+		t.true(ps.output.includes('B'));
+		t.false(ps.output.includes('C'));
+	}
+);
+
 test.serial(
 	'erase screen where <Static> exists but interactive part is taller than viewport',
 	async t => {

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -18,7 +18,11 @@ const {spawn} = require('node-pty') as typeof import('node-pty');
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
-const term = (fixture: string, args: string[] = []) => {
+const term = (
+	fixture: string,
+	args: string[] = [],
+	{rows}: {rows?: number} = {}
+) => {
 	let resolve: (value?: unknown) => void;
 	let reject: (error: Error) => void;
 
@@ -43,6 +47,7 @@ const term = (fixture: string, args: string[] = []) => {
 		{
 			name: 'xterm-color',
 			cols: 100,
+			rows,
 			cwd: __dirname,
 			env
 		}
@@ -107,7 +112,7 @@ test.serial('erase screen', async t => {
 });
 
 test.serial('erase screen once then continue rendering as usual', async t => {
-	const ps = term('erase-once', ['3']);
+	const ps = term('erase-once', [], {rows: 3});
 	await delay(1000);
 
 	t.true(ps.output.includes(ansiEscapes.clearTerminal));
@@ -130,7 +135,7 @@ test.serial('erase screen once then continue rendering as usual', async t => {
 test.serial(
 	'erase screen once then continue rendering as usual with <Static> present',
 	async t => {
-		const ps = term('erase-once-with-static', ['3']);
+		const ps = term('erase-once-with-static', [], {rows: 3});
 		await delay(1000);
 
 		t.true(ps.output.includes(ansiEscapes.clearTerminal));


### PR DESCRIPTION
Fixes https://github.com/vadimdemedes/ink/issues/585.

@matteodepalo did a great job documenting the issue, so I'm not going to repeat it here.

## Context

Ink has two ways of rendering output, depending how tall it is:

1. If output is shorter than terminal height, Ink erases the lines from last output and writes lines from the new output. Ink tracks how many lines did the last output have for this to work. This is handled in https://github.com/vadimdemedes/ink/blob/master/src/log-update.ts, which is a fork of [`log-update`](https://github.com/sindresorhus/log-update) package.

2. If output is equal or taller than terminal height, Ink erases the entire terminal history (or scrollback as it's commonly referred to) and writes new output. Note that Ink doesn't need to track how many lines to erase here, because it just erases the entire contents of the current terminal.
 https://github.com/vadimdemedes/ink/blob/8a0476024cf997e0dbc02e493ad3972349b02474/src/ink.tsx#L176-L182

## Root cause

The key insight here is this:

> Note that Ink doesn't need to track how many lines to erase here, because it just erases the entire contents of the current terminal.

In https://github.com/vadimdemedes/ink/issues/585, the very first render starts with the second rendering method and erases the terminal completely. On next render, the first method kicks in, but there's no information how many lines to erase, since second method doesn't store that information.

That's why the output from the first render doesn't get erased, since for `logUpdate` this variable is zero.

https://github.com/vadimdemedes/ink/blob/8a0476024cf997e0dbc02e493ad3972349b02474/src/log-update.ts#L12

## Solution

This PR fixes this bug by separating the write operation that erases the terminal and writes the output. This way, even if the entire terminal is erased, `logUpdate` is still used to render the output and keep track of how many lines were written.

I've also added `force` option to `logUpdate` render function to force it to always render the string we give to it without bailing out if it equals to the last output. This can happen when [`Static`](https://github.com/vadimdemedes/ink#static) output changes, but normal output isn't.

https://github.com/vadimdemedes/ink/blob/8a0476024cf997e0dbc02e493ad3972349b02474/src/log-update.ts#L23-L25

I've also added `erase` option to `logUpdate` render function, so that we can tell it to not do erasing of its own, if we erased the entire terminal already.