### PR TITLE
Remove dead replit links from README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,6 @@ render(<Counter />);
 
 <img src="media/demo.svg" width="600">
 
-You can also check it out live on [repl.it sandbox](https://ink-counter-demo.vadimdemedes.repl.run/).
 Feel free to play around with the code and fork this repl at [https://repl.it/@vadimdemedes/ink-counter-demo](https://repl.it/@vadimdemedes/ink-counter-demo).
 
 ## Who's Using Ink?
@@ -2142,8 +2141,8 @@ npm run example examples/[example name]
 # e.g. npm run example examples/borders
 ```
 
-- [Jest](examples/jest/jest.tsx) - Implementation of basic Jest UI [(live demo)](https://ink-jest-demo.vadimdemedes.repl.run/).
-- [Counter](examples/counter/counter.tsx) - Simple counter that increments every 100ms [(live demo)](https://ink-counter-demo.vadimdemedes.repl.run/).
+- [Jest](examples/jest/jest.tsx) - Implementation of basic Jest UI.
+- [Counter](examples/counter/counter.tsx) - Simple counter that increments every 100ms.
 - [Form with validation](https://github.com/final-form/rff-cli-example) - Manage form state using [Final Form](https://github.com/final-form/final-form#-final-form).
 - [Borders](examples/borders/borders.tsx) - Add borders to `<Box>` component.
 - [Suspense](examples/suspense/suspense.tsx) - Use React Suspense.


### PR DESCRIPTION
Several of the "live demo" Replit links now lead to a 404. I've removed them from the README file.

Here are the links I've removed:

- https://ink-counter-demo.vadimdemedes.repl.run/
- https://ink-jest-demo.vadimdemedes.repl.run/