### PR TITLE
Fix devtools import in production

### DIFF
--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -95,7 +95,7 @@ export default class Ink {
 		// Unmount when process exits
 		this.unsubscribeExit = signalExit(this.unmount, {alwaysLast: false});
 
-		if (process.env['DEV'] === 'true') {
+		if (process.env['NODE_ENV'] === 'development') {
 			reconciler.injectIntoDevTools({
 				bundleType: 0,
 				// Reporting React DOM's version, not Ink's

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -23,7 +23,7 @@ import {type OutputTransformer} from './render-node-to-output.js';
 // We need to conditionally perform devtools connection to avoid
 // accidentally breaking other third-party code.
 // See https://github.com/vadimdemedes/ink/issues/384
-if (process.env['DEV'] === 'true') {
+if (process.env['NODE_ENV'] === 'development') {
 	try {
 		await import('./devtools.js');
 		// eslint-disable-next-line @typescript-eslint/no-implicit-any-catch


### PR DESCRIPTION
webpack bundler sets the `process.env.NODE_ENV` to `production` when `mode` is set to `production` in webpack config file. My aim with this commit is to skip devtools injection and import in production mode.