### PR TITLE
perf: use caches to speed up output generation

### DIFF
--- a/src/output.ts
+++ b/src/output.ts
@@ -54,7 +54,7 @@ class OutputCaches {
 
 	getStyledChars(line: string): StyledChar[] {
 		let cached = this.styledChars.get(line);
-		if (!cached) {
+		if (cached === undefined) {
 			cached = styledCharsFromTokens(tokenize(line));
 			this.styledChars.set(line, cached);
 		}
@@ -64,7 +64,7 @@ class OutputCaches {
 
 	getStringWidth(text: string): number {
 		let cached = this.widths.get(text);
-		if (!cached) {
+		if (cached === undefined) {
 			cached = stringWidth(text);
 			this.widths.set(text, cached);
 		}
@@ -74,7 +74,7 @@ class OutputCaches {
 
 	getWidestLine(text: string): number {
 		let cached = this.blockWidths.get(text);
-		if (!cached) {
+		if (cached === undefined) {
 			let lineWidth = 0;
 			for (const line of text.split('\n')) {
 				lineWidth = Math.max(lineWidth, this.getStringWidth(line));


### PR DESCRIPTION
Really only noticeable for huge terminals so hard to use the current benchmarks, but anecdotally on my 150x200 terminal it's sped renders up from ~40ms to ~9ms, so almost 5x faster. Presumably it'd be more of a speedup the larger the terminal gets.

All tests (that were passing on current `master`) are passing.