### PR TITLE
Update `yoga-wasm-web` dependency to `yoga-layout`

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"widest-line": "^5.0.0",
 		"wrap-ansi": "^9.0.0",
 		"ws": "^8.18.0",
-		"yoga-wasm-web": "~0.3.3"
+		"yoga-layout": "~3.2.1"
 	},
 	"devDependencies": {
 		"@faker-js/faker": "^9.2.0",

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -1,4 +1,4 @@
-import Yoga, {type Node as YogaNode} from 'yoga-wasm-web/auto';
+import Yoga, {type Node as YogaNode} from 'yoga-layout';
 import measureText from './measure-text.js';
 import {type Styles} from './styles.js';
 import wrapText from './wrap-text.js';

--- a/src/get-max-width.ts
+++ b/src/get-max-width.ts
@@ -1,4 +1,4 @@
-import Yoga, {type Node as YogaNode} from 'yoga-wasm-web/auto';
+import Yoga, {type Node as YogaNode} from 'yoga-layout';
 
 const getMaxWidth = (yogaNode: YogaNode) => {
 	return (

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -7,7 +7,7 @@ import autoBind from 'auto-bind';
 import signalExit from 'signal-exit';
 import patchConsole from 'patch-console';
 import {type FiberRoot} from 'react-reconciler';
-import Yoga from 'yoga-wasm-web/auto';
+import Yoga from 'yoga-layout';
 import reconciler from './reconciler.js';
 import render from './renderer.js';
 import * as dom from './dom.js';

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -1,7 +1,7 @@
 import process from 'node:process';
 import createReconciler from 'react-reconciler';
 import {DefaultEventPriority} from 'react-reconciler/constants.js';
-import Yoga, {type Node as YogaNode} from 'yoga-wasm-web/auto';
+import Yoga, {type Node as YogaNode} from 'yoga-layout';
 import {
 	createTextNode,
 	appendChildNode,

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -1,6 +1,6 @@
 import widestLine from 'widest-line';
 import indentString from 'indent-string';
-import Yoga from 'yoga-wasm-web/auto';
+import Yoga from 'yoga-layout';
 import wrapText from './wrap-text.js';
 import getMaxWidth from './get-max-width.js';
 import squashTextNodes from './squash-text-nodes.js';

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -2,7 +2,7 @@
 import {type Boxes, type BoxStyle} from 'cli-boxes';
 import {type LiteralUnion} from 'type-fest';
 import {type ForegroundColorName} from 'ansi-styles'; // Note: We import directly from `ansi-styles` to avoid a bug in TypeScript.
-import Yoga, {type Node as YogaNode} from 'yoga-wasm-web/auto';
+import Yoga, {type Node as YogaNode} from 'yoga-layout';
 
 export type Styles = {
 	readonly textWrap?:


### PR DESCRIPTION
Fixes #647 by removing dependency on `yoga-wasm-web` and replacing it with `yoga-layout` package, updating imports, etc.
