### PR TITLE
Adding Canva CLI to "Who's using Ink" section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,7 @@ Feel free to play around with the code and fork this repl at [https://repl.it/@v
 - [Claude Code](https://github.com/anthropics/claude-code) - An agentic coding tool, made by Anthropic.
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli) - An agentic coding tool, made by Google.
 - [GitHub Copilot for CLI](https://githubnext.com/projects/copilot-cli) - Just say what you want the shell to do.
+- [Canva CLI](https://www.canva.dev/docs/apps/canva-cli/) - CLI for creating and managing Canva Apps.
 - [Cloudflare's Wrangler](https://github.com/cloudflare/wrangler2) - The CLI for Cloudflare Workers.
 - [Linear](https://linear.app) - Linear built an internal CLI for managing deployments, configs and other housekeeping tasks.
 - [Gatsby](https://www.gatsbyjs.org) - Gatsby is a modern web framework for blazing fast websites.


### PR DESCRIPTION
Add Canva CLI to list of projects using InkJS 🙌🏼 

<img width="898" alt="Screenshot 2025-06-26 at 1 25 21 pm" src="https://github.com/user-attachments/assets/fb80b2cc-84c2-45e5-a02f-b6af2d0e277c" />
