### PR TITLE
Fix extra newline in full-screen mode

### DIFF
--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -238,7 +238,7 @@ export default class Ink {
 
 		if (this.lastOutputHeight >= this.options.stdout.rows) {
 			this.options.stdout.write(
-				ansiEscapes.clearTerminal + this.fullStaticOutput + output + '\n',
+				ansiEscapes.clearTerminal + this.fullStaticOutput + output,
 			);
 			this.lastOutput = output;
 			this.lastOutputHeight = outputHeight;

--- a/test/fixtures/fullscreen-no-extra-newline.tsx
+++ b/test/fixtures/fullscreen-no-extra-newline.tsx
@@ -1,0 +1,33 @@
+import process from 'node:process';
+import React, {useEffect} from 'react';
+import {Box, Text, render, useApp} from '../../src/index.js';
+
+function FullScreen() {
+	const {exit} = useApp();
+
+	useEffect(() => {
+		// Exit after first render to check the output
+		const timer = setTimeout(() => {
+			exit();
+		}, 100);
+
+		return () => clearTimeout(timer);
+	}, [exit]);
+
+	// Force the root to occupy exactly terminal rows
+	const rows = Number(process.argv[2]) || 5;
+
+	return (
+		<Box height={rows} flexDirection="column">
+			<Box flexGrow={1}>
+				<Text>Full-screen: top</Text>
+			</Box>
+			<Text>Bottom line (should be usable)</Text>
+		</Box>
+	);
+}
+
+// Set terminal size from argument
+process.stdout.rows = Number(process.argv[2]) || 5;
+
+render(<FullScreen />);

--- a/test/fixtures/fullscreen-no-extra-newline.tsx
+++ b/test/fixtures/fullscreen-no-extra-newline.tsx
@@ -2,7 +2,7 @@ import process from 'node:process';
 import React, {useEffect} from 'react';
 import {Box, Text, render, useApp} from '../../src/index.js';
 
-function FullScreen() {
+function Fullscreen() {
 	const {exit} = useApp();
 
 	useEffect(() => {
@@ -32,4 +32,4 @@ function FullScreen() {
 // Set terminal size from argument
 process.stdout.rows = Number(process.argv[2]) || 5;
 
-render(<FullScreen />);
+render(<Fullscreen />);

--- a/test/fixtures/fullscreen-no-extra-newline.tsx
+++ b/test/fixtures/fullscreen-no-extra-newline.tsx
@@ -11,7 +11,9 @@ function FullScreen() {
 			exit();
 		}, 100);
 
-		return () => clearTimeout(timer);
+		return () => {
+			clearTimeout(timer);
+		};
 	}, [exit]);
 
 	// Force the root to occupy exactly terminal rows

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -145,7 +145,7 @@ test.serial('erase screen where state changes in small viewport', async t => {
 });
 
 test.serial(
-	'full-screen mode should not add extra newline at the bottom',
+	'fullscreen mode should not add extra newline at the bottom',
 	async t => {
 		const ps = term('fullscreen-no-extra-newline', ['5']);
 		await ps.waitForExit();
@@ -156,7 +156,7 @@ test.serial(
 
 		// Check that the bottom line is at the end without extra newlines
 		// In a 5-line terminal:
-		// Line 1: Full-screen: top
+		// Line 1: Fullscreen: top
 		// Lines 2-4: empty (from flexGrow)
 		// Line 5: Bottom line (should be usable)
 		const lines = lastFrame.split('\n');

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -170,10 +170,6 @@ test.serial(
 			lines[4]?.includes('Bottom line') ?? false,
 			'Bottom line should be on line 5',
 		);
-
-		if (lines.length > 5) {
-			t.fail('Should not have more than 5 lines (extra newline detected)');
-		}
 	},
 );
 

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -144,6 +144,36 @@ test.serial('erase screen where state changes in small viewport', async t => {
 	}
 });
 
+test.serial(
+	'full-screen mode should not add extra newline at the bottom',
+	async t => {
+		const ps = term('fullscreen-no-extra-newline', ['5']);
+		await ps.waitForExit();
+
+		// Get the final output
+		const output = ps.output;
+
+		// The output should end with the bottom line text, not an extra newline
+		t.true(output.includes('Bottom line'));
+
+		// Check that there's no trailing newline after the bottom line
+		// The output should not end with multiple newlines
+		const lines = output.split('\n');
+		const lastLine = lines[lines.length - 1];
+
+		// The last line should contain the bottom text or be part of ANSI escape codes
+		// but should not be an empty line caused by an extra newline
+		if (lastLine === '') {
+			// If the last line is empty, check if the second-to-last has the bottom text
+			const secondToLast = lines[lines.length - 2];
+			t.false(
+				secondToLast?.includes('Bottom line'),
+				'Bottom line should be on the last line, not have a blank line after it',
+			);
+		}
+	},
+);
+
 test.serial('clear output', async t => {
 	const ps = term('clear');
 	await ps.waitForExit();

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -152,17 +152,14 @@ test.serial(
 
 		t.true(ps.output.includes('Bottom line'));
 
-		const lastFrame = ps.output.split(ansiEscapes.clearTerminal).at(-1) || '';
-
-		// Remove cursor control sequences that node-pty might add
-		const cleanFrame = lastFrame.replace(/\x1b\[\?25[hl]/g, '');
+		const lastFrame = ps.output.split(ansiEscapes.clearTerminal).at(-1) ?? '';
 
 		// Check that the bottom line is at the end without extra newlines
 		// In a 5-line terminal:
 		// Line 1: Full-screen: top
 		// Lines 2-4: empty (from flexGrow)
 		// Line 5: Bottom line (should be usable)
-		const lines = cleanFrame.split('\n');
+		const lines = lastFrame.split('\n');
 
 		t.is(lines.length, 5, 'Should have exactly 5 lines for 5-row terminal');
 


### PR DESCRIPTION
## Summary
Fixed an issue where an extra newline was added at the bottom of the screen in full-screen mode.

Fix #752, Related https://github.com/vadimdemedes/ink/pull/717

## Changes
- Removed trailing newline from full-screen output
- Allow the bottom line of the terminal to be usable

## Test
- Added test to verify that the bottom line is correctly usable in full-screen mode