### PR TITLE
remove tscrypt error when working within IDE

### DIFF
--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"extends": "../tsconfig"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "@sindresorhus/tsconfig",
 	"compilerOptions": {
+		"esModuleInterop": true,
 		"moduleResolution": "node16",
 		"module": "node16",
 		"outDir": "build",


### PR DESCRIPTION
eliminated annoying ts configuration mismatch, which produces red marks working with examples inside IDE
I'm not sure how it could affect on the other parts of project but to me look all good.
See https://stackoverflow.com/questions/62273153/this-module-is-declared-with-using-export-and-can-only-be-used-with-a-defau where I got a solution -)