### PR TITLE
docs(readme/useful-components): add ink-chart

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2298,6 +2298,7 @@ For a practical example of building an accessible component, see the [ARIA examp
 - [ink-task-list](https://github.com/privatenumber/ink-task-list) - Task list.
 - [ink-spawn](https://github.com/kraenhansen/ink-spawn) - Spawn child processes.
 - [ink-titled-box](https://github.com/mishieck/ink-titled-box) - Box with title.
+- [ink-chart](https://github.com/pppp606/ink-chart) - Sparkline and BarChart visualization components.
 
 ## Useful Hooks
 

--- a/readme.md
+++ b/readme.md
@@ -2298,7 +2298,7 @@ For a practical example of building an accessible component, see the [ARIA examp
 - [ink-task-list](https://github.com/privatenumber/ink-task-list) - Task list.
 - [ink-spawn](https://github.com/kraenhansen/ink-spawn) - Spawn child processes.
 - [ink-titled-box](https://github.com/mishieck/ink-titled-box) - Box with title.
-- [ink-chart](https://github.com/pppp606/ink-chart) - Sparkline and BarChart visualization components.
+- [ink-chart](https://github.com/pppp606/ink-chart) - Sparkline and bar chart.
 
 ## Useful Hooks
 


### PR DESCRIPTION
## Summary
Add [ink-chart](https://github.com/pppp606/ink-chart) to the Useful Components section in the README.

ink-chart provides terminal visualization components for the Ink CLI framework:
- **Sparkline component** - For displaying inline charts
- **BarChart component** - For displaying bar charts
- Full **TypeScript support**

I am the author of this library.

## Test plan
- [x] Link is correct and working
- [x] Description accurately represents the library's functionality
- [x] Follows the same format as other entries in the Useful Components section