### PR TITLE
Fix a bug that causes static content to not be updated in time

### DIFF
--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -95,7 +95,8 @@ type HostContext = {
 };
 
 let currentUpdatePriority = NoEventPriority;
-let currentRootNode : DOMElement | null = null;
+
+let currentRootNode: DOMElement | undefined;
 
 export default createReconciler<
 	ElementNames,
@@ -251,6 +252,7 @@ export default createReconciler<
 		if (currentRootNode && node.internal_static) {
 			currentRootNode.isStaticDirty = true;
 		}
+
 		const props = diff(oldProps, newProps);
 
 		const style = diff(

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -95,6 +95,7 @@ type HostContext = {
 };
 
 let currentUpdatePriority = NoEventPriority;
+let currentRootNode : DOMElement | null = null;
 
 export default createReconciler<
 	ElementNames,
@@ -183,6 +184,7 @@ export default createReconciler<
 			}
 
 			if (key === 'internal_static') {
+				currentRootNode = rootNode;
 				node.internal_static = true;
 				rootNode.isStaticDirty = true;
 
@@ -245,7 +247,10 @@ export default createReconciler<
 		removeChildNode(node, removeNode);
 		cleanupYogaNode(removeNode.yogaNode);
 	},
-	commitUpdate(node, _type, oldProps, newProps, _root) {
+	commitUpdate(node, _type, oldProps, newProps) {
+		if (currentRootNode && node.internal_static) {
+			currentRootNode.isStaticDirty = true;
+		}
 		const props = diff(oldProps, newProps);
 
 		const style = diff(


### PR DESCRIPTION
In React 19 support PR #719 , logic for marking Static as dirty was [removed](https://github.com/vadimdemedes/ink/pull/719/files#diff-92cf748778b8e4481e8c7e0e81785c68bf04046c7b16192b7b4c185c58e9e2cbL251). I'm not sure why this was removed, but it prevents the Static component from being updated when new components are added to items.

I see React [removed prepareUpdate()](https://github.com/facebook/react/pull/26583) and asked developers to do the preparation in commitUpdate, however, the [commitUpdate](https://github.com/facebook/react/tree/main/packages/react-reconciler#commitupdateinstance-type-prevprops-nextprops-internalhandle) method doesn't provide root node. The solution is to add a global variable tracking the root node.