### PR TITLE
Add ink-picture to the list of useful components

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2298,6 +2298,7 @@ For a practical example of building an accessible component, see the [ARIA examp
 - [ink-spawn](https://github.com/kraenhansen/ink-spawn) - Spawn child processes.
 - [ink-titled-box](https://github.com/mishieck/ink-titled-box) - Box with a title.
 - [ink-chart](https://github.com/pppp606/ink-chart) - Sparkline and bar chart.
+- [ink-picture](https://github.com/endernoke/ink-picture) - More advanced and modern image component with Ink 6 support.
 
 ## Useful Hooks
 


### PR DESCRIPTION
## Summary
Add [ink-picture](https://github.com/endernoke/ink-picture) to the Useful Components section in the README.

ink-picture enables Ink apps to render images with different protocols, e.g. sixel, kitty terminal graphics protocol, etc. as well as ascii art fallbacks.

The component has full typescript support.
 
I am the author of this library.

I am aware of the existence of [ink-image](https://github.com/kevva/ink-image), but unfortunately that project is unmaintained and doesn't support Ink 3+.

## Test plan
* [x]  Link is correct and working
* [x]  Description accurately represents the library's functionality
* [x]  Follows the same format as other entries in the Useful Components section

---

As a side note, should we order the who's using ink and useful components/hooks entries in alphabetical order to reduce the chance of merge conflicts?