### PR TITLE
Fix input parsing of control characters

### DIFF
--- a/src/parse-keypress.ts
+++ b/src/parse-keypress.ts
@@ -191,7 +191,7 @@ const parseKeypress = (s: Buffer | string = ''): ParsedKey => {
 	} else if (s === ' ' || s === '\x1b ') {
 		key.name = 'space';
 		key.meta = s.length === 2;
-	} else if (s <= '\x1a') {
+	} else if (s.length === 1 && s <= '\x1a') {
 		// ctrl+letter
 		key.name = String.fromCharCode(s.charCodeAt(0) + 'a'.charCodeAt(0) - 1);
 		key.ctrl = true;

--- a/test/fixtures/use-input.tsx
+++ b/test/fixtures/use-input.tsx
@@ -16,6 +16,16 @@ function UserInput({test}: {readonly test: string | undefined}) {
 			return;
 		}
 
+		if (test === 'pastedCarriageReturn' && input === '\rtest') {
+			exit();
+			return;
+		}
+
+		if (test === 'pastedTab' && input === '\ttest') {
+			exit();
+			return;
+		}
+
 		if (test === 'escape' && key.escape) {
 			exit();
 			return;

--- a/test/hooks.tsx
+++ b/test/hooks.tsx
@@ -82,6 +82,20 @@ test.serial('useInput - handle uppercase character', async t => {
 	t.true(ps.output.includes('exited'));
 });
 
+test.serial('useInput - pasted carriage return', async t => {
+	const ps = term('use-input', ['pastedCarriageReturn']);
+	ps.write('\rtest');
+	await ps.waitForExit();
+	t.true(ps.output.includes('exited'));
+});
+
+test.serial('useInput - pasted tab', async t => {
+	const ps = term('use-input', ['pastedTab']);
+	ps.write('\ttest');
+	await ps.waitForExit();
+	t.true(ps.output.includes('exited'));
+});
+
 test.serial('useInput - handle escape', async t => {
 	const ps = term('use-input', ['escape']);
 	ps.write('\u001B');


### PR DESCRIPTION
Strings that start with control characters (e.g.
"\rfoo") were previously parsed incorrectly and
treated as if it was a ctrl+letter combination.

Fixes #649.