### PR TITLE
fix: readme screen reader support <Box> example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2208,7 +2208,7 @@ For example, for this code:
 
 ```jsx
 <Box aria-role="checkbox" aria-state={{checked: true}}>
-	Accept terms and conditions
+	<Text>Accept terms and conditions</Text>
 </Box>
 ```
 


### PR DESCRIPTION
Continuation of #802 

Directly copy pasting the following code from the readme would result in an error without wrapping the string in a `<Text>` component.
```
<Box aria-role="checkbox" aria-state={{checked: true}}>
	Accept terms and conditions
</Box>
```

Error:
```
  ERROR  Text string "Accept terms and conditions" must be rendered inside <Text> component

 node_modules/.pnpm/ink@6.3.1_@types+react@19.2.2_react-devtools-core@7.0.1_react@19.2.0/node_modules/ink/build/reconciler.js:136:19

 133:     },
 134:     createTextInstance(text, _root, hostContext) {
 135:         if (!hostContext.isInsideText) {
 136:             throw new Error(`Text string "${text}" must be rendered inside <Text> component`);
 137:         }
 138:         return createTextNode(text);
 139:     },
```
