### PR TITLE
React 19 Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 		"indent-string": "^5.0.0",
 		"is-in-ci": "^1.0.0",
 		"patch-console": "^2.0.0",
-		"react-reconciler": "^0.29.0",
+		"react-reconciler": "^0.32.0",
 		"scheduler": "^0.23.0",
 		"signal-exit": "^3.0.7",
 		"slice-ansi": "^7.1.0",
@@ -74,8 +74,8 @@
 		"@types/benchmark": "^2.1.2",
 		"@types/ms": "^0.7.31",
 		"@types/node": "^22.9.0",
-		"@types/react": "^18.3.12",
-		"@types/react-reconciler": "^0.28.2",
+		"@types/react": "^19.1.5",
+		"@types/react-reconciler": "^0.32.0",
 		"@types/scheduler": "^0.23.0",
 		"@types/signal-exit": "^3.0.0",
 		"@types/sinon": "^17.0.3",
@@ -92,7 +92,7 @@
 		"node-pty": "^1.0.0",
 		"p-queue": "^8.0.0",
 		"prettier": "^3.3.3",
-		"react": "^18.0.0",
+		"react": "^19.1.0",
 		"react-devtools-core": "^5.0.0",
 		"sinon": "^19.0.2",
 		"strip-ansi": "^7.1.0",
@@ -101,8 +101,8 @@
 		"xo": "^0.59.3"
 	},
 	"peerDependencies": {
-		"@types/react": ">=18.0.0",
-		"react": ">=18.0.0",
+		"@types/react": ">=19.0.0",
+		"react": ">=19.0.0",
 		"react-devtools-core": "^4.19.1"
 	},
 	"peerDependenciesMeta": {

--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -14,6 +14,10 @@ const Box = forwardRef<DOMElement, PropsWithChildren<Props>>(
 			<ink-box
 				ref={ref}
 				style={{
+					flexWrap: 'nowrap',
+					flexDirection: 'row',
+					flexGrow: 0,
+					flexShrink: 1,
 					...style,
 					overflowX: style.overflowX ?? style.overflow ?? 'visible',
 					overflowY: style.overflowY ?? style.overflow ?? 'visible',
@@ -26,12 +30,5 @@ const Box = forwardRef<DOMElement, PropsWithChildren<Props>>(
 );
 
 Box.displayName = 'Box';
-
-Box.defaultProps = {
-	flexWrap: 'nowrap',
-	flexDirection: 'row',
-	flexGrow: 0,
-	flexShrink: 1,
-};
 
 export default Box;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -3,7 +3,7 @@ import {type Except} from 'type-fest';
 import {type DOMElement} from './dom.js';
 import {type Styles} from './styles.js';
 
-declare global {
+declare module 'react' {
 	namespace JSX {
 		// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 		interface IntrinsicElements {

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -6,6 +6,7 @@ import isInCi from 'is-in-ci';
 import autoBind from 'auto-bind';
 import signalExit from 'signal-exit';
 import patchConsole from 'patch-console';
+import {ConcurrentRoot} from 'react-reconciler/constants.js';
 import {type FiberRoot} from 'react-reconciler';
 import Yoga from 'yoga-layout';
 import reconciler from './reconciler.js';
@@ -79,12 +80,16 @@ export default class Ink {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		this.container = reconciler.createContainer(
 			this.rootNode,
-			// Legacy mode
-			0,
+			ConcurrentRoot,
 			null,
 			false,
 			null,
 			'id',
+			() => {},
+			() => {},
+			// @ts-expect-error @types/react-reconciler are not up to date
+			// See https://github.com/facebook/react/blob/c0464aedb16b1c970d717651bba8d1c66c578729/packages/react-reconciler/src/ReactFiberReconciler.js#L236-L259
+			() => {},
 			() => {},
 			null,
 		);

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -6,7 +6,7 @@ import isInCi from 'is-in-ci';
 import autoBind from 'auto-bind';
 import signalExit from 'signal-exit';
 import patchConsole from 'patch-console';
-import {ConcurrentRoot} from 'react-reconciler/constants.js';
+import {LegacyRoot} from 'react-reconciler/constants.js';
 import {type FiberRoot} from 'react-reconciler';
 import Yoga from 'yoga-layout';
 import reconciler from './reconciler.js';
@@ -80,14 +80,14 @@ export default class Ink {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		this.container = reconciler.createContainer(
 			this.rootNode,
-			ConcurrentRoot,
+			LegacyRoot,
 			null,
 			false,
 			null,
 			'id',
 			() => {},
 			() => {},
-			// @ts-expect-error @types/react-reconciler are not up to date
+			// @ts-expect-error the types for `react-reconciler` are not up to date with the library.
 			// See https://github.com/facebook/react/blob/c0464aedb16b1c970d717651bba8d1c66c578729/packages/react-reconciler/src/ReactFiberReconciler.js#L236-L259
 			() => {},
 			() => {},
@@ -212,7 +212,12 @@ export default class Ink {
 			</App>
 		);
 
-		reconciler.updateContainer(tree, this.container, null, noop);
+		// @ts-expect-error the types for `react-reconciler` are not up to date with the library.
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+		reconciler.updateContainerSync(tree, this.container, null, noop);
+		// @ts-expect-error the types for `react-reconciler` are not up to date with the library.
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+		reconciler.flushSyncWork();
 	}
 
 	writeToStdout(data: string): void {
@@ -284,7 +289,12 @@ export default class Ink {
 
 		this.isUnmounted = true;
 
-		reconciler.updateContainer(null, this.container, null, noop);
+		// @ts-expect-error the types for `react-reconciler` are not up to date with the library.
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+		reconciler.updateContainerSync(null, this.container, null, noop);
+		// @ts-expect-error the types for `react-reconciler` are not up to date with the library.
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+		reconciler.flushSyncWork();
 		instances.delete(this.options.stdout);
 
 		if (error instanceof Error) {

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -115,7 +115,7 @@ export default createReconciler<
 		return {isInsideText};
 	},
 	shouldSetTextContent: () => false,
-	createInstance(originalType, newProps, _root, hostContext) {
+	createInstance(originalType, newProps, rootNode, hostContext) {
 		if (hostContext.isInsideText && originalType === 'ink-box') {
 			throw new Error(`<Box> can’t be nested inside <Text> component`);
 		}
@@ -149,6 +149,11 @@ export default createReconciler<
 
 			if (key === 'internal_static') {
 				node.internal_static = true;
+				rootNode.isStaticDirty = true;
+
+				// Save reference to <Static> node to skip traversal of entire
+				// node tree to find it
+				rootNode.staticNode = node;
 				continue;
 			}
 
@@ -183,15 +188,7 @@ export default createReconciler<
 	appendInitialChild: appendChildNode,
 	appendChild: appendChildNode,
 	insertBefore: insertBeforeNode,
-	finalizeInitialChildren(node, _type, _props, rootNode) {
-		if (node.internal_static) {
-			rootNode.isStaticDirty = true;
-
-			// Save reference to <Static> node to skip traversal of entire
-			// node tree to find it
-			rootNode.staticNode = node;
-		}
-
+	finalizeInitialChildren() {
 		return false;
 	},
 	isPrimaryRenderer: true,

--- a/test/helpers/render-to-string.ts
+++ b/test/helpers/render-to-string.ts
@@ -2,7 +2,7 @@ import {render} from '../../src/index.js';
 import createStdout from './create-stdout.js';
 
 export const renderToString: (
-	node: JSX.Element,
+	node: React.JSX.Element,
 	options?: {columns: number},
 ) => string = (node, options) => {
 	const stdout = createStdout(options?.columns ?? 100);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,7 @@
 		],
 		"sourceMap": true,
 		"jsx": "react",
-		"isolatedModules": true,
-		"lib": ["ES2023"]
+		"isolatedModules": true
 	},
 	"include": ["src"],
 	"ts-node": {


### PR DESCRIPTION
I spent some time over the weekend working on adding support for React 19. I’ve successfully got it working, but opted to stick with the **legacy rendering mode** rather than enabling concurrent mode for now.

This means that React will continue to render updates synchronously, maintaining the existing behaviour.

At this point, **all but two tests are passing**, and I'm currently stumped on why these specific tests are failing. I’d appreciate any suggestions or help debugging them:

- `borders › render border after update`
- `focus › switch focus to the last component if currently focused component is the first one on Shift+Tab`

Additionally, the types provided by DefinitelyTyped are not yet up to date with the latest version of the React reconciler, so I’ve added a few `@ts-expect-error` comments to work around that for the time being.

I’ve published a testing version of this fork as:

```
msmps-ink@6.0.0-beta.1
```

## Concurrent Mode

I did experiment with enabling concurrent mode and got it working, but the test suite revealed several issues:

- Many tests fail unless wrapped in `act()` and converted to async.
- There are frequent warnings about state updates occurring outside of `act()`.
- It looked like `unmount()` is/was firing multiple times, potentially causing these warnings.

It felt like concurrent mode would require a more involved refactor. I’d suggest we consider this as a **fast follow-up** once React 19 legacy support is merged.

I’ve pushed a [separate branch](https://github.com/msmps/ink/tree/feat/react-v19-support-concurrent) with the concurrent mode changes if anyone wants to explore or contribute to that effort.

Addresses: #688 #656 