### PR TITLE
feat: support word-break for Text component

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -334,11 +334,12 @@ Inverse background and foreground colors.
 #### wrap
 
 Type: `string`\
-Allowed values: `wrap` `truncate` `truncate-start` `truncate-middle` `truncate-end`\
+Allowed values: `wrap` `wrap-break-word` `truncate` `truncate-start` `truncate-middle` `truncate-end`\
 Default: `wrap`
 
 This property tells Ink to wrap or truncate text if its width is larger than container.
 If `wrap` is passed (by default), Ink will wrap text and split it into multiple lines.
+If `wrap-break-word` is passed, Ink will wrap text and split it into multiple lines, breaking words if necessary.
 If `truncate-*` is passed, Ink will truncate text instead, which will result in one line of text with the rest cut off.
 
 ```jsx

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -7,6 +7,7 @@ import Yoga, {type Node as YogaNode} from 'yoga-layout';
 export type Styles = {
 	readonly textWrap?:
 		| 'wrap'
+		| 'wrap-break-word'
 		| 'end'
 		| 'middle'
 		| 'truncate-end'

--- a/src/wrap-text.ts
+++ b/src/wrap-text.ts
@@ -25,6 +25,14 @@ const wrapText = (
 		});
 	}
 
+	if (wrapType === 'wrap-break-word') {
+		wrappedText = wrapAnsi(text, maxWidth, {
+			trim: false,
+			hard: true,
+			wordWrap: false,
+		});
+	}
+
 	if (wrapType!.startsWith('truncate')) {
 		let position: 'end' | 'middle' | 'start' = 'end';
 

--- a/test/text.tsx
+++ b/test/text.tsx
@@ -120,3 +120,21 @@ test('text with content "constructor" wraps correctly', t => {
 	const output = renderToString(<Text>constructor</Text>);
 	t.is(output, 'constructor');
 });
+
+test('text with "wrap" wraps correctly', t => {
+	const output = renderToString(
+		<Box width={7}>
+			<Text wrap="wrap">hello word!</Text>
+		</Box>,
+	);
+	t.is(output, 'hello\nword!');
+});
+
+test('text with "wrap-break-word" wraps correctly', t => {
+	const output = renderToString(
+		<Box width={7}>
+			<Text wrap="wrap-break-word">hello word!</Text>
+		</Box>,
+	);
+	t.is(output, 'hello w\nord!');
+});


### PR DESCRIPTION
Currently the `<Text />` only support `wrap` props to make Ink wrap text and split it into multiple lines

In this PR, add a `wrap-break-word` value for `wrap` props on `<Text />` component, which control this behavior