### PR TITLE
Add argonaut to "Who's using Ink?"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,7 @@ Feel free to play around with the code and fork this repl at [https://repl.it/@v
 - [swiff](https://github.com/simple-integrated-marketing/swiff) - Multi-environment command line tools for time-saving web developers.
 - [share](https://github.com/marionebl/share-cli) - Quickly share files.
 - [Kubelive](https://github.com/ameerthehacker/kubelive) - CLI for Kubernetes to provide live data about the cluster and its resources.
+- [argonaut](https://github.com/darksworm/argonaut) - k9s-like TUI app for managing Argo CD resources.
 - [changelog-view](https://github.com/jdeniau/changelog-view) - View changelogs.
 - [cfpush](https://github.com/mamachanko/cfpush) - An interactive Cloud Foundry tutorial.
 - [startd](https://github.com/mgrip/startd) - Turn your React component into a web app.

--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,6 @@ Feel free to play around with the code and fork this repl at [https://repl.it/@v
 - [swiff](https://github.com/simple-integrated-marketing/swiff) - Multi-environment command line tools for time-saving web developers.
 - [share](https://github.com/marionebl/share-cli) - Quickly share files.
 - [Kubelive](https://github.com/ameerthehacker/kubelive) - CLI for Kubernetes to provide live data about the cluster and its resources.
-- [argonaut](https://github.com/darksworm/argonaut) - k9s-like TUI app for managing Argo CD resources.
 - [changelog-view](https://github.com/jdeniau/changelog-view) - View changelogs.
 - [cfpush](https://github.com/mamachanko/cfpush) - An interactive Cloud Foundry tutorial.
 - [startd](https://github.com/mgrip/startd) - Turn your React component into a web app.
@@ -122,6 +121,7 @@ Feel free to play around with the code and fork this repl at [https://repl.it/@v
 - [Sea Trader](https://github.com/zyishai/sea-trader) - Taipan! inspired trading simulator game.
 - [srtd](https://github.com/t1mmen/srtd) - Live-reloading SQL templates for Supabase projects.
 - [tweakcc](https://github.com/Piebald-AI/tweakcc) - Customize your Claude Code styling.
+- [argonaut](https://github.com/darksworm/argonaut) - Manage Argo CD resources.
 
 ## Contents
 


### PR DESCRIPTION
Hi! I've added a project I've recently built using ink: https://github.com/darksworm/argonaut

I put it next to the other k8s-related project (kubelive), as that seems more logical than putting it at the bottom. 

quick preview of argonaut:

https://github.com/user-attachments/assets/96fb21b4-12c1-48f8-90cc-c947b07aec66

Thank you for considering adding my project to your list :)