### PR TITLE
Add Cursor component

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,7 @@ Feel free to play around with the code and fork this repl at [https://repl.it/@v
   - [`<Spacer>`](#spacer)
   - [`<Static>`](#static)
   - [`<Transform>`](#transform)
+  - [`<Cursor>`](#cursor)
 - [Hooks](#hooks)
   - [`useInput`](#useinputinputhandler-options)
   - [`useApp`](#useapp)
@@ -1420,6 +1421,30 @@ Output of child components.
 Type: `number`
 
 The zero-indexed line number of the line currently being transformed.
+
+### `<Cursor>`
+
+The `<Cursor>` component allows you to specify the cursor position in your terminal. It positions the terminal cursor at the exact location where the component is placed in your layout.
+
+```jsx
+import {render, Box, Text, Cursor} from 'ink';
+
+const Example = () => (
+	<Box>
+		<Text>Hello, </Text>
+		<Cursor />
+		<Text>World</Text>
+	</Box>
+);
+
+render(<Example />);
+```
+
+In this example, the cursor will be positioned between "Hello, " and "World", creating an interactive input-like appearance.
+
+**Note:** Only one `<Cursor>` component should be used per application. If you need to use multiple `<Cursor>` components, you should ensure that they are not rendered at the same time, for example by checking focus.
+
+The cursor is automatically shown when a `<Cursor>` component is present and hidden when it's not.
 
 ## Hooks
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,7 +1,6 @@
 import {EventEmitter} from 'node:events';
 import process from 'node:process';
 import React, {PureComponent, type ReactNode} from 'react';
-import cliCursor from 'cli-cursor';
 import AppContext from './AppContext.js';
 import StdinContext from './StdinContext.js';
 import StdoutContext from './StdoutContext.js';
@@ -126,13 +125,7 @@ export default class App extends PureComponent<Props, State> {
 		);
 	}
 
-	override componentDidMount() {
-		cliCursor.hide(this.props.stdout);
-	}
-
 	override componentWillUnmount() {
-		cliCursor.show(this.props.stdout);
-
 		// ignore calling setRawMode on an handle stdin it cannot be called
 		if (this.isRawModeSupported()) {
 			this.handleSetRawMode(false);

--- a/src/components/Cursor.tsx
+++ b/src/components/Cursor.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+/**
+ * This component is used to specify a cursor position in the terminal.
+ */
+export default function Cursor() {
+	return <ink-cursor style={{flexGrow: 0, flexShrink: 1}} />;
+}

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -17,7 +17,8 @@ export type ElementNames =
 	| 'ink-root'
 	| 'ink-box'
 	| 'ink-text'
-	| 'ink-virtual-text';
+	| 'ink-virtual-text'
+	| 'ink-cursor';
 
 export type NodeNames = ElementNames | TextName;
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -9,6 +9,7 @@ declare module 'react' {
 		interface IntrinsicElements {
 			'ink-box': Ink.Box;
 			'ink-text': Ink.Text;
+			'ink-cursor': Ink.Cursor;
 		}
 	}
 }
@@ -29,5 +30,10 @@ declare namespace Ink {
 
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		internal_transform?: (children: string, index: number) => string;
+	};
+
+	type Cursor = {
+		key?: Key;
+		style?: Except<Styles, 'textWrap'>;
 	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export type {Props as BoxProps} from './components/Box.js';
 export {default as Box} from './components/Box.js';
 export type {Props as TextProps} from './components/Text.js';
 export {default as Text} from './components/Text.js';
+export {default as Cursor} from './components/Cursor.js';
 export type {Props as AppProps} from './components/AppContext.js';
 export type {Props as StdinProps} from './components/StdinContext.js';
 export type {Props as StdoutProps} from './components/StdoutContext.js';

--- a/src/log-update.ts
+++ b/src/log-update.ts
@@ -1,55 +1,102 @@
 import {type Writable} from 'node:stream';
 import ansiEscapes from 'ansi-escapes';
 import cliCursor from 'cli-cursor';
+import {type Position} from './output.js';
 
 export type LogUpdate = {
 	clear: () => void;
+	clearTerminal: () => void;
 	done: () => void;
-	sync: (str: string) => void;
-	(str: string): void;
+	(str: string, cursorPosition: Position | undefined): void;
 };
 
-const create = (stream: Writable, {showCursor = false} = {}): LogUpdate => {
+const create = (stream: Writable): LogUpdate => {
 	let previousLineCount = 0;
 	let previousOutput = '';
+	let previousCursorPosition: Position | undefined;
+	let previousCursorOffsetY = 0;
 	let hasHiddenCursor = false;
 
-	const render = (str: string) => {
-		if (!showCursor && !hasHiddenCursor) {
+	const render = (str: string, cursorPosition: Position | undefined): void => {
+		if (!hasHiddenCursor && cursorPosition === undefined) {
 			cliCursor.hide();
 			hasHiddenCursor = true;
-		}
-
-		const output = str + '\n';
-		if (output === previousOutput) {
-			return;
-		}
-
-		previousOutput = output;
-		stream.write(ansiEscapes.eraseLines(previousLineCount) + output);
-		previousLineCount = output.split('\n').length;
-	};
-
-	render.clear = () => {
-		stream.write(ansiEscapes.eraseLines(previousLineCount));
-		previousOutput = '';
-		previousLineCount = 0;
-	};
-
-	render.done = () => {
-		previousOutput = '';
-		previousLineCount = 0;
-
-		if (!showCursor) {
+		} else if (hasHiddenCursor && cursorPosition !== undefined) {
 			cliCursor.show();
 			hasHiddenCursor = false;
 		}
+
+		const output = str + '\n';
+		if (
+			output === previousOutput &&
+			cursorPosition?.x === previousCursorPosition?.x &&
+			cursorPosition?.y === previousCursorPosition?.y
+		) {
+			return;
+		}
+
+		const lineCount = output.split('\n').length;
+		const cursorOffsetY = cursorPosition
+			? lineCount - cursorPosition.y - 1 // -1 is for the last '\n'
+			: 0;
+
+		const moveCursorToBottom = previousCursorOffsetY
+			? ansiEscapes.cursorDown(previousCursorOffsetY)
+			: '';
+		const eraseLines = ansiEscapes.eraseLines(previousLineCount);
+		const moveCursorY = cursorOffsetY
+			? ansiEscapes.cursorUp(cursorOffsetY)
+			: '';
+		const moveCursorX =
+			cursorPosition === undefined
+				? ''
+				: ansiEscapes.cursorTo(cursorPosition.x);
+		stream.write(
+			moveCursorToBottom + eraseLines + output + moveCursorY + moveCursorX,
+		);
+
+		previousOutput = output;
+		previousLineCount = lineCount;
+		previousCursorPosition = cursorPosition;
+		previousCursorOffsetY = cursorOffsetY;
 	};
 
-	render.sync = (str: string) => {
-		const output = str + '\n';
-		previousOutput = output;
-		previousLineCount = output.split('\n').length;
+	render.clear = () => {
+		const moveCursorToBottom = previousCursorOffsetY
+			? ansiEscapes.cursorDown(previousCursorOffsetY)
+			: '';
+		const eraseLines = ansiEscapes.eraseLines(previousLineCount);
+		stream.write(moveCursorToBottom + eraseLines);
+
+		previousOutput = '';
+		previousLineCount = 0;
+		previousCursorPosition = undefined;
+		previousCursorOffsetY = 0;
+	};
+
+	render.clearTerminal = () => {
+		stream.write(ansiEscapes.clearTerminal);
+
+		previousOutput = '';
+		previousLineCount = 0;
+		previousCursorPosition = undefined;
+		previousCursorOffsetY = 0;
+	};
+
+	render.done = () => {
+		if (previousCursorOffsetY) {
+			stream.write(ansiEscapes.cursorDown(previousCursorOffsetY));
+		}
+
+		previousOutput = '';
+		previousLineCount = 0;
+		previousCursorPosition = undefined;
+		previousCursorOffsetY = 0;
+
+		if (hasHiddenCursor) {
+			cliCursor.show();
+			hasHiddenCursor = false;
+		}
 	};
 
 	return render;

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -89,6 +89,11 @@ const renderNodeToOutput = (
 			return;
 		}
 
+		if (node.nodeName === 'ink-cursor') {
+			output.setCursor({x, y});
+			return;
+		}
+
 		let clipped = false;
 
 		if (node.nodeName === 'ink-box') {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,10 +1,11 @@
 import renderNodeToOutput from './render-node-to-output.js';
-import Output from './output.js';
+import Output, {type Position} from './output.js';
 import {type DOMElement} from './dom.js';
 
 type Result = {
 	output: string;
 	outputHeight: number;
+	outputCursorPosition: Position | undefined;
 	staticOutput: string;
 };
 
@@ -30,11 +31,16 @@ const renderer = (node: DOMElement): Result => {
 			});
 		}
 
-		const {output: generatedOutput, height: outputHeight} = output.get();
+		const {
+			output: generatedOutput,
+			height: outputHeight,
+			cursorPosition: outputCursorPosition,
+		} = output.get();
 
 		return {
 			output: generatedOutput,
 			outputHeight,
+			outputCursorPosition,
 			// Newline at the end is needed, because static output doesn't have one, so
 			// interactive output will override last line of static output
 			staticOutput: staticOutput ? `${staticOutput.get().output}\n` : '',
@@ -44,6 +50,7 @@ const renderer = (node: DOMElement): Result => {
 	return {
 		output: '',
 		outputHeight: 0,
+		outputCursorPosition: undefined,
 		staticOutput: '',
 	};
 };

--- a/test/cursor.tsx
+++ b/test/cursor.tsx
@@ -1,0 +1,70 @@
+import test from 'ava';
+import React from 'react';
+import ansiEscapes from 'ansi-escapes';
+import {Box, Cursor, Text, render} from '../src/index.js';
+import createStdout from './helpers/create-stdout.js';
+
+test('cursor - before text', t => {
+	const stdout = createStdout();
+	render(
+		<Box>
+			<Cursor />
+			<Text>Hello</Text>
+		</Box>,
+		{stdout},
+	);
+
+	t.is(
+		stdout.get(),
+		'Hello\n' + ansiEscapes.cursorUp(1) + ansiEscapes.cursorTo(0),
+	);
+});
+
+test('cursor - between text', t => {
+	const stdout = createStdout();
+	render(
+		<Box>
+			<Text>Hello, </Text>
+			<Cursor />
+			<Text>World</Text>
+		</Box>,
+		{stdout},
+	);
+
+	t.is(
+		stdout.get(),
+		'Hello, World\n' + ansiEscapes.cursorUp(1) + ansiEscapes.cursorTo(7),
+	);
+});
+
+test('cursor - after text', t => {
+	const stdout = createStdout();
+	render(
+		<Box>
+			<Text>Hello</Text>
+			<Cursor />
+		</Box>,
+		{stdout},
+	);
+
+	t.is(
+		stdout.get(),
+		'Hello\n' + ansiEscapes.cursorUp(1) + ansiEscapes.cursorTo(5),
+	);
+});
+
+test('cursor - in a box with padding', t => {
+	const stdout = createStdout();
+	render(
+		<Box padding={1}>
+			<Text>Hello</Text>
+			<Cursor />
+		</Box>,
+		{stdout},
+	);
+
+	t.is(
+		stdout.get(),
+		'\n Hello\n\n' + ansiEscapes.cursorUp(2) + ansiEscapes.cursorTo(6),
+	);
+});


### PR DESCRIPTION
Fixes #251

This PR adds a new component `<Cursor>`, which controls the position of an actual cursor in a terminal by ANSI escape codes.

Previously, there was no way to control the position and visibility of an actual cursor in Ink applications.
We could show a fake cursor, as [ink-text-input](https://github.com/vadimdemedes/ink-text-input/blob/4ac429ca11da17c2321f7dec1076e38c06d738d5/source/index.tsx#L91) does, but that only works for visual purposes and still causes problems with IME. Without an actual cursor, the IME always displays a text being entered on the last line.
The`<Cursor>` component works as an anchor for IME to display at the intended position.

## Example

```jsx
<Box borderStyle="single" margin={10} paddingX={1}>
	<Text>Label: </Text>
	<Cursor />
	<Text>Type here</Text>
</Box>
```

| Without Cursor | With Cursor |
| -- | -- |
| <video src="https://github.com/user-attachments/assets/f96889f6-dcc9-4ee5-9ac2-35042dc07dc8" /> | <video src="https://github.com/user-attachments/assets/0f829042-77f9-4f44-af30-8d91ad622b4a" /> |

