### PR TITLE
Fix stale output when outputHeight changes from above stdout.rows to below stdout.rows

### DIFF
--- a/src/devtools-window-polyfill.ts
+++ b/src/devtools-window-polyfill.ts
@@ -5,6 +5,7 @@ import ws from 'ws';
 const customGlobal = global as any;
 
 // These things must exist before importing `react-devtools-core`
+// eslint-disable-next-line n/no-unsupported-features/node-builtins
 customGlobal.WebSocket ||= ws;
 
 customGlobal.window ||= global;

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -175,7 +175,7 @@ export default class Ink {
 
 		if (this.lastOutputHeight >= this.options.stdout.rows) {
 			this.options.stdout.write(
-				ansiEscapes.clearTerminal + this.fullStaticOutput + output + "\n",
+				ansiEscapes.clearTerminal + this.fullStaticOutput + output + '\n',
 			);
 			this.lastOutput = output;
 			this.lastOutputHeight = outputHeight;

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -34,6 +34,7 @@ export default class Ink {
 	// Ignore last render after unmounting a tree to prevent empty output before exit
 	private isUnmounted: boolean;
 	private lastOutput: string;
+	private lastOutputHeight: number;
 	private readonly container: FiberRoot;
 	private readonly rootNode: dom.DOMElement;
 	// This variable is used only in debug mode to store full static output
@@ -71,6 +72,7 @@ export default class Ink {
 
 		// Store last output to only rerender when needed
 		this.lastOutput = '';
+		this.lastOutputHeight = 0;
 
 		// This variable is used only in debug mode to store full static output
 		// so that it's rerendered every time, not just new static parts, like in non-debug mode
@@ -163,6 +165,7 @@ export default class Ink {
 			}
 
 			this.lastOutput = output;
+			this.lastOutputHeight = outputHeight;
 			return;
 		}
 
@@ -170,11 +173,13 @@ export default class Ink {
 			this.fullStaticOutput += staticOutput;
 		}
 
-		if (outputHeight >= this.options.stdout.rows) {
+		if (this.lastOutputHeight >= this.options.stdout.rows) {
 			this.options.stdout.write(
-				ansiEscapes.clearTerminal + this.fullStaticOutput + output,
+				ansiEscapes.clearTerminal + this.fullStaticOutput + output + "\n",
 			);
 			this.lastOutput = output;
+			this.lastOutputHeight = outputHeight;
+			this.log.sync(output);
 			return;
 		}
 
@@ -190,6 +195,7 @@ export default class Ink {
 		}
 
 		this.lastOutput = output;
+		this.lastOutputHeight = outputHeight;
 	};
 
 	render(node: ReactNode): void {

--- a/src/log-update.ts
+++ b/src/log-update.ts
@@ -5,6 +5,7 @@ import cliCursor from 'cli-cursor';
 export type LogUpdate = {
 	clear: () => void;
 	done: () => void;
+	sync: (str: string) => void;
 	(str: string): void;
 };
 
@@ -44,6 +45,12 @@ const create = (stream: Writable, {showCursor = false} = {}): LogUpdate => {
 			hasHiddenCursor = false;
 		}
 	};
+
+	render.sync = (str: string) => {
+		const output = str + '\n';
+        previousOutput = output;
+        previousLineCount = output.split('\n').length;
+	}
 
 	return render;
 };

--- a/src/log-update.ts
+++ b/src/log-update.ts
@@ -48,9 +48,9 @@ const create = (stream: Writable, {showCursor = false} = {}): LogUpdate => {
 
 	render.sync = (str: string) => {
 		const output = str + '\n';
-        previousOutput = output;
-        previousLineCount = output.split('\n').length;
-	}
+		previousOutput = output;
+		previousLineCount = output.split('\n').length;
+	};
 
 	return render;
 };

--- a/test/fixtures/erase-with-state-change.tsx
+++ b/test/fixtures/erase-with-state-change.tsx
@@ -6,7 +6,9 @@ function Erase() {
 	const [show, setShow] = useState(true);
 
 	useEffect(() => {
-		const timer = setTimeout(() => setShow(false));
+		const timer = setTimeout(() => {
+			setShow(false);
+		});
 
 		return () => {
 			clearTimeout(timer);

--- a/test/fixtures/erase-with-state-change.tsx
+++ b/test/fixtures/erase-with-state-change.tsx
@@ -1,0 +1,30 @@
+import process from 'node:process';
+import React, {useEffect, useState} from 'react';
+import {Box, Text, render} from '../../src/index.js';
+
+function Erase() {
+	const [show, setShow] = useState(true);
+
+	useEffect(() => {
+		const timer = setTimeout(() => setShow(false));
+
+		return () => {
+			clearTimeout(timer);
+		};
+	}, []);
+
+	return (
+		<Box flexDirection="column">
+			{show && (
+				<>
+					<Text>A</Text>
+					<Text>B</Text>
+					<Text>C</Text>
+				</>
+			)}
+		</Box>
+	);
+}
+
+process.stdout.rows = Number(process.argv[2]);
+render(<Erase />);

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -120,6 +120,29 @@ test.serial(
 	},
 );
 
+test.serial('erase screen where state changes', async t => {
+	const ps = term('erase-with-state-change', ['4']);
+	await ps.waitForExit();
+
+	const secondFrame = ps.output.split(ansiEscapes.eraseLines(3))[1];
+
+	for (const letter of ['A', 'B', 'C']) {
+		t.false(secondFrame?.includes(letter));
+	}
+});
+
+test.serial('erase screen where state changes in small viewport', async t => {
+	const ps = term('erase-with-state-change', ['3']);
+	await ps.waitForExit();
+
+	const frames = ps.output.split(ansiEscapes.clearTerminal);
+	const lastFrame = frames[frames.length - 1];
+
+	for (const letter of ['A', 'B', 'C']) {
+		t.false(lastFrame?.includes(letter));
+	}
+});
+
 test.serial('clear output', async t => {
 	const ps = term('clear');
 	await ps.waitForExit();

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -136,7 +136,7 @@ test.serial('erase screen where state changes in small viewport', async t => {
 	await ps.waitForExit();
 
 	const frames = ps.output.split(ansiEscapes.clearTerminal);
-	const lastFrame = frames[frames.length - 1];
+	const lastFrame = frames.at(-1);
 
 	for (const letter of ['A', 'B', 'C']) {
 		t.false(lastFrame?.includes(letter));


### PR DESCRIPTION
When the outputHeight goes from a value ` >= stdout.rows` to a value `< stdout.rows` in between re-render, it is possible that the old content is not completely removed from the terminal. 

This happens for three reasons
1. We actually want to consider the previous output height when deciding to entirely clear the terminal or only delete several lines. If the current output has a `height >= stdout.rows`, but we only need to clear the previous render's output, there's no point in writing `ansiEscapes.clearTerminal`. Similarly, if the current output has a `height < stdout.rows` but the previous output exceeded `stdout.rows`, then writing `ansiEscapes.eraseLines(previousLineCount)` won't clear all of the old output.
2. `this.log.clear()` doesn't actually track the height of the output if we rendered via the `outputHeight >= this.options.stdout.rows` conditional. I've added a helper `LogUpdate.sync` to keep it in sync.
3. The `outputHeight >= this.options.stdout.rows` conditional differs slightly in behavior to `this.log` in that it does not append a newline at the end.

Addressing all three of these points fixes the bug.

To test, I verified locally using a small example, and I've also added a test (see "erase screen where state changes in small viewport") which fails on master but passes in this branch.

Fixes #585