### PR TITLE
Render last frame only when there is no output TTY

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -22,6 +22,7 @@ type Props = {
 	readonly writeToStderr: (data: string) => void;
 	readonly exitOnCtrlC: boolean;
 	readonly onExit: (error?: Error) => void;
+	readonly debug: boolean;
 };
 
 type State = {
@@ -127,11 +128,15 @@ export default class App extends PureComponent<Props, State> {
 	}
 
 	override componentDidMount() {
-		cliCursor.hide(this.props.stdout);
+		if (!this.props.debug) {
+			cliCursor.hide(this.props.stdout);
+		}
 	}
 
 	override componentWillUnmount() {
-		cliCursor.show(this.props.stdout);
+		if (!this.props.debug) {
+			cliCursor.show(this.props.stdout);
+		}
 
 		// ignore calling setRawMode on an handle stdin it cannot be called
 		if (this.isRawModeSupported()) {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -22,7 +22,7 @@ type Props = {
 	readonly writeToStderr: (data: string) => void;
 	readonly exitOnCtrlC: boolean;
 	readonly onExit: (error?: Error) => void;
-	readonly debug: boolean;
+	readonly hasCursor: boolean;
 };
 
 type State = {
@@ -128,13 +128,13 @@ export default class App extends PureComponent<Props, State> {
 	}
 
 	override componentDidMount() {
-		if (!this.props.debug) {
+		if (this.props.hasCursor) {
 			cliCursor.hide(this.props.stdout);
 		}
 	}
 
 	override componentWillUnmount() {
-		if (!this.props.debug) {
+		if (this.props.hasCursor) {
 			cliCursor.show(this.props.stdout);
 		}
 

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -209,6 +209,7 @@ export default class Ink {
 				writeToStdout={this.writeToStdout}
 				writeToStderr={this.writeToStderr}
 				exitOnCtrlC={this.options.exitOnCtrlC}
+				debug={this.options.debug}
 				onExit={this.unmount}
 			>
 				{node}

--- a/src/render.ts
+++ b/src/render.ts
@@ -41,6 +41,13 @@ export type RenderOptions = {
 	 * @default true
 	 */
 	patchConsole?: boolean;
+
+	/**
+	 * Configure whether Ink should only render the last frame of non-static output. Useful when ANSI erase codes are not supported.
+	 *
+	 * @default true if in CI or stdout is not a TTY
+	 */
+	renderLastFrameOnly?: boolean;
 };
 
 export type Instance = {

--- a/test/errors.tsx
+++ b/test/errors.tsx
@@ -22,7 +22,10 @@ test('catch and display error', t => {
 		throw new Error('Oh no');
 	};
 
-	render(<Test />, {stdout});
+	render(<Test />, {
+		stdout,
+		debug: true,
+	});
 
 	t.deepEqual(
 		stripAnsi((stdout.write as any).lastCall.args[0] as string)
@@ -40,7 +43,7 @@ test('catch and display error', t => {
 			" 22:     throw new Error('Oh no');",
 			' 23:   };',
 			' 24:',
-			' 25:   render(<Test />, {stdout});',
+			' 25:   render(<Test />, {',
 			'',
 			' - Test (test/errors.tsx:22:9)',
 		],

--- a/test/helpers/create-stdout.ts
+++ b/test/helpers/create-stdout.ts
@@ -12,6 +12,7 @@ const createStdout = (columns?: number): FakeStdout => {
 
 	const write = spy();
 	stdout.write = write;
+	stdout.isTTY = true;
 
 	stdout.get = () => write.lastCall.args[0] as string;
 

--- a/test/helpers/create-stdout.ts
+++ b/test/helpers/create-stdout.ts
@@ -6,13 +6,13 @@ type FakeStdout = {
 	get: () => string;
 } & NodeJS.WriteStream;
 
-const createStdout = (columns?: number): FakeStdout => {
+const createStdout = (columns?: number, isTTY?: boolean): FakeStdout => {
 	const stdout = new EventEmitter() as unknown as FakeStdout;
 	stdout.columns = columns ?? 100;
 
 	const write = spy();
 	stdout.write = write;
-	stdout.isTTY = true;
+	stdout.isTTY = isTTY ?? true;
 
 	stdout.get = () => write.lastCall.args[0] as string;
 


### PR DESCRIPTION
Fixes #667

Mirror existing CI behavior when there is no output TTY. This will enable the output of ink-based CLIs to gracefully pipe into other processes, such as pagers like `more` and `less`.

Also provides control over this behavior for CLIs which wish to support piping into processes that support ANSI deletion escapes.

## Testing
Try some various uses of the `Static` example --

```
npm run example examples/static
npm run example examples/static | more
CI=1 npm run example examples/static 
```