### PR TITLE
Fix broken link escapes

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"text"
 	],
 	"dependencies": {
-		"@alcalzone/ansi-tokenize": "^0.1.2",
+		"@alcalzone/ansi-tokenize": "^0.1.3",
 		"ansi-escapes": "^6.0.0",
 		"auto-bind": "^5.0.1",
 		"chalk": "^5.2.0",

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -722,10 +722,10 @@ test('vertical spacer', t => {
 	t.is(output, 'Top\n\n\n\n\nBottom');
 });
 
-test('ansi escapes are closed properly', t => {
+test('link ansi escapes are closed properly', t => {
 	const output = renderToString(
 		<Text>{ansiEscapes.link('Example', 'https://example.com')}</Text>
 	);
 
-	t.is(output, '"]8;;https://example.comExample]8;;"');
+	t.is(output, ']8;;https://example.comExample]8;;');
 });

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -3,6 +3,7 @@ import test from 'ava';
 import chalk from 'chalk';
 import React, {Component, useState} from 'react';
 import {spy} from 'sinon';
+import ansiEscapes from 'ansi-escapes';
 import {
 	Box,
 	Newline,
@@ -719,4 +720,12 @@ test('vertical spacer', t => {
 	);
 
 	t.is(output, 'Top\n\n\n\n\nBottom');
+});
+
+test('ansi escapes are closed properly', t => {
+	const output = renderToString(
+		<Text>{ansiEscapes.link('Example', 'https://example.com')}</Text>
+	);
+
+	t.is(output, '"]8;;https://example.comExample]8;;"');
 });


### PR DESCRIPTION
A bug has been introduced with the work done [here](https://github.com/vadimdemedes/ink/pull/564) and it relates to the tokenization of ansi escape characters. We noticed it with `ansiEscapes.link` and I added a test case in this repo which now fails. 

@AlCalzone I don't know enough about your `ansi-tokenize` project, but could this be fixed there?

Here's a screenshot of the failing test:

<img width="387" alt="Screenshot 2023-09-07 at 11 25 04" src="https://github.com/vadimdemedes/ink/assets/151725/beb46aad-b211-4839-bc8f-8304346d4e0a">

You can see from the screenshot that the link escape is not being closed properly so the link "leaks" in all the text after that.