### PR TITLE
feat: add ci option to override CI environment detection

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -41,6 +41,13 @@ export type RenderOptions = {
 	 * @default true
 	 */
 	patchConsole?: boolean;
+
+	/**
+	 * Force is-in-ci to behave one way or another
+	 *
+	 * @default undefined
+	 */
+	ci?: boolean;
 };
 
 export type Instance = {

--- a/test/exit.tsx
+++ b/test/exit.tsx
@@ -115,3 +115,17 @@ test.serial('don’t exit while raw mode is active', async t => {
 		});
 	});
 });
+
+test.serial('ci override true', async t => {
+	const output = await run('ci-override');
+	// When ci: true, should behave as CI and only render last frame
+	t.false(output.includes('Hello'));
+	t.true(output.includes('World'));
+});
+
+test.serial('ci override false', async t => {
+	const output = await run('ci-override-false');
+	// When ci: false, should behave as NOT CI and render all frames
+	t.true(output.includes('Hello'));
+	t.true(output.includes('World'));
+});

--- a/test/fixtures/ci-override-false.tsx
+++ b/test/fixtures/ci-override-false.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import {render, Text} from '../../src/index.js';
+
+function Ci({text}: {readonly text: string}) {
+	return <Text>{text}</Text>;
+}
+
+const instance = render(<Ci text="Hello" />, {ci: false});
+
+setTimeout(() => {
+	instance.rerender(<Ci text="World" />);
+}, 50);

--- a/test/fixtures/ci-override.tsx
+++ b/test/fixtures/ci-override.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import {render, Text} from '../../src/index.js';
+
+function Test({text}: {readonly text: string}) {
+	return <Text>{text}</Text>;
+}
+
+const instance = render(<Test text="Hello" />, {ci: true});
+
+setTimeout(() => {
+	instance.rerender(<Test text="World" />);
+}, 50);


### PR DESCRIPTION
## Summary
This PR adds an optional `ci` parameter to render options that allows explicitly controlling CI behavior, overriding the automatic detection from the `is-ci` package.

## Motivation
Some users have environments where environment variables incorrectly trigger CI mode detection, causing their Ink applications to only render the final frame instead of showing animations. This provides a way to force the desired behavior.

## Changes
- Added optional `ci?: boolean` parameter to `RenderOptions` and `Options` types
- Modified `Ink` constructor to use the `ci` option when provided, falling back to `isInCi` detection
- Added tests to verify both `ci: true` and `ci: false` behaviors work correctly

## Usage
```typescript
// Force CI behavior (only render last frame)
render(<App />, {ci: true});

// Force non-CI behavior (render all frames)
render(<App />, {ci: false});

// Use default is-ci detection (current behavior)
render(<App />);
```

## Testing
- Added test cases for both `ci: true` and `ci: false` scenarios
- All existing tests continue to pass
- The feature is backwards compatible - when `ci` is not specified, behavior remains unchanged

Fixes #718
Fixes https://github.com/google-gemini/gemini-cli/issues/1563