### PR TITLE
fix: only focus active elements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1858,7 +1858,7 @@ const Example = () => {
 
 Switch focus to the next focusable component.
 If there's no active component right now, focus will be given to the first focusable component.
-If active component is the last in the list of focusable components, focus will be switched to the first component.
+If active component is the last in the list of focusable components, focus will be switched to the first focusable component.
 
 **Note:** Ink calls this method when user presses <kbd>Tab</kbd>.
 

--- a/readme.md
+++ b/readme.md
@@ -1858,7 +1858,7 @@ const Example = () => {
 
 Switch focus to the next focusable component.
 If there's no active component right now, focus will be given to the first focusable component.
-If active component is the last in the list of focusable components, focus will be switched to the first focusable component.
+If active component is the last in the list of focusable components, focus will be switched to the first active component.
 
 **Note:** Ink calls this method when user presses <kbd>Tab</kbd>.
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -250,7 +250,9 @@ export default class App extends PureComponent<Props, State> {
 
 	focusNext = (): void => {
 		this.setState(previousState => {
-			const firstFocusableId = previousState.focusables[0]?.id;
+			const firstFocusableId = previousState.focusables.find(
+				focusable => focusable.isActive
+			)?.id;
 			const nextFocusableId = this.findNextFocusable(previousState);
 
 			return {
@@ -261,8 +263,9 @@ export default class App extends PureComponent<Props, State> {
 
 	focusPrevious = (): void => {
 		this.setState(previousState => {
-			const lastFocusableId = previousState.focusables.at(-1)?.id;
-
+			const lastFocusableId = previousState.focusables.findLast(
+				(focusable) => focusable.isActive
+			)?.id;
 			const previousFocusableId = this.findPreviousFocusable(previousState);
 
 			return {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -264,7 +264,7 @@ export default class App extends PureComponent<Props, State> {
 	focusPrevious = (): void => {
 		this.setState(previousState => {
 			const lastFocusableId = previousState.focusables.findLast(
-				(focusable) => focusable.isActive
+				focusable => focusable.isActive
 			)?.id;
 			const previousFocusableId = this.findPreviousFocusable(previousState);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
 		"outDir": "build",
 		"sourceMap": true,
 		"jsx": "react",
-		"isolatedModules": true
+		"isolatedModules": true,
+		"lib": ["ES2023"]
 	},
 	"include": ["src"],
 	"ts-node": {


### PR DESCRIPTION
When wrapping around at the beginning or end of the list of components, we should search respectively for the last or first _active_ component.

I didn't use `Array.prototype.findLast` because the `tsconfig` doesn't support it and it was simple enough to write a loop.