### PR TITLE
Fix inability to read user input after app exit

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -163,6 +163,7 @@ export default class App extends PureComponent<Props, State> {
 		if (isEnabled) {
 			// Ensure raw mode is enabled only once
 			if (this.rawModeEnabledCount === 0) {
+				stdin.ref();
 				stdin.setRawMode(true);
 				stdin.addListener('readable', this.handleReadable);
 			}

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -448,6 +448,8 @@ test('disable raw mode when all input components are unmounted', t => {
 	stdin.setEncoding = () => {};
 	stdin.setRawMode = spy();
 	stdin.isTTY = true; // Without this, setRawMode will throw
+	stdin.ref = spy();
+	stdin.unref = spy();
 
 	const options = {
 		stdout,
@@ -493,15 +495,20 @@ test('disable raw mode when all input components are unmounted', t => {
 	);
 
 	t.true(stdin.setRawMode.calledOnce);
+	t.true(stdin.ref.calledOnce);
 	t.deepEqual(stdin.setRawMode.firstCall.args, [true]);
 
 	rerender(<Test renderFirstInput />);
 
 	t.true(stdin.setRawMode.calledOnce);
+	t.true(stdin.ref.calledOnce);
+	t.true(stdin.unref.notCalled);
 
 	rerender(<Test />);
 
 	t.true(stdin.setRawMode.calledTwice);
+	t.true(stdin.ref.calledOnce);
+	t.true(stdin.unref.calledOnce);
 	t.deepEqual(stdin.setRawMode.lastCall.args, [false]);
 });
 

--- a/test/focus.tsx
+++ b/test/focus.tsx
@@ -13,6 +13,7 @@ const createStdin = () => {
 	stdin.setEncoding = () => {};
 	stdin.read = stub();
 	stdin.unref = () => {};
+	stdin.ref = () => {};
 
 	return stdin;
 };


### PR DESCRIPTION
There is a bug I introduced with https://github.com/vadimdemedes/ink/pull/616

If someone invokes `render` once with a component that uses `useInput`, then everything works fine (and that's why tests are passing).
If instead you invoke `render`, wait for Ink to exit and then later in the execution you invoke it again with the same component, then node just quits because `stdin` has been dereferenced in the previous call to `render`.

With this PR I add a call to `ref` so that when the second call happens node stays up.