### PR TITLE
feat: add Kitty keyboard protocol support (Ralph Wiggum approach)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -154,6 +154,7 @@ Feel free to play around with the code and fork this Repl at [https://repl.it/@v
 - [Useful Components](#useful-components)
 - [Useful Hooks](#useful-hooks)
 - [Examples](#examples)
+- [Kitty Keyboard Protocol](#kitty-keyboard-protocol)
 
 ## Getting Started
 
@@ -1589,6 +1590,22 @@ Default: `false`
 
 [Meta key](https://en.wikipedia.org/wiki/Meta_key) was pressed.
 
+###### key.super
+
+Type: `boolean`\
+Default: `false`
+
+Super key (Windows key or Command key on macOS) was pressed.
+This is only reliably detected when the terminal supports the [Kitty keyboard protocol](#kitty-keyboard-protocol).
+
+###### key.isKittyProtocol
+
+Type: `boolean`\
+Default: `false`
+
+Whether this keypress was detected via the [Kitty keyboard protocol](#kitty-keyboard-protocol).
+When `true`, modifier detection is more reliable (e.g., Shift+Enter is distinguishable from Enter, Ctrl+I is distinguishable from Tab).
+
 #### options
 
 Type: `object`
@@ -2353,6 +2370,74 @@ npm run example examples/[example name]
 - [Write to stderr](examples/use-stderr/use-stderr.tsx) - Write to stderr, bypassing main Ink output.
 - [Static](examples/static/static.tsx) - Use the `<Static>` component to render permanent output.
 - [Child process](examples/subprocess-output) - Renders output from a child process.
+
+## Kitty Keyboard Protocol
+
+Ink supports the [Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/), which provides enhanced keyboard input detection in supporting terminals.
+
+### What it enables
+
+With the Kitty keyboard protocol, Ink can reliably distinguish between:
+- **Shift+Enter vs Enter** - Traditional terminals send the same escape code for both
+- **Ctrl+I vs Tab** - These are normally indistinguishable
+- **Ctrl+M vs Enter** - Same issue as above
+- **Super key (⌘/Windows)** - Not detectable in legacy mode
+
+### Supported terminals
+
+The following terminals support the Kitty keyboard protocol:
+- [Kitty](https://sw.kovidgoyal.net/kitty/)
+- [iTerm2](https://iterm2.com/)
+- [Alacritty](https://alacritty.org/)
+- [Ghostty](https://ghostty.org/)
+- [WezTerm](https://wezfurlong.org/wezterm/)
+- [Foot](https://codeberg.org/dnkl/foot)
+- [Rio](https://raphamorim.io/rio/)
+
+### Usage
+
+The protocol is automatically enabled when Ink detects a supporting terminal. No configuration is needed.
+
+To check if a keypress was detected via the Kitty protocol, use the `isKittyProtocol` property:
+
+```jsx
+import {useInput} from 'ink';
+
+const Example = () => {
+	useInput((input, key) => {
+		if (key.return && key.shift) {
+			// This only works reliably when key.isKittyProtocol is true
+			console.log('Shift+Enter pressed!');
+		}
+
+		if (key.isKittyProtocol) {
+			console.log('Enhanced keyboard detection is active');
+		}
+	});
+
+	return null;
+};
+```
+
+### Exported constants
+
+Ink exports the following constants for advanced use cases:
+
+```jsx
+import {KittyModifiers, KittyFlags} from 'ink';
+
+// Modifier bit values
+KittyModifiers.shift   // 1
+KittyModifiers.alt     // 2
+KittyModifiers.ctrl    // 4
+KittyModifiers.super   // 8
+
+// Protocol enhancement flags
+KittyFlags.disambiguateEscapeCodes    // 1 (enabled by default)
+KittyFlags.reportEventTypes           // 2
+KittyFlags.reportAlternateKeys        // 4
+KittyFlags.reportAllKeysAsEscapeCodes // 8
+```
 
 ## Maintainers
 

--- a/src/components/StdinContext.ts
+++ b/src/components/StdinContext.ts
@@ -18,6 +18,12 @@ export type Props = {
 	*/
 	readonly isRawModeSupported: boolean;
 
+	/**
+	Whether the Kitty keyboard protocol is enabled. When enabled, modifier key detection
+	is more reliable (e.g., Shift+Enter is distinguishable from Enter).
+	*/
+	readonly isKittyProtocolEnabled: boolean;
+
 	readonly internal_exitOnCtrlC: boolean;
 
 	readonly internal_eventEmitter: EventEmitter;
@@ -33,6 +39,7 @@ const StdinContext = createContext<Props>({
 	internal_eventEmitter: new EventEmitter(),
 	setRawMode() {},
 	isRawModeSupported: false,
+	isKittyProtocolEnabled: false,
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	internal_exitOnCtrlC: true,
 });

--- a/src/hooks/use-input.ts
+++ b/src/hooks/use-input.ts
@@ -86,6 +86,19 @@ export type Key = {
 	[Meta key](https://en.wikipedia.org/wiki/Meta_key) was pressed.
 	*/
 	meta: boolean;
+
+	/**
+	Super key (Windows key or Command key on macOS) was pressed.
+	Only reliably detected when Kitty keyboard protocol is enabled.
+	*/
+	super: boolean;
+
+	/**
+	Whether this keypress was detected via the Kitty keyboard protocol.
+	When true, modifier detection is more reliable (e.g., Shift+Enter
+	is distinguishable from Enter, Ctrl+I is distinguishable from Tab).
+	*/
+	isKittyProtocol: boolean;
 };
 
 type Handler = (input: string, key: Key) => void;
@@ -145,7 +158,7 @@ const useInput = (inputHandler: Handler, options: Options = {}) => {
 		const handleData = (data: string) => {
 			const keypress = parseKeypress(data);
 
-			const key = {
+			const key: Key = {
 				upArrow: keypress.name === 'up',
 				downArrow: keypress.name === 'down',
 				leftArrow: keypress.name === 'left',
@@ -154,7 +167,7 @@ const useInput = (inputHandler: Handler, options: Options = {}) => {
 				pageUp: keypress.name === 'pageup',
 				home: keypress.name === 'home',
 				end: keypress.name === 'end',
-				return: keypress.name === 'return',
+				return: keypress.name === 'return' || keypress.name === 'enter',
 				escape: keypress.name === 'escape',
 				ctrl: keypress.ctrl,
 				shift: keypress.shift,
@@ -166,6 +179,8 @@ const useInput = (inputHandler: Handler, options: Options = {}) => {
 				// to avoid breaking changes in Ink.
 				// TODO(vadimdemedes): consider removing this in the next major version.
 				meta: keypress.meta || keypress.name === 'escape' || keypress.option,
+				super: keypress.super ?? false,
+				isKittyProtocol: keypress.isKittyProtocol ?? false,
 			};
 
 			let input = keypress.ctrl ? keypress.name : keypress.sequence;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,12 @@ export {default as Newline} from './components/Newline.js';
 export {default as Spacer} from './components/Spacer.js';
 export type {Key} from './hooks/use-input.js';
 export {default as useInput} from './hooks/use-input.js';
+export {
+	KittyModifiers,
+	KittyFlags,
+	type KittyKeypress,
+	type KittyEventType,
+} from './kitty-keyboard.js';
 export {default as useApp} from './hooks/use-app.js';
 export {default as useStdin} from './hooks/use-stdin.js';
 export {default as useStdout} from './hooks/use-stdout.js';

--- a/src/kitty-keyboard.ts
+++ b/src/kitty-keyboard.ts
@@ -1,0 +1,537 @@
+/**
+ * Kitty Keyboard Protocol support for Ink
+ *
+ * This module implements parsing and handling of the Kitty keyboard protocol,
+ * which provides enhanced keyboard input detection including:
+ * - Reliable modifier key detection (Shift, Ctrl, Alt, Super, Hyper, Meta)
+ * - Disambiguation of keys like Ctrl+I vs Tab, Shift+Enter vs Enter
+ * - Support for key event types (press, repeat, release)
+ *
+ * Protocol spec: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+ */
+
+/**
+ * Modifier bitfield values as defined by the Kitty keyboard protocol.
+ * These are the raw bit values; the protocol sends (1 + modifiers).
+ */
+export const KittyModifiers = {
+	shift: 0b1,
+	alt: 0b10,
+	ctrl: 0b100,
+	super: 0b1000,
+	hyper: 0b10000,
+	meta: 0b100000,
+	capsLock: 0b1000000,
+	numLock: 0b10000000,
+} as const;
+
+/**
+ * Progressive enhancement flags for the Kitty keyboard protocol.
+ */
+export const KittyFlags = {
+	/**
+	 * Disambiguate escape codes - makes keys like Ctrl+I distinguishable from Tab
+	 */
+	disambiguateEscapeCodes: 0b1,
+	/**
+	 * Report key event types (press=1, repeat=2, release=3)
+	 */
+	reportEventTypes: 0b10,
+	/**
+	 * Report alternate keys (shifted and base layout variants)
+	 */
+	reportAlternateKeys: 0b100,
+	/**
+	 * Report all keys as escape codes (not just special ones)
+	 */
+	reportAllKeysAsEscapeCodes: 0b1000,
+	/**
+	 * Report associated text as codepoints
+	 */
+	reportAssociatedText: 0b10000,
+} as const;
+
+/**
+ * Functional key codes from the Unicode Private Use Area
+ * as defined by the Kitty keyboard protocol.
+ */
+export const KittyFunctionalKeys: Record<number, string> = {
+	// Standard ASCII control codes used as key identifiers
+	27: 'escape',
+	13: 'return',
+	9: 'tab',
+	127: 'backspace',
+
+	// Navigation keys
+	57344: 'escape', // ESCAPE alternate
+	57345: 'enter', // ENTER alternate (KP_ENTER uses different code)
+	57346: 'tab', // TAB alternate
+	57347: 'backspace', // BACKSPACE alternate
+	57348: 'insert',
+	57349: 'delete',
+	57350: 'left',
+	57351: 'right',
+	57352: 'up',
+	57353: 'down',
+	57354: 'pageup',
+	57355: 'pagedown',
+	57356: 'home',
+	57357: 'end',
+	57358: 'capslock',
+	57359: 'scrolllock',
+	57360: 'numlock',
+	57361: 'printscreen',
+	57362: 'pause',
+	57363: 'menu',
+
+	// Function keys F1-F35
+	57364: 'f1',
+	57365: 'f2',
+	57366: 'f3',
+	57367: 'f4',
+	57368: 'f5',
+	57369: 'f6',
+	57370: 'f7',
+	57371: 'f8',
+	57372: 'f9',
+	57373: 'f10',
+	57374: 'f11',
+	57375: 'f12',
+	57376: 'f13',
+	57377: 'f14',
+	57378: 'f15',
+	57379: 'f16',
+	57380: 'f17',
+	57381: 'f18',
+	57382: 'f19',
+	57383: 'f20',
+	57384: 'f21',
+	57385: 'f22',
+	57386: 'f23',
+	57387: 'f24',
+	57388: 'f25',
+	57389: 'f26',
+	57390: 'f27',
+	57391: 'f28',
+	57392: 'f29',
+	57393: 'f30',
+	57394: 'f31',
+	57395: 'f32',
+	57396: 'f33',
+	57397: 'f34',
+	57398: 'f35',
+
+	// Keypad keys
+	57399: 'kp_0',
+	57400: 'kp_1',
+	57401: 'kp_2',
+	57402: 'kp_3',
+	57403: 'kp_4',
+	57404: 'kp_5',
+	57405: 'kp_6',
+	57406: 'kp_7',
+	57407: 'kp_8',
+	57408: 'kp_9',
+	57409: 'kp_decimal',
+	57410: 'kp_divide',
+	57411: 'kp_multiply',
+	57412: 'kp_subtract',
+	57413: 'kp_add',
+	57414: 'kp_enter',
+	57415: 'kp_equal',
+	57416: 'kp_separator',
+	57417: 'kp_left',
+	57418: 'kp_right',
+	57419: 'kp_up',
+	57420: 'kp_down',
+	57421: 'kp_pageup',
+	57422: 'kp_pagedown',
+	57423: 'kp_home',
+	57424: 'kp_end',
+	57425: 'kp_insert',
+	57426: 'kp_delete',
+	57427: 'kp_begin',
+
+	// Media keys
+	57428: 'media_play',
+	57429: 'media_pause',
+	57430: 'media_play_pause',
+	57431: 'media_reverse',
+	57432: 'media_stop',
+	57433: 'media_fast_forward',
+	57434: 'media_rewind',
+	57435: 'media_track_next',
+	57436: 'media_track_previous',
+	57437: 'media_record',
+	57438: 'lower_volume',
+	57439: 'raise_volume',
+	57440: 'mute_volume',
+
+	// Modifier keys (when reported as key events)
+	57441: 'left_shift',
+	57442: 'left_control',
+	57443: 'left_alt',
+	57444: 'left_super',
+	57445: 'left_hyper',
+	57446: 'left_meta',
+	57447: 'right_shift',
+	57448: 'right_control',
+	57449: 'right_alt',
+	57450: 'right_super',
+	57451: 'right_hyper',
+	57452: 'right_meta',
+	57453: 'iso_level3_shift',
+	57454: 'iso_level5_shift',
+};
+
+/**
+ * Event types for key events in the Kitty keyboard protocol.
+ */
+export type KittyEventType = 'press' | 'repeat' | 'release';
+
+/**
+ * Parsed result from a Kitty keyboard protocol escape sequence.
+ */
+export type KittyKeypress = {
+	/**
+	 * The key name (e.g., 'return', 'tab', 'a', 'f1')
+	 */
+	name: string;
+	/**
+	 * The Unicode codepoint of the key
+	 */
+	codepoint: number;
+	/**
+	 * Whether the Shift modifier was held
+	 */
+	shift: boolean;
+	/**
+	 * Whether the Alt (Option on macOS) modifier was held
+	 */
+	alt: boolean;
+	/**
+	 * Whether the Ctrl modifier was held
+	 */
+	ctrl: boolean;
+	/**
+	 * Whether the Super (Windows/Command) modifier was held
+	 */
+	super: boolean;
+	/**
+	 * Whether the Hyper modifier was held
+	 */
+	hyper: boolean;
+	/**
+	 * Whether the Meta modifier was held
+	 */
+	meta: boolean;
+	/**
+	 * Whether Caps Lock was active
+	 */
+	capsLock: boolean;
+	/**
+	 * Whether Num Lock was active
+	 */
+	numLock: boolean;
+	/**
+	 * The type of key event (press, repeat, or release)
+	 */
+	eventType: KittyEventType;
+	/**
+	 * The original escape sequence
+	 */
+	sequence: string;
+	/**
+	 * Whether this keypress was parsed from a Kitty protocol sequence
+	 */
+	isKittyProtocol: true;
+};
+
+/**
+ * Regex to match Kitty keyboard protocol CSI u sequences.
+ *
+ * Format: CSI unicode-key-code:alternate-keys ; modifiers:event-type ; text-as-codepoints u
+ *
+ * Examples:
+ * - \x1b[97u - 'a' key with no modifiers
+ * - \x1b[97;2u - 'a' key with shift
+ * - \x1b[13;2u - Enter key with shift (Shift+Enter)
+ * - \x1b[9;5u - Tab key with ctrl (Ctrl+Tab, distinguishable from Ctrl+I)
+ */
+const kittySequenceRegex =
+	/^\x1b\[(\d+)(?::[\d:]*)?(?:;(\d+)(?::(\d+))?)?(?:;[\d:]*)?u$/;
+
+/**
+ * Regex to match Kitty keyboard protocol CSI ~ sequences for functional keys.
+ *
+ * Format: CSI number ; modifiers ~
+ *
+ * Examples:
+ * - \x1b[3~    - Delete key
+ * - \x1b[3;2~  - Shift+Delete
+ * - \x1b[5~    - Page Up
+ */
+const kittyTildeSequenceRegex = /^\x1b\[(\d+)(?:;(\d+))?~$/;
+
+/**
+ * Regex to match Kitty keyboard protocol letter-terminated sequences.
+ *
+ * Format: CSI 1 ; modifiers [ABCDEFHPQRS]
+ *
+ * Examples:
+ * - \x1b[1;2A  - Shift+Up
+ * - \x1b[1;5C  - Ctrl+Right
+ */
+const kittyLetterSequenceRegex = /^\x1b\[1;(\d+)([ABCDEFHPQRS])$/;
+
+/**
+ * Letter code to key name mapping for letter-terminated sequences.
+ */
+const letterKeyNames: Record<string, string> = {
+	A: 'up',
+	B: 'down',
+	C: 'right',
+	D: 'left',
+	E: 'clear',
+	F: 'end',
+	H: 'home',
+	P: 'f1',
+	Q: 'f2',
+	R: 'f3',
+	S: 'f4',
+};
+
+/**
+ * Tilde code to key name mapping.
+ */
+const tildeKeyNames: Record<number, string> = {
+	1: 'home',
+	2: 'insert',
+	3: 'delete',
+	4: 'end',
+	5: 'pageup',
+	6: 'pagedown',
+	7: 'home',
+	8: 'end',
+	11: 'f1',
+	12: 'f2',
+	13: 'f3',
+	14: 'f4',
+	15: 'f5',
+	17: 'f6',
+	18: 'f7',
+	19: 'f8',
+	20: 'f9',
+	21: 'f10',
+	23: 'f11',
+	24: 'f12',
+};
+
+/**
+ * Parse modifiers from the Kitty keyboard protocol modifier field.
+ *
+ * The modifier field is encoded as (1 + sum of modifier bits).
+ */
+function parseModifiers(modifierValue: number): {
+	shift: boolean;
+	alt: boolean;
+	ctrl: boolean;
+	super: boolean;
+	hyper: boolean;
+	meta: boolean;
+	capsLock: boolean;
+	numLock: boolean;
+} {
+	// Subtract 1 to get the actual modifier bitfield
+	const modifiers = modifierValue - 1;
+
+	return {
+		shift: !!(modifiers & KittyModifiers.shift),
+		alt: !!(modifiers & KittyModifiers.alt),
+		ctrl: !!(modifiers & KittyModifiers.ctrl),
+		super: !!(modifiers & KittyModifiers.super),
+		hyper: !!(modifiers & KittyModifiers.hyper),
+		meta: !!(modifiers & KittyModifiers.meta),
+		capsLock: !!(modifiers & KittyModifiers.capsLock),
+		numLock: !!(modifiers & KittyModifiers.numLock),
+	};
+}
+
+/**
+ * Parse event type from the Kitty keyboard protocol event type field.
+ */
+function parseEventType(eventTypeValue: number | undefined): KittyEventType {
+	switch (eventTypeValue) {
+		case 2:
+			return 'repeat';
+		case 3:
+			return 'release';
+		default:
+			return 'press';
+	}
+}
+
+/**
+ * Get the key name from a Unicode codepoint.
+ */
+function getKeyName(codepoint: number): string {
+	// Check if it's a known functional key
+	const functionalKey = KittyFunctionalKeys[codepoint];
+	if (functionalKey) {
+		return functionalKey;
+	}
+
+	// For regular characters, return the character itself (lowercase)
+	if (codepoint >= 32 && codepoint <= 126) {
+		return String.fromCodePoint(codepoint).toLowerCase();
+	}
+
+	// For control characters, map to their letter equivalent
+	if (codepoint >= 1 && codepoint <= 26) {
+		return String.fromCharCode(codepoint + 96); // 1 -> 'a', 2 -> 'b', etc.
+	}
+
+	// Unknown key, return the codepoint as a string
+	return `u${codepoint}`;
+}
+
+/**
+ * Check if a string is a Kitty keyboard protocol escape sequence.
+ */
+export function isKittySequence(input: string): boolean {
+	return (
+		kittySequenceRegex.test(input) ||
+		kittyTildeSequenceRegex.test(input) ||
+		kittyLetterSequenceRegex.test(input)
+	);
+}
+
+/**
+ * Parse a Kitty keyboard protocol escape sequence.
+ *
+ * @param input The input string to parse
+ * @returns The parsed keypress, or null if not a valid Kitty sequence
+ */
+export function parseKittySequence(input: string): KittyKeypress | null {
+	// Try CSI u format first
+	let match = kittySequenceRegex.exec(input);
+	if (match) {
+		const codepoint = parseInt(match[1]!, 10);
+		const modifierValue = match[2] ? parseInt(match[2], 10) : 1;
+		const eventTypeValue = match[3] ? parseInt(match[3], 10) : undefined;
+
+		const modifiers = parseModifiers(modifierValue);
+		const eventType = parseEventType(eventTypeValue);
+		const name = getKeyName(codepoint);
+
+		return {
+			name,
+			codepoint,
+			...modifiers,
+			eventType,
+			sequence: input,
+			isKittyProtocol: true,
+		};
+	}
+
+	// Try CSI ~ format for functional keys
+	match = kittyTildeSequenceRegex.exec(input);
+	if (match) {
+		const keyCode = parseInt(match[1]!, 10);
+		const modifierValue = match[2] ? parseInt(match[2], 10) : 1;
+
+		const modifiers = parseModifiers(modifierValue);
+		const name = tildeKeyNames[keyCode] || `f${keyCode}`;
+
+		return {
+			name,
+			codepoint: keyCode,
+			...modifiers,
+			eventType: 'press',
+			sequence: input,
+			isKittyProtocol: true,
+		};
+	}
+
+	// Try letter-terminated format
+	match = kittyLetterSequenceRegex.exec(input);
+	if (match) {
+		const modifierValue = parseInt(match[1]!, 10);
+		const letter = match[2]!;
+
+		const modifiers = parseModifiers(modifierValue);
+		const name = letterKeyNames[letter] || letter.toLowerCase();
+
+		return {
+			name,
+			codepoint: letter.charCodeAt(0),
+			...modifiers,
+			eventType: 'press',
+			sequence: input,
+			isKittyProtocol: true,
+		};
+	}
+
+	return null;
+}
+
+/**
+ * Generate the escape sequence to enable the Kitty keyboard protocol.
+ *
+ * @param flags The enhancement flags to enable (default: disambiguate escape codes only)
+ * @returns The escape sequence to send to the terminal
+ */
+export function enableKittyProtocol(
+	flags: number = KittyFlags.disambiguateEscapeCodes,
+): string {
+	// CSI > flags u - Push flags onto the stack
+	return `\x1b[>${flags}u`;
+}
+
+/**
+ * Generate the escape sequence to disable the Kitty keyboard protocol.
+ *
+ * @returns The escape sequence to send to the terminal
+ */
+export function disableKittyProtocol(): string {
+	// CSI < u - Pop flags from the stack
+	return `\x1b[<u`;
+}
+
+/**
+ * Generate the escape sequence to query Kitty keyboard protocol support.
+ *
+ * @returns The escape sequence to send to the terminal
+ */
+export function queryKittyProtocol(): string {
+	// CSI ? u - Query current flags
+	return `\x1b[?u`;
+}
+
+/**
+ * Regex to match the Kitty protocol query response.
+ *
+ * Format: CSI ? flags u
+ */
+const kittyQueryResponseRegex = /^\x1b\[\?(\d+)u$/;
+
+/**
+ * Check if a string is a Kitty protocol query response.
+ */
+export function isKittyQueryResponse(input: string): boolean {
+	return kittyQueryResponseRegex.test(input);
+}
+
+/**
+ * Parse a Kitty protocol query response to get the current flags.
+ *
+ * @param input The response string
+ * @returns The current flags, or null if not a valid response
+ */
+export function parseKittyQueryResponse(input: string): number | null {
+	const match = kittyQueryResponseRegex.exec(input);
+	if (match) {
+		return parseInt(match[1]!, 10);
+	}
+	return null;
+}

--- a/test/fixtures/use-input.tsx
+++ b/test/fixtures/use-input.tsx
@@ -151,6 +151,32 @@ function UserInput({test}: {readonly test: string | undefined}) {
 			return;
 		}
 
+		// Kitty protocol tests - these test the enhanced modifier detection
+		if (test === 'kittyShiftEnter' && key.return && key.shift) {
+			exit();
+			return;
+		}
+
+		if (test === 'kittyCtrlTab' && key.tab && key.ctrl) {
+			exit();
+			return;
+		}
+
+		if (test === 'kittyCtrlI' && input === 'i' && key.ctrl && !key.tab) {
+			exit();
+			return;
+		}
+
+		if (test === 'kittySuper' && input === 'a' && key.super) {
+			exit();
+			return;
+		}
+
+		if (test === 'kittyMultiMod' && input === 'a' && key.ctrl && key.shift) {
+			exit();
+			return;
+		}
+
 		throw new Error('Crash');
 	});
 

--- a/test/hooks.tsx
+++ b/test/hooks.tsx
@@ -274,6 +274,61 @@ test.serial('useInput - handle remove (delete)', async t => {
 	t.true(ps.output.includes('exited'));
 });
 
+// Kitty keyboard protocol tests
+// These test the enhanced modifier detection available when a terminal
+// supports the Kitty keyboard protocol
+test.serial(
+	'useInput - handle Shift+Enter via Kitty protocol (CSI 13;2 u)',
+	async t => {
+		const ps = term('use-input', ['kittyShiftEnter']);
+		// Kitty protocol: Enter (13) with Shift modifier (1+1=2)
+		ps.write('\u001B[13;2u');
+		await ps.waitForExit();
+		t.true(ps.output.includes('exited'));
+	},
+);
+
+test.serial(
+	'useInput - handle Ctrl+Tab via Kitty protocol (CSI 9;5 u)',
+	async t => {
+		const ps = term('use-input', ['kittyCtrlTab']);
+		// Kitty protocol: Tab (9) with Ctrl modifier (1+4=5)
+		ps.write('\u001B[9;5u');
+		await ps.waitForExit();
+		t.true(ps.output.includes('exited'));
+	},
+);
+
+test.serial(
+	'useInput - handle Ctrl+I via Kitty protocol (distinguishable from Tab)',
+	async t => {
+		const ps = term('use-input', ['kittyCtrlI']);
+		// Kitty protocol: 'i' (105) with Ctrl modifier (1+4=5)
+		ps.write('\u001B[105;5u');
+		await ps.waitForExit();
+		t.true(ps.output.includes('exited'));
+	},
+);
+
+test.serial('useInput - handle Super+a via Kitty protocol', async t => {
+	const ps = term('use-input', ['kittySuper']);
+	// Kitty protocol: 'a' (97) with Super modifier (1+8=9)
+	ps.write('\u001B[97;9u');
+	await ps.waitForExit();
+	t.true(ps.output.includes('exited'));
+});
+
+test.serial(
+	'useInput - handle Ctrl+Shift+a via Kitty protocol',
+	async t => {
+		const ps = term('use-input', ['kittyMultiMod']);
+		// Kitty protocol: 'a' (97) with Ctrl+Shift modifiers (1+4+1=6)
+		ps.write('\u001B[97;6u');
+		await ps.waitForExit();
+		t.true(ps.output.includes('exited'));
+	},
+);
+
 test.serial('useInput - ignore input if not active', async t => {
 	const ps = term('use-input-multiple');
 	ps.write('x');

--- a/test/kitty-keyboard.tsx
+++ b/test/kitty-keyboard.tsx
@@ -1,0 +1,283 @@
+import test from 'ava';
+import {
+	parseKittySequence,
+	isKittySequence,
+	enableKittyProtocol,
+	disableKittyProtocol,
+	queryKittyProtocol,
+	isKittyQueryResponse,
+	parseKittyQueryResponse,
+	KittyFlags,
+	KittyModifiers,
+} from '../src/kitty-keyboard.js';
+
+// Test CSI u format parsing
+test('parseKittySequence - parses basic letter key', t => {
+	const result = parseKittySequence('\x1b[97u');
+	t.truthy(result);
+	t.is(result?.name, 'a');
+	t.is(result?.codepoint, 97);
+	t.false(result?.shift);
+	t.false(result?.ctrl);
+	t.false(result?.alt);
+	t.false(result?.super);
+	t.is(result?.eventType, 'press');
+	t.true(result?.isKittyProtocol);
+});
+
+test('parseKittySequence - parses shift+letter', t => {
+	// Shift modifier is encoded as 1 + 1 = 2
+	const result = parseKittySequence('\x1b[97;2u');
+	t.truthy(result);
+	t.is(result?.name, 'a');
+	t.true(result?.shift);
+	t.false(result?.ctrl);
+	t.false(result?.alt);
+});
+
+test('parseKittySequence - parses ctrl+letter', t => {
+	// Ctrl modifier is encoded as 1 + 4 = 5
+	const result = parseKittySequence('\x1b[97;5u');
+	t.truthy(result);
+	t.is(result?.name, 'a');
+	t.false(result?.shift);
+	t.true(result?.ctrl);
+	t.false(result?.alt);
+});
+
+test('parseKittySequence - parses alt+letter', t => {
+	// Alt modifier is encoded as 1 + 2 = 3
+	const result = parseKittySequence('\x1b[97;3u');
+	t.truthy(result);
+	t.is(result?.name, 'a');
+	t.false(result?.shift);
+	t.false(result?.ctrl);
+	t.true(result?.alt);
+});
+
+test('parseKittySequence - parses super+letter', t => {
+	// Super modifier is encoded as 1 + 8 = 9
+	const result = parseKittySequence('\x1b[97;9u');
+	t.truthy(result);
+	t.is(result?.name, 'a');
+	t.false(result?.shift);
+	t.false(result?.ctrl);
+	t.false(result?.alt);
+	t.true(result?.super);
+});
+
+test('parseKittySequence - parses multiple modifiers (ctrl+shift)', t => {
+	// Ctrl+Shift is encoded as 1 + 4 + 1 = 6
+	const result = parseKittySequence('\x1b[97;6u');
+	t.truthy(result);
+	t.is(result?.name, 'a');
+	t.true(result?.shift);
+	t.true(result?.ctrl);
+	t.false(result?.alt);
+});
+
+test('parseKittySequence - parses Enter key', t => {
+	const result = parseKittySequence('\x1b[13u');
+	t.truthy(result);
+	t.is(result?.name, 'return');
+	t.is(result?.codepoint, 13);
+});
+
+test('parseKittySequence - parses Shift+Enter', t => {
+	const result = parseKittySequence('\x1b[13;2u');
+	t.truthy(result);
+	t.is(result?.name, 'return');
+	t.true(result?.shift);
+	t.false(result?.ctrl);
+});
+
+test('parseKittySequence - parses Tab key', t => {
+	const result = parseKittySequence('\x1b[9u');
+	t.truthy(result);
+	t.is(result?.name, 'tab');
+	t.is(result?.codepoint, 9);
+});
+
+test('parseKittySequence - parses Ctrl+Tab (distinguishable from Ctrl+I)', t => {
+	const result = parseKittySequence('\x1b[9;5u');
+	t.truthy(result);
+	t.is(result?.name, 'tab');
+	t.true(result?.ctrl);
+});
+
+test('parseKittySequence - parses Ctrl+I (distinguishable from Tab)', t => {
+	// Ctrl+I sends the 'i' codepoint with ctrl modifier
+	const result = parseKittySequence('\x1b[105;5u');
+	t.truthy(result);
+	t.is(result?.name, 'i');
+	t.true(result?.ctrl);
+});
+
+test('parseKittySequence - parses Escape key', t => {
+	const result = parseKittySequence('\x1b[27u');
+	t.truthy(result);
+	t.is(result?.name, 'escape');
+	t.is(result?.codepoint, 27);
+});
+
+test('parseKittySequence - parses Backspace key', t => {
+	const result = parseKittySequence('\x1b[127u');
+	t.truthy(result);
+	t.is(result?.name, 'backspace');
+	t.is(result?.codepoint, 127);
+});
+
+test('parseKittySequence - parses event types', t => {
+	// Press (1) - default
+	const press = parseKittySequence('\x1b[97;1:1u');
+	t.is(press?.eventType, 'press');
+
+	// Repeat (2)
+	const repeat = parseKittySequence('\x1b[97;1:2u');
+	t.is(repeat?.eventType, 'repeat');
+
+	// Release (3)
+	const release = parseKittySequence('\x1b[97;1:3u');
+	t.is(release?.eventType, 'release');
+});
+
+// Test CSI ~ format for functional keys
+test('parseKittySequence - parses Delete key (CSI ~ format)', t => {
+	const result = parseKittySequence('\x1b[3~');
+	t.truthy(result);
+	t.is(result?.name, 'delete');
+});
+
+test('parseKittySequence - parses Shift+Delete (CSI ~ format)', t => {
+	const result = parseKittySequence('\x1b[3;2~');
+	t.truthy(result);
+	t.is(result?.name, 'delete');
+	t.true(result?.shift);
+});
+
+test('parseKittySequence - parses Page Up (CSI ~ format)', t => {
+	const result = parseKittySequence('\x1b[5~');
+	t.truthy(result);
+	t.is(result?.name, 'pageup');
+});
+
+test('parseKittySequence - parses Page Down (CSI ~ format)', t => {
+	const result = parseKittySequence('\x1b[6~');
+	t.truthy(result);
+	t.is(result?.name, 'pagedown');
+});
+
+// Test letter-terminated format for arrow keys with modifiers
+test('parseKittySequence - parses Shift+Up (letter format)', t => {
+	const result = parseKittySequence('\x1b[1;2A');
+	t.truthy(result);
+	t.is(result?.name, 'up');
+	t.true(result?.shift);
+});
+
+test('parseKittySequence - parses Ctrl+Right (letter format)', t => {
+	const result = parseKittySequence('\x1b[1;5C');
+	t.truthy(result);
+	t.is(result?.name, 'right');
+	t.true(result?.ctrl);
+});
+
+test('parseKittySequence - parses Alt+Down (letter format)', t => {
+	const result = parseKittySequence('\x1b[1;3B');
+	t.truthy(result);
+	t.is(result?.name, 'down');
+	t.true(result?.alt);
+});
+
+// Test isKittySequence
+test('isKittySequence - returns true for CSI u format', t => {
+	t.true(isKittySequence('\x1b[97u'));
+	t.true(isKittySequence('\x1b[97;2u'));
+	t.true(isKittySequence('\x1b[13;5u'));
+});
+
+test('isKittySequence - returns true for CSI ~ format', t => {
+	t.true(isKittySequence('\x1b[3~'));
+	t.true(isKittySequence('\x1b[3;2~'));
+});
+
+test('isKittySequence - returns true for letter format', t => {
+	t.true(isKittySequence('\x1b[1;2A'));
+	t.true(isKittySequence('\x1b[1;5C'));
+});
+
+test('isKittySequence - returns false for legacy escape sequences', t => {
+	t.false(isKittySequence('\x1b[A')); // Legacy up arrow
+	t.false(isKittySequence('\x1bm')); // Meta+m
+	t.false(isKittySequence('\x03')); // Ctrl+C
+});
+
+test('isKittySequence - returns false for regular characters', t => {
+	t.false(isKittySequence('a'));
+	t.false(isKittySequence('A'));
+	t.false(isKittySequence('\r'));
+});
+
+// Test protocol enable/disable/query sequences
+test('enableKittyProtocol - generates correct sequence with default flags', t => {
+	const sequence = enableKittyProtocol();
+	t.is(sequence, '\x1b[>1u');
+});
+
+test('enableKittyProtocol - generates correct sequence with custom flags', t => {
+	const sequence = enableKittyProtocol(
+		KittyFlags.disambiguateEscapeCodes | KittyFlags.reportEventTypes,
+	);
+	t.is(sequence, '\x1b[>3u');
+});
+
+test('disableKittyProtocol - generates correct sequence', t => {
+	const sequence = disableKittyProtocol();
+	t.is(sequence, '\x1b[<u');
+});
+
+test('queryKittyProtocol - generates correct sequence', t => {
+	const sequence = queryKittyProtocol();
+	t.is(sequence, '\x1b[?u');
+});
+
+// Test query response parsing
+test('isKittyQueryResponse - returns true for valid response', t => {
+	t.true(isKittyQueryResponse('\x1b[?1u'));
+	t.true(isKittyQueryResponse('\x1b[?0u'));
+	t.true(isKittyQueryResponse('\x1b[?31u'));
+});
+
+test('isKittyQueryResponse - returns false for invalid response', t => {
+	t.false(isKittyQueryResponse('\x1b[1u'));
+	t.false(isKittyQueryResponse('\x1b[?u'));
+	t.false(isKittyQueryResponse('hello'));
+});
+
+test('parseKittyQueryResponse - parses flags correctly', t => {
+	t.is(parseKittyQueryResponse('\x1b[?0u'), 0);
+	t.is(parseKittyQueryResponse('\x1b[?1u'), 1);
+	t.is(parseKittyQueryResponse('\x1b[?31u'), 31);
+	t.is(parseKittyQueryResponse('invalid'), null);
+});
+
+// Test modifier constants
+test('KittyModifiers - has correct values', t => {
+	t.is(KittyModifiers.shift, 1);
+	t.is(KittyModifiers.alt, 2);
+	t.is(KittyModifiers.ctrl, 4);
+	t.is(KittyModifiers.super, 8);
+	t.is(KittyModifiers.hyper, 16);
+	t.is(KittyModifiers.meta, 32);
+	t.is(KittyModifiers.capsLock, 64);
+	t.is(KittyModifiers.numLock, 128);
+});
+
+// Test flag constants
+test('KittyFlags - has correct values', t => {
+	t.is(KittyFlags.disambiguateEscapeCodes, 1);
+	t.is(KittyFlags.reportEventTypes, 2);
+	t.is(KittyFlags.reportAlternateKeys, 4);
+	t.is(KittyFlags.reportAllKeysAsEscapeCodes, 8);
+	t.is(KittyFlags.reportAssociatedText, 16);
+});


### PR DESCRIPTION
> [!WARNING]
  > **Please ignore this PR - created in error**
  >
  > This PR was accidentally opened against the upstream repository instead of my fork. I apologize for the noise. This is part of an AI coding experiment and was not intended as a real contribution to Ink.
  
 ## Summary

This PR implements Kitty keyboard protocol support for enhanced modifier detection in Ink, enabling:
- Shift+Enter vs Enter distinction
- Ctrl+I vs Tab distinction  
- Full modifier key detection (Shift, Ctrl, Alt, Super)

**This implementation was generated using the Ralph Wiggum approach** - a simple iterative loop that feeds the same prompt to Claude until completion.

## Experiment Context

This PR is part of a comparison experiment between two AI coding approaches:
- **Ralph Wiggum**: Simple loop, self-verification, single iteration
- **Colony**: Parallel task execution with independent verification

See the [full comparison results](https://github.com/mattheworiordan/ink/pull/new/poc/colony) for detailed analysis.

## Implementation Details

- **Time taken**: 41 minutes 17 seconds
- **Commits**: 1 (monolithic)
- **Lines changed**: +1,115 / -3
- **Files modified**: 10
- **Lint status**: 419 errors (escape sequences, member ordering, formatting)

## Test Plan

- [x] TypeScript compiles
- [x] Feature works in supported terminals
- [ ] Lint errors need fixing before merge
- [ ] Integration tests pass (blocked by environment issue)

## Notes

This PR demonstrates the "prototype quality" output typical of simple AI coding loops. The feature is functional but would require cleanup before merging:
- 419 lint errors to fix
- Code could be more modular (537-line main module)

🤖 Generated with [Claude Code](https://claude.ai/code) using Ralph Wiggum approach