### PR TITLE
Use stdin `readable` event instead of `data`

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,3 +1,4 @@
+import {EventEmitter} from 'node:events';
 import process from 'node:process';
 import React, {PureComponent, type ReactNode} from 'react';
 import cliCursor from 'cli-cursor';
@@ -55,6 +56,8 @@ export default class App extends PureComponent<Props, State> {
 	// Count how many components enabled raw mode to avoid disabling
 	// raw mode until all components don't need it anymore
 	rawModeEnabledCount = 0;
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	internal_eventEmitter = new EventEmitter();
 
 	// Determines if TTY is supported on the provided stdin
 	isRawModeSupported(): boolean {
@@ -76,7 +79,9 @@ export default class App extends PureComponent<Props, State> {
 						setRawMode: this.handleSetRawMode,
 						isRawModeSupported: this.isRawModeSupported(),
 						// eslint-disable-next-line @typescript-eslint/naming-convention
-						internal_exitOnCtrlC: this.props.exitOnCtrlC
+						internal_exitOnCtrlC: this.props.exitOnCtrlC,
+						// eslint-disable-next-line @typescript-eslint/naming-convention
+						internal_eventEmitter: this.internal_eventEmitter
 					}}
 				>
 					<StdoutContext.Provider
@@ -179,6 +184,7 @@ export default class App extends PureComponent<Props, State> {
 		// eslint-disable-next-line @typescript-eslint/ban-types
 		while ((chunk = this.props.stdin.read() as string | null) !== null) {
 			this.handleInput(chunk);
+			this.internal_eventEmitter.emit('input', chunk);
 		}
 	};
 

--- a/src/components/StdinContext.ts
+++ b/src/components/StdinContext.ts
@@ -1,3 +1,4 @@
+import {EventEmitter} from 'node:events';
 import process from 'node:process';
 import {createContext} from 'react';
 
@@ -19,6 +20,8 @@ export type Props = {
 	readonly isRawModeSupported: boolean;
 
 	readonly internal_exitOnCtrlC: boolean;
+
+	readonly internal_eventEmitter: EventEmitter;
 };
 
 /**
@@ -27,6 +30,8 @@ export type Props = {
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const StdinContext = createContext<Props>({
 	stdin: process.stdin,
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	internal_eventEmitter: new EventEmitter(),
 	setRawMode() {},
 	isRawModeSupported: false,
 	// eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/hooks/use-input.ts
+++ b/src/hooks/use-input.ts
@@ -117,7 +117,8 @@ type Options = {
  */
 const useInput = (inputHandler: Handler, options: Options = {}) => {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
-	const {stdin, setRawMode, internal_exitOnCtrlC} = useStdin();
+	const {stdin, setRawMode, internal_exitOnCtrlC, internal_eventEmitter} =
+		useStdin();
 
 	useEffect(() => {
 		if (options.isActive === false) {
@@ -189,10 +190,10 @@ const useInput = (inputHandler: Handler, options: Options = {}) => {
 			}
 		};
 
-		stdin?.on('data', handleData);
+		internal_eventEmitter?.on('input', handleData);
 
 		return () => {
-			stdin?.off('data', handleData);
+			internal_eventEmitter?.removeListener('input', handleData);
 		};
 	}, [options.isActive, stdin, internal_exitOnCtrlC, inputHandler]);
 };

--- a/src/hooks/use-input.ts
+++ b/src/hooks/use-input.ts
@@ -1,4 +1,3 @@
-import {type Buffer} from 'node:buffer';
 import {useEffect} from 'react';
 import {isUpperCase} from 'is-upper-case';
 import parseKeypress, {nonAlphanumericKeys} from '../parse-keypress.js';
@@ -137,7 +136,7 @@ const useInput = (inputHandler: Handler, options: Options = {}) => {
 			return;
 		}
 
-		const handleData = (data: Buffer) => {
+		const handleData = (data: string) => {
 			const keypress = parseKeypress(data);
 
 			const key = {

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -423,8 +423,6 @@ test('disable raw mode when all input components are unmounted', t => {
 	stdin.setEncoding = () => {};
 	stdin.setRawMode = spy();
 	stdin.isTTY = true; // Without this, setRawMode will throw
-	stdin.resume = spy();
-	stdin.pause = spy();
 
 	const options = {
 		stdout,
@@ -471,21 +469,15 @@ test('disable raw mode when all input components are unmounted', t => {
 
 	t.true(stdin.setRawMode.calledOnce);
 	t.deepEqual(stdin.setRawMode.firstCall.args, [true]);
-	t.true(stdin.resume.calledOnce);
-	t.false(stdin.pause.called);
 
 	rerender(<Test renderFirstInput />);
 
 	t.true(stdin.setRawMode.calledOnce);
-	t.true(stdin.resume.calledOnce);
-	t.false(stdin.pause.called);
 
 	rerender(<Test />);
 
 	t.true(stdin.setRawMode.calledTwice);
 	t.deepEqual(stdin.setRawMode.lastCall.args, [false]);
-	t.true(stdin.resume.calledOnce);
-	t.true(stdin.pause.calledOnce);
 });
 
 test('setRawMode() should throw if raw mode is not supported', t => {
@@ -495,8 +487,6 @@ test('setRawMode() should throw if raw mode is not supported', t => {
 	stdin.setEncoding = () => {};
 	stdin.setRawMode = spy();
 	stdin.isTTY = false;
-	stdin.resume = spy();
-	stdin.pause = spy();
 
 	const didCatchInMount = spy();
 	const didCatchInUnmount = spy();
@@ -540,8 +530,6 @@ test('setRawMode() should throw if raw mode is not supported', t => {
 	t.is(didCatchInMount.callCount, 1);
 	t.is(didCatchInUnmount.callCount, 1);
 	t.false(stdin.setRawMode.called);
-	t.false(stdin.resume.called);
-	t.false(stdin.pause.called);
 });
 
 test('render different component based on whether stdin is a TTY or not', t => {
@@ -551,8 +539,6 @@ test('render different component based on whether stdin is a TTY or not', t => {
 	stdin.setEncoding = () => {};
 	stdin.setRawMode = spy();
 	stdin.isTTY = false;
-	stdin.resume = spy();
-	stdin.pause = spy();
 
 	const options = {
 		stdout,
@@ -602,20 +588,14 @@ test('render different component based on whether stdin is a TTY or not', t => {
 	);
 
 	t.false(stdin.setRawMode.called);
-	t.false(stdin.resume.called);
-	t.false(stdin.pause.called);
 
 	rerender(<Test renderFirstInput />);
 
 	t.false(stdin.setRawMode.called);
-	t.false(stdin.resume.called);
-	t.false(stdin.pause.called);
 
 	rerender(<Test />);
 
 	t.false(stdin.setRawMode.called);
-	t.false(stdin.resume.called);
-	t.false(stdin.pause.called);
 });
 
 test('render only last frame when run in CI', async t => {


### PR DESCRIPTION
By doing testing of the Shopify CLI on Windows we found that `stdin` could get in a broken (paused) state if `pause` and `resume` were called in rapid succession by mounting and unmounting components that use `useInput`. Not all components would do this which leads me to believe it's a timing issue.

Here's a video showcasing one of our text prompts getting into this broken state.

https://github.com/vadimdemedes/ink/assets/151725/3b422178-e159-4119-854a-eb4ba25ab417

I've tracked down the issue and it seems like removing `pause` and `resume` and switching to the `readable` event fixes things. I don't think this project needs to keep supporting node <10 right? If so, this change should create no backwards compatibility issues.