### PR TITLE
add support for iterm natural editing mode

### DIFF
--- a/src/parse-keypress.ts
+++ b/src/parse-keypress.ts
@@ -236,6 +236,15 @@ const parseKeypress = (s: Buffer | string = ''): ParsedKey => {
 		key.ctrl = isCtrlKey(code) || key.ctrl;
 	}
 
+	// iTerm in natural text editing mode
+	if (key.raw === '\x1Bb') {
+		key.meta = true;
+		key.name = 'left';
+	} else if (key.raw === '\x1Bf') {
+		key.meta = true;
+		key.name = 'right';
+	}
+
 	return key;
 };
 


### PR DESCRIPTION
Quick improvement to enable opt+left and opt+right

<img width="721" alt="Screenshot 2024-11-26 at 4 19 16 PM" src="https://github.com/user-attachments/assets/dae9bc76-f7f7-49bc-96f1-f894faefa031">
