### PR TITLE
Examples eliminate ts warnings

### DIFF
--- a/examples/jest/jest.tsx
+++ b/examples/jest/jest.tsx
@@ -32,7 +32,7 @@ type State = {
 };
 
 class Jest extends React.Component<Record<string, unknown>, State> {
-	constructor(props) {
+	constructor(props: any) {
 		super(props);
 
 		this.state = {
@@ -42,7 +42,7 @@ class Jest extends React.Component<Record<string, unknown>, State> {
 		};
 	}
 
-	render() {
+	override render() {
 		const {startTime, completedTests, runningTests} = this.state;
 
 		return (
@@ -71,7 +71,7 @@ class Jest extends React.Component<Record<string, unknown>, State> {
 		);
 	}
 
-	componentDidMount() {
+	override componentDidMount() {
 		const queue = new PQueue({concurrency: 4});
 
 		for (const path of paths) {

--- a/examples/static/static.tsx
+++ b/examples/static/static.tsx
@@ -11,7 +11,7 @@ function Example() {
 
 	React.useEffect(() => {
 		let completedTests = 0;
-		let timer;
+		let timer: string | number | NodeJS.Timeout | undefined; //any?
 
 		const run = () => {
 			if (completedTests++ < 10) {
@@ -23,7 +23,7 @@ function Example() {
 					}
 				]);
 
-				timer = setTimeout(run, 100);
+				timer = setTimeout(run, 500);
 			}
 		};
 

--- a/examples/subprocess-output/subprocess-output.tsx
+++ b/examples/subprocess-output/subprocess-output.tsx
@@ -1,5 +1,5 @@
 import childProcess from 'node:child_process';
-import type Buffer from 'node:buffer';
+// import type Buffer from 'node:buffer';
 import React from 'react';
 import stripAnsi from 'strip-ansi';
 import {render, Text, Box} from '../../src/index.js';
@@ -22,7 +22,7 @@ function SubprocessOutput() {
 
 	return (
 		<Box flexDirection="column" padding={1}>
-			<Text>Сommand output:</Text>
+			<Text>Command output:</Text>
 			<Box marginTop={1}>
 				<Text>{output}</Text>
 			</Box>

--- a/examples/suspense/suspense.tsx
+++ b/examples/suspense/suspense.tsx
@@ -8,7 +8,7 @@ let value: string | undefined;
 const read = () => {
 	if (!promise) {
 		promise = new Promise(resolve => {
-			setTimeout(resolve, 500);
+			setTimeout(resolve, 2500);
 		});
 
 		state = 'pending';
@@ -27,6 +27,7 @@ const read = () => {
 	if (state === 'done') {
 		return value;
 	}
+	return undefined;
 };
 
 function Example() {

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"extends": "../tsconfig"
+}

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,3 +1,4 @@
 {
-	"extends": "../tsconfig"
+	"extends": "../tsconfig",
+	"jsx": "react"
 }

--- a/examples/use-focus-with-id/use-focus-with-id.tsx
+++ b/examples/use-focus-with-id/use-focus-with-id.tsx
@@ -41,7 +41,7 @@ function Focus() {
 }
 
 type ItemProps = {
-	id: number;
+	id?: string;
 	label: string;
 };
 

--- a/examples/use-focus/use-focus.tsx
+++ b/examples/use-focus/use-focus.tsx
@@ -17,7 +17,7 @@ function Focus() {
 	);
 }
 
-function Item({label}) {
+function Item({label}: {label: string}) {
 	const {isFocused} = useFocus();
 	return (
 		<Text>


### PR DESCRIPTION
Maybe more intelligent way to discard all ts errors in the example. Additionally minor changes to code and increasing timeouts to more convenient watching