### PR TITLE
fix(incremental-rendering): individual line flicker

### DIFF
--- a/src/log-update.ts
+++ b/src/log-update.ts
@@ -111,7 +111,12 @@ const createIncremental = (
 				continue;
 			}
 
-			buffer.push(ansiEscapes.eraseLine + nextLines[i] + '\n');
+			buffer.push(
+				ansiEscapes.cursorTo(0) +
+					nextLines[i] +
+					ansiEscapes.eraseEndLine +
+					'\n',
+			);
 		}
 
 		stream.write(buffer.join(''));


### PR DESCRIPTION
## Summary

Writes changed lines directly instead of using `eraseLine` first, preventing flickering effects during an incremental render.

## Commentary

Tested this on the existing incremental rendering ink example. I don't think any new tests are necessary here since this is a tiny optimization.