### PR TITLE
fix: correctly detect shift key only for uppercase letters

### DIFF
--- a/src/hooks/use-input.ts
+++ b/src/hooks/use-input.ts
@@ -175,7 +175,7 @@ const useInput = (inputHandler: Handler, options: Options = {}) => {
 			if (
 				input.length === 1 &&
 				typeof input[0] === 'string' &&
-				input[0].toUpperCase() === input[0]
+				/[A-Z]/.test(input[0])
 			) {
 				key.shift = true;
 			}

--- a/test/fixtures/use-input.tsx
+++ b/test/fixtures/use-input.tsx
@@ -16,6 +16,11 @@ function UserInput({test}: {readonly test: string | undefined}) {
 			return;
 		}
 
+		if (test === 'uppercase' && input === '\r' && !key.shift) {
+			exit();
+			return;
+		}
+
 		if (test === 'pastedCarriageReturn' && input === '\rtest') {
 			exit();
 			return;

--- a/test/hooks.tsx
+++ b/test/hooks.tsx
@@ -82,6 +82,16 @@ test.serial('useInput - handle uppercase character', async t => {
 	t.true(ps.output.includes('exited'));
 });
 
+test.serial(
+	'useInput - \r should not count as an uppercase character',
+	async t => {
+		const ps = term('use-input', ['uppercase']);
+		ps.write('\r');
+		await ps.waitForExit();
+		t.true(ps.output.includes('exited'));
+	},
+);
+
 test.serial('useInput - pasted carriage return', async t => {
 	const ps = term('use-input', ['pastedCarriageReturn']);
 	ps.write('\rtest');


### PR DESCRIPTION
### Description

When I press the return key (`\r`) on macOS, the `key` object incorrectly indicates that the `shift` key is also pressed:

```js
{
  input: '\r',
  key: {
    upArrow: false,
    downArrow: false,
    leftArrow: false,
    rightArrow: false,
    pageDown: false,
    pageUp: false,
    return: true,
    escape: false,
    ctrl: false,
    shift: true,
    tab: false,
    backspace: false,
    delete: false,
    meta: false
  }
}
```

#### Root Cause

The previous logic inferred the shift key was pressed for any single character where `input[0].toUpperCase() === input[0]`. This included not only uppercase letters, but also control characters (like `\r`) and symbols, leading to incorrect detection of the shift key.

#### Solution

This PR updates the shift key detection logic to use a regular expression (`/^[A-Z]$/`) that matches only uppercase ASCII letters. Now, `key.shift` will only be set to `true` when the input is an uppercase letter, and not for control characters or symbols.

#### Testing

- Verified that pressing the return key no longer sets `key.shift` to `true`.
- Confirmed that uppercase letter input (e.g., `Q`) still sets `key.shift` to `true`.