### PR TITLE
Remove Project Wallace from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,7 +100,6 @@ Feel free to play around with the code and fork this repl at [https://repl.it/@v
 - [Twilio's SIGNAL](https://github.com/twilio-labs/plugin-signal2020) - CLI for Twilio's SIGNAL conference. [Blog post](https://www.twilio.com/blog/building-conference-cli-in-react).
 - [Typewriter](https://github.com/segmentio/typewriter) - Generates strongly-typed [Segment](https://segment.com) analytics clients from arbitrary JSON Schema.
 - [Prisma](https://www.prisma.io) - The unified data layer for modern applications.
-- [Wallace](https://www.projectwallace.com) - Pretty CSS analytics.
 - [Blitz](https://blitzjs.com) - The Fullstack React Framework.
 - [New York Times](https://github.com/nytimes/kyt) - NYT uses Ink `kyt` - a toolkit that encapsulates and manages the configuration for web apps.
 - [tink](https://github.com/npm/tink) - Next-generation runtime and package manager.


### PR DESCRIPTION
Wallace CLI v3 was built from the ground up and no longer uses an external library to render some basic boxes, so it's time to say goodbye 😅

Thank you so much for this library and for the early opportunity to use it and giving Wallace a platform by showcasing it for many years in this readme. According to my analytics we've received 500+ visitors over the last years by this single line in the readme alone 🥰

![Fathom Analytics dashboard](https://github.com/vadimdemedes/ink/assets/1536852/d9f2ac49-c1f5-4807-8cd6-7098cb053d08)

This partially reverts 206f0b7c932ef7d48339f1d7abe9d53d4f1d1493 from September 2019 ;)
