### PR TITLE
Add Nanocoder to Who's Using Ink section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,7 @@ Feel free to play around with the code and fork this Repl at [https://repl.it/@v
 - [tweakcc](https://github.com/Piebald-AI/tweakcc) - Customize your Claude Code styling.
 - [argonaut](https://github.com/darksworm/argonaut) - Manage Argo CD resources.
 - [Qodo Command](https://github.com/qodo-ai/command) - Build, run, and manage AI agents.
-- [Nanocoder](https://github.com/nano-collective/nano-coder) - A community-built, local-first AI coding agent with multi-provider support.
+- [Nanocoder](https://github.com/nano-collective/nanocoder) - A community-built, local-first AI coding agent with multi-provider support.
 
 *(PRs welcome. Append new entries at the end. Repos must have 100+ stars and showcase Ink beyond a basic list picker.)*
 


### PR DESCRIPTION
This PR adds Nanocoder to the "Who's Using Ink?" section of the README.

Nanocoder is a community-built, local-first AI coding agent with multi-provider support (Ollama, OpenRouter, and OpenAI-compatible APIs). It's built with Ink and React, providing an interactive CLI experience for AI-assisted coding.

Repository: https://github.com/nano-collective/nanocoder