### PR TITLE
Add failing test for dim+bold text

### DIFF
--- a/test/text.tsx
+++ b/test/text.tsx
@@ -20,6 +20,15 @@ test('text with standard color', t => {
 	t.is(output, chalk.green('Test'));
 });
 
+test.failing('text with dim+bold', t => {
+	const output = renderToString(
+		<Text dimColor bold>
+			Test
+		</Text>,
+	);
+	t.is(output, chalk.dim.bold('Test'));
+});
+
 test('text with dimmed color', t => {
 	const output = renderToString(
 		<Text dimColor color="green">


### PR DESCRIPTION
Dim+bold text is rendered as dim but not bold.