### PR TITLE
Document missing stderr option in render()

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2009,6 +2009,13 @@ Default: `process.stdin`
 
 Input stream where app will listen for input.
 
+###### stderr
+
+Type: `stream.Writable`\
+Default: `process.stderr`
+
+Error stream.
+
 ###### exitOnCtrlC
 
 Type: `boolean`\


### PR DESCRIPTION
  ## Summary
  Added missing documentation for the `stderr` option in `render()`.

  The `stderr` option existed in the `RenderOptions` type but was not
  documented in the README's API reference section.

  This is a small documentation-only change. Please review when you have
  time.