### PR TITLE
fix: ui stamping artifacts on terminal resize

### DIFF
--- a/examples/terminal-resize/index.ts
+++ b/examples/terminal-resize/index.ts
@@ -1,0 +1,1 @@
+import './terminal-resize.js';

--- a/examples/terminal-resize/terminal-resize.tsx
+++ b/examples/terminal-resize/terminal-resize.tsx
@@ -1,0 +1,40 @@
+import React, {useState} from 'react';
+import {render, Box, Text, useInput} from '../../src/index.js';
+
+function TerminalResizeTest() {
+	const [value, setValue] = useState('');
+
+	useInput(input => {
+		if (input === '\r') {
+			// Enter key - clear input
+			setValue('');
+		} else if (input === '\u007F' || input === '\b') {
+			// Backspace
+			setValue(previous => previous.slice(0, -1));
+		} else {
+			// Regular character
+			setValue(previous => previous + input);
+		}
+	});
+
+	return (
+		<Box flexDirection="column" padding={1}>
+			<Text bold color="cyan">
+				=== Terminal Resize Test ===
+			</Text>
+			<Text>
+				Type something and then resize your terminal (drag the edge or press
+				Cmd/Ctrl -/+)
+			</Text>
+			<Text>Input: "{value}"</Text>
+			<Box marginTop={1}>
+				<Text dimColor>Press Ctrl+C to exit</Text>
+			</Box>
+		</Box>
+	);
+}
+
+render(<TerminalResizeTest />, {
+	patchConsole: true,
+	exitOnCtrlC: true,
+});

--- a/test/terminal-resize.tsx
+++ b/test/terminal-resize.tsx
@@ -1,0 +1,157 @@
+import test from 'ava';
+import delay from 'delay';
+import stripAnsi from 'strip-ansi';
+import React from 'react';
+import {render, Box, Text} from '../src/index.js';
+import createStdout from './helpers/create-stdout.js';
+
+test.serial('clear screen when terminal width decreases', async t => {
+	const stdout = createStdout(100);
+
+	function Test() {
+		return (
+			<Box borderStyle="round">
+				<Text>Hello World</Text>
+			</Box>
+		);
+	}
+
+	render(<Test />, {stdout});
+
+	const initialOutput = stripAnsi(
+		(stdout.write as any).firstCall.args[0] as string,
+	);
+	t.true(initialOutput.includes('Hello World'));
+	t.true(initialOutput.includes('╭')); // Box border
+
+	// Decrease width - should trigger clear and rerender
+	stdout.columns = 50;
+	stdout.emit('resize');
+	await delay(100);
+
+	// Verify the output was updated for smaller width
+	const lastOutput = stripAnsi(
+		(stdout.write as any).lastCall.args[0] as string,
+	);
+	t.true(lastOutput.includes('Hello World'));
+	t.true(lastOutput.includes('╭')); // Box border
+	t.not(initialOutput, lastOutput); // Output should change due to width
+});
+
+test.serial('no screen clear when terminal width increases', async t => {
+	const stdout = createStdout(50);
+
+	function Test() {
+		return (
+			<Box borderStyle="round">
+				<Text>Test</Text>
+			</Box>
+		);
+	}
+
+	render(<Test />, {stdout});
+
+	const initialOutput = (stdout.write as any).firstCall.args[0] as string;
+
+	// Increase width - should rerender but not clear
+	stdout.columns = 100;
+	stdout.emit('resize');
+	await delay(100);
+
+	const lastOutput = (stdout.write as any).lastCall.args[0] as string;
+
+	// When increasing width, we don't clear, so we should see eraseLines used for incremental update
+	// But when decreasing, the clear() is called which also uses eraseLines
+	// The key difference: decreasing width triggers an explicit clear before render
+	t.not(stripAnsi(initialOutput), stripAnsi(lastOutput));
+	t.true(stripAnsi(lastOutput).includes('Test'));
+});
+
+test.serial(
+	'consecutive width decreases trigger screen clear each time',
+	async t => {
+		const stdout = createStdout(100);
+
+		function Test() {
+			return (
+				<Box borderStyle="round">
+					<Text>Content</Text>
+				</Box>
+			);
+		}
+
+		render(<Test />, {stdout});
+
+		const initialOutput = stripAnsi(
+			(stdout.write as any).firstCall.args[0] as string,
+		);
+
+		// First decrease
+		stdout.columns = 80;
+		stdout.emit('resize');
+		await delay(100);
+
+		const afterFirstDecrease = stripAnsi(
+			(stdout.write as any).lastCall.args[0] as string,
+		);
+		t.not(initialOutput, afterFirstDecrease);
+		t.true(afterFirstDecrease.includes('Content'));
+
+		// Second decrease
+		stdout.columns = 60;
+		stdout.emit('resize');
+		await delay(100);
+
+		const afterSecondDecrease = stripAnsi(
+			(stdout.write as any).lastCall.args[0] as string,
+		);
+		t.not(afterFirstDecrease, afterSecondDecrease);
+		t.true(afterSecondDecrease.includes('Content'));
+	},
+);
+
+test.serial('width decrease clears lastOutput to force rerender', async t => {
+	const stdout = createStdout(100);
+
+	function Test() {
+		return (
+			<Box borderStyle="round">
+				<Text>Test Content</Text>
+			</Box>
+		);
+	}
+
+	const {rerender} = render(<Test />, {stdout});
+
+	const initialOutput = stripAnsi(
+		(stdout.write as any).firstCall.args[0] as string,
+	);
+
+	// Decrease width - with a border, this will definitely change the output
+	stdout.columns = 50;
+	stdout.emit('resize');
+	await delay(100);
+
+	const afterResizeOutput = stripAnsi(
+		(stdout.write as any).lastCall.args[0] as string,
+	);
+
+	// Outputs should be different because the border width changed
+	t.not(initialOutput, afterResizeOutput);
+	t.true(afterResizeOutput.includes('Test Content'));
+
+	// Now try to rerender with a different component
+	rerender(
+		<Box borderStyle="round">
+			<Text>Updated Content</Text>
+		</Box>,
+	);
+	await delay(100);
+
+	// Verify content was updated
+	t.true(
+		stripAnsi((stdout.write as any).lastCall.args[0] as string).includes(
+			'Updated Content',
+		),
+	);
+});


### PR DESCRIPTION
## Summary

Fixes an issue where decreasing terminal width results in duplicate UI stamping artifacts.

Fixes #816
Fixes #711

## Commentary

Reducing terminal width results in duplicate UI stamping because `previousOutput` becomes stale, resulting in a failure to erase lines that are in the delta between the new and previous render height. This creates a rendering *dead zone*. This is not an issue when increasing terminal width since the line count will either stay the same or decrease.

The simplest solution here is to clear the log when the terminal width shrinks.

### Before

https://github.com/user-attachments/assets/f808d798-4386-4dc8-93a2-4aa84c04f6ef

### After

https://github.com/user-attachments/assets/4e1fd9e8-a1bf-48dc-be77-2221fcf5e5f2

