### PR TITLE
Fix screen reader rendering with static components

### DIFF
--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -33,8 +33,13 @@ export const renderNodeToScreenReaderOutput = (
 	node: DOMElement,
 	options: {
 		parentRole?: string;
+		skipStaticElements?: boolean;
 	} = {},
 ): string => {
+	if (options.skipStaticElements && node.internal_static) {
+		return '';
+	}
+
 	if (node.yogaNode?.getDisplay() === Yoga.DISPLAY_NONE) {
 		return '';
 	}
@@ -62,6 +67,7 @@ export const renderNodeToScreenReaderOutput = (
 					childNode as DOMElement,
 					{
 						parentRole: node.internal_accessibility?.role,
+						skipStaticElements: options.skipStaticElements,
 					},
 				);
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -13,13 +13,24 @@ type Result = {
 const renderer = (node: DOMElement, isScreenReaderEnabled: boolean): Result => {
 	if (node.yogaNode) {
 		if (isScreenReaderEnabled) {
-			const output = renderNodeToScreenReaderOutput(node);
+			const output = renderNodeToScreenReaderOutput(node, {
+				skipStaticElements: true,
+			});
+
 			const outputHeight = output === '' ? 0 : output.split('\n').length;
+
+			let staticOutput = '';
+
+			if (node.staticNode) {
+				staticOutput = renderNodeToScreenReaderOutput(node.staticNode, {
+					skipStaticElements: false,
+				});
+			}
 
 			return {
 				output,
 				outputHeight,
-				staticOutput: '',
+				staticOutput: staticOutput ? `${staticOutput}\n` : '',
 			};
 		}
 


### PR DESCRIPTION
I was seeing issues downstream in gemini-cli where messages would disappear when inside of a static component. This adds static handling to screen reader mode.

Tested here: https://github.com/google-gemini/gemini-cli/compare/cb/screenreadermode?expand=1