### PR TITLE
Initialize react-devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 	"peerDependencies": {
 		"@types/react": ">=19.0.0",
 		"react": ">=19.0.0",
-		"react-devtools-core": "^4.19.1"
+		"react-devtools-core": "^6.1.2"
 	},
 	"peerDependenciesMeta": {
 		"@types/react": {

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -8,4 +8,5 @@ import './devtools-window-polyfill.js';
 import devtools from 'react-devtools-core';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+(devtools as any).initialize();
 (devtools as any).connectToDevTools();


### PR DESCRIPTION
:wave: I've been trying to get react-devtools working with Ink and I believe it's been broken as of #719. Prior to #719 in 991aaa54eae39e1ad6d1964e747ea936d5a4ad12 one can run

`DEV=true node --loader ts-node/esm examples/counter`

And then `npx react-devtools` and it'll work great. But after #719 in b9e9466e76c9f9822cc5611a47a6681c8d379d25 devtools will connect  fine but fail to load the element tree

<img width="514" height="161" alt="Image" src="https://github.com/user-attachments/assets/d0c89a38-05b8-4e95-89f1-2c505d08dbf8" />

I'm guessing this is because Ink's version of react-devtools-core at this commit (`^5.0.0`) is not compatible with React 19. It has since been upgraded to 6.1.2 in https://github.com/vadimdemedes/ink/commit/434b713b33c84d6c9b9f8c3f45513b4de86abb10 but upgrading `react-devtools-core` to 6.x requires patching devtools.ts to manually initialize the library (https://github.com/facebook/react/commit/a86afe8e560f452a9df5ceb4893d9423e5840800).

> Previously, we would call `installHook` at a top level of the JavaScript
> module. Because of this, having `require` statement for
> `react-devtools-core` package was enough to initialize the React
> DevTools global hook on the `window`.
> 
> Now, the Hook can actually receive an argument - initial user settings
> for console patching. We expose this as a function `initialize`, which
> can be used by third parties (including React Native) to provide the
> persisted settings.
> 

Lastly I've updated the peer dependency to match what is in `devDependencies` so that dependant projects know to install a version that is compatible with react 19.