### PR TITLE
Update `ansi-tokenize` dependency to be compatible with Node.js v14.x again

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"text"
 	],
 	"dependencies": {
-		"@alcalzone/ansi-tokenize": "^0.1.1",
+		"@alcalzone/ansi-tokenize": "^0.1.2",
 		"ansi-escapes": "^6.0.0",
 		"auto-bind": "^5.0.1",
 		"chalk": "^5.2.0",


### PR DESCRIPTION
Fixes https://github.com/vadimdemedes/ink/issues/617