### PR TITLE
Update useInput() to include `name` in `key`

### DIFF
--- a/src/hooks/use-input.ts
+++ b/src/hooks/use-input.ts
@@ -140,6 +140,7 @@ const useInput = (inputHandler: Handler, options: Options = {}) => {
 			const keypress = parseKeypress(data);
 
 			const key = {
+				name: keypress.name,
 				upArrow: keypress.name === 'up',
 				downArrow: keypress.name === 'down',
 				leftArrow: keypress.name === 'left',


### PR DESCRIPTION
Some key values (e.g. 'insert', 'home', 'end') were basically lost. In these cases, the `input` value would be an empty string and the generated `key` data would contain no additional information about the value.

To resolve this, directly include `keypress.name` in the generated `key` data so this information is not lost.