### PR TITLE
chore: bump react-reconciler and remove unused ts-expect-error

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 		"@types/ms": "^2.1.0",
 		"@types/node": "^22.15.24",
 		"@types/react": "^19.1.5",
-		"@types/react-reconciler": "^0.32.0",
+		"@types/react-reconciler": "^0.32.2",
 		"@types/signal-exit": "^3.0.0",
 		"@types/sinon": "^17.0.3",
 		"@types/stack-utils": "^2.0.2",

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -104,8 +104,6 @@ export default class Ink {
 			'id',
 			() => {},
 			() => {},
-			// @ts-expect-error the types for `react-reconciler` are not up to date with the library.
-			// See https://github.com/facebook/react/blob/c0464aedb16b1c970d717651bba8d1c66c578729/packages/react-reconciler/src/ReactFiberReconciler.js#L236-L259
 			() => {},
 			() => {},
 			null,


### PR DESCRIPTION
## Summary

`@types/react-reconciler` had a release which is now breaking CI due to a `ts-expect-error` no longer being relevant (see #789 CI for example). This increments the dev dependency and also removes the unused `ts-expect-error`.