### PR TITLE
Removed indent-string as dependency and replaced usages with built-in function

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
 		"cli-truncate": "^5.1.1",
 		"code-excerpt": "^4.0.0",
 		"es-toolkit": "^1.39.10",
-		"indent-string": "^5.0.0",
 		"is-in-ci": "^2.0.0",
 		"patch-console": "^2.0.0",
 		"react-reconciler": "^0.33.0",

--- a/src/indent-string.ts
+++ b/src/indent-string.ts
@@ -1,0 +1,16 @@
+type Options = {
+	readonly indent?: string;
+	readonly includeEmptyLines?: boolean;
+};
+
+export default function indentString(
+	string: string,
+	count = 1,
+	{indent = ' ', includeEmptyLines = false}: Options = {},
+): string {
+	if (count === 0) return string;
+
+	const regex = includeEmptyLines ? /^/gm : /^(?!\s*$)/gm;
+
+	return string.replace(regex, indent.repeat(count));
+}

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -1,6 +1,6 @@
 import widestLine from 'widest-line';
-import indentString from 'indent-string';
 import Yoga from 'yoga-layout';
+import indentString from './indent-string.js';
 import wrapText from './wrap-text.js';
 import getMaxWidth from './get-max-width.js';
 import squashTextNodes from './squash-text-nodes.js';

--- a/test/borders.tsx
+++ b/test/borders.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import test from 'ava';
 import boxen from 'boxen';
-import indentString from 'indent-string';
 import cliBoxes from 'cli-boxes';
 import chalk from 'chalk';
+import indentString from '../src/indent-string.js';
 import {render, Box, Text} from '../src/index.js';
 import {renderToString} from './helpers/render-to-string.js';
 import createStdout from './helpers/create-stdout.js';


### PR DESCRIPTION
The denepdency `indent-string` is extremaly minimal one, MIT licensed. I don't believe there is a point in keeping in as dependency in `node_modules` when it can easily be a function built in the codebase itself. There is not much more to maintain, it does one thing and does it well. In this case I propose to merge this PR, reducing the amount of dependencies for this project. 