### PR TITLE
Fix measure text bug reading text "constructor"

### DIFF
--- a/src/measure-text.ts
+++ b/src/measure-text.ts
@@ -1,6 +1,6 @@
 import widestLine from 'widest-line';
 
-const cache: Record<string, Output> = {};
+const cache = new Map<string, Output>();
 
 type Output = {
 	width: number;
@@ -15,7 +15,7 @@ const measureText = (text: string): Output => {
 		};
 	}
 
-	const cachedDimensions = cache[text];
+	const cachedDimensions = cache.get(text);
 
 	if (cachedDimensions) {
 		return cachedDimensions;
@@ -23,9 +23,10 @@ const measureText = (text: string): Output => {
 
 	const width = widestLine(text);
 	const height = text.split('\n').length;
-	cache[text] = {width, height};
+	const dimensions = {width, height};
+	cache.set(text, dimensions);
 
-	return {width, height};
+	return dimensions;
 };
 
 export default measureText;

--- a/test/measure-text.tsx
+++ b/test/measure-text.tsx
@@ -1,0 +1,7 @@
+import test from 'ava';
+import measureText from '../src/measure-text.js';
+
+test('measure "constructor"', t => {
+	const {width} = measureText('constructor');
+	t.is(width, 11);
+});

--- a/test/text.tsx
+++ b/test/text.tsx
@@ -113,3 +113,10 @@ test('remeasure text when text nodes are changed', t => {
 	rerender(<Test add />);
 	t.is((stdout.write as any).lastCall.args[0], 'abcx');
 });
+
+// See https://github.com/vadimdemedes/ink/issues/743
+// Without the fix, the output was ''.
+test('text with content "constructor" wraps correctly', t => {
+	const output = renderToString(<Text>constructor</Text>);
+	t.is(output, 'constructor');
+});


### PR DESCRIPTION
This fixes #743 by using a `Map` instead of an `Object` avoiding the bug reading the cached value for strings such as "constructor" that are properties of `Object`.

I've added a regression test that fails without the change.
As described in #743, fixing this is important for Gemini CLI.