### PR TITLE
Add activeId property to useFocusManager hook

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1962,6 +1962,22 @@ const Example = () => {
 };
 ```
 
+#### activeId
+
+Type: `string | undefined`
+
+[`id`](#id) of the currently focused component. If there's no active focus on component right now, the value is `undefined`.
+
+```js
+import {useFocusManager} from 'ink';
+
+const Example = () => {
+	const {activeId} = useFocusManager();
+
+	return <Text>Focused component ID: {activeId ?? "-"}</Text>;
+};
+```
+
 ### useIsScreenReaderEnabled()
 
 Returns whether a screen reader is enabled. This is useful when you want to render different output for screen readers.

--- a/src/hooks/use-focus-manager.ts
+++ b/src/hooks/use-focus-manager.ts
@@ -26,6 +26,11 @@ type Output = {
 	Switch focus to the element with provided `id`. If there's no element with that `id`, focus will be given to the first focusable component.
 	*/
 	focus: Props['focus'];
+
+	/**
+	Contains the `id` of the currently focused component. If no component is focused, the value will be `undefined`.
+	*/
+	activeId: Props['activeId'];
 };
 
 /**
@@ -40,6 +45,7 @@ const useFocusManager = (): Output => {
 		focusNext: focusContext.focusNext,
 		focusPrevious: focusContext.focusPrevious,
 		focus: focusContext.focus,
+		activeId: focusContext.activeId,
 	};
 };
 

--- a/test/focus.tsx
+++ b/test/focus.tsx
@@ -508,3 +508,30 @@ test('skips disabled elements when wrapping around from the front', async t => {
 		['First', 'Second ✔', 'Third'].join('\n'),
 	);
 });
+
+test('the focus helper reports whichever id currently holds focus', async t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+
+	let activeId: string | undefined;
+
+	function TestActiveId() {
+		const focusManager = useFocusManager();
+		activeId = focusManager.activeId;
+
+		return <Test autoFocus />;
+	}
+
+	render(<TestActiveId />, {
+		stdout,
+		stdin,
+		debug: true,
+	});
+
+	await delay(100);
+	t.not(activeId, undefined);
+
+	emitReadable(stdin, '\u001B');
+	await delay(100);
+	t.is(activeId, undefined);
+});


### PR DESCRIPTION
## Summary

  - Exposes `activeId` property from `FocusContext` in `useFocusManager` hook to get the `id` of the currently focused component
  - Returns `undefined` when no component has focus
  - Added test coverage for the new property
  - Updated documentation in root readme

## Use case

This allows components to programmatically check which component currently has focus without needing to track focus state manually. Useful for displaying focus state in UI or conditionally rendering based on what's focused.

## Test plan
  - Added new test _"the focus helper reports whichever id currently holds focus"_ in test/focus.tsx
  - Test verifies that `activeId` is defined when a component is focused
  - Test verifies that `activeId` becomes `undefined` when focus is cleared with Esc key