### PR TITLE
Add `ink-spawn` to "Useful Components"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2126,6 +2126,7 @@ You can even inspect and change the props of components, and see the results imm
 - [ink-syntax-highlight](https://github.com/vsashyn/ink-syntax-highlight) - Code syntax highlighting.
 - [ink-form](https://github.com/lukasbach/ink-form) - Form.
 - [ink-task-list](https://github.com/privatenumber/ink-task-list) - Task list.
+- [ink-spawn](https://github.com/kraenhansen/ink-spawn) - Spawn child processes.
 
 ## Useful Hooks
 


### PR DESCRIPTION
I'm building a CLI wrapping other commands, using React (and the https://www.npmjs.com/package/ink) package and I built this library to orchestrate spawning child processes: https://github.com/kraenhansen/ink-spawn

This PR adds a link to it in the readme, along with other components made by the community.

Thanks for an awesome package 👍