### PR TITLE
chore: changed the GitHub Actions specification to digest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
         node_version:
           - 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: ${{ matrix.node_version }}
       - run: npm install


### PR DESCRIPTION
## Summary

Updated GitHub Actions workflow to use pinned commit SHAs for improved security and reproducibility.

## Changes

- Replaced floating action versions with commit-specific references
  - Updated actions/checkout to v5.0.0 with SHA pinning
  - Updated actions/setup-node to v5.0.0 with SHA pinning