### PR TITLE
Added Qodo Command to "Who's Using Ink?"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,7 @@ Feel free to play around with the code and fork this repl at [https://repl.it/@v
 - [Claude Code](https://github.com/anthropics/claude-code) - An agentic coding tool, made by Anthropic.
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli) - An agentic coding tool, made by Google.
 - [GitHub Copilot for CLI](https://githubnext.com/projects/copilot-cli) - Just say what you want the shell to do.
+- [Qodo Command](https://github.com/qodo-ai/command) - A powerful CLI for building, running, and managing AI agents.
 - [Canva CLI](https://www.canva.dev/docs/apps/canva-cli/) - CLI for creating and managing Canva Apps.
 - [Cloudflare's Wrangler](https://github.com/cloudflare/wrangler2) - The CLI for Cloudflare Workers.
 - [Linear](https://linear.app) - Linear built an internal CLI for managing deployments, configs and other housekeeping tasks.


### PR DESCRIPTION
Qodo Command is a powerful command-line interface for building, running, and managing AI agents.

Try it out: `npm install -g @qodo/command`

More on Qodo Command, by Qodo: https://www.qodo.ai/products/qodo-command/