### PR TITLE
Use terminal-size as fallback for piped processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"slice-ansi": "^7.1.0",
 		"stack-utils": "^2.0.6",
 		"string-width": "^8.1.0",
+		"terminal-size": "^4.0.0",
 		"type-fest": "^4.27.0",
 		"widest-line": "^5.0.0",
 		"wrap-ansi": "^9.0.0",

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -10,6 +10,7 @@ import {LegacyRoot} from 'react-reconciler/constants.js';
 import {type FiberRoot} from 'react-reconciler';
 import Yoga from 'yoga-layout';
 import wrapAnsi from 'wrap-ansi';
+import terminalSize from 'terminal-size';
 import reconciler from './reconciler.js';
 import render from './renderer.js';
 import * as dom from './dom.js';
@@ -153,8 +154,13 @@ export default class Ink {
 
 	getTerminalWidth = () => {
 		// The 'columns' property can be undefined or 0 when not using a TTY.
-		// In that case we fall back to 80.
-		return this.options.stdout.columns || 80;
+		// Use terminal-size as a fallback for piped processes, then default to 80.
+		if (this.options.stdout.columns) {
+			return this.options.stdout.columns;
+		}
+
+		const size = terminalSize();
+		return size?.columns ?? 80;
 	};
 
 	resized = () => {
@@ -239,7 +245,7 @@ export default class Ink {
 				return;
 			}
 
-			const terminalWidth = this.options.stdout.columns || 80;
+			const terminalWidth = this.getTerminalWidth();
 
 			const wrappedOutput = wrapAnsi(output, terminalWidth, {
 				trim: false,


### PR DESCRIPTION
## Summary
- Uses `terminal-size` package to detect actual terminal width when `stdout.columns` is unavailable (piped processes)
- Falls back to 80 columns only when both methods fail
- Ensures consistent terminal width detection across all code paths

## Problem
When Ink's output is piped (e.g., `node app.js | cat`), `stdout.columns` returns `0` or `undefined`, causing layout to default to 80 columns even when the terminal is wider.

## Solution
The `terminal-size` package can detect terminal dimensions even when stdout is piped, by checking stdin/stderr or using platform-specific methods.

### Changes made:
1. **Added `terminal-size` dependency** - Zero-dependency package by @sindresorhus
2. **Modified `getTerminalWidth()` method** - Uses terminal-size as fallback:
   ```typescript
   getTerminalWidth = () => {
       if (this.options.stdout.columns) {
           return this.options.stdout.columns;
       }
       const size = terminalSize();
       return size?.columns ?? 80;
   };
   ```
3. **Updated screen reader code path** - Changed direct `stdout.columns` access to use `getTerminalWidth()` for consistency

## Test plan
- [x] TypeScript compilation passes
- [x] Linting passes
- [x] All `stdout.columns` usages now go through `getTerminalWidth()`
- [x] Manual test: Verified piped output (`npm run example test.tsx | cat`) detects actual terminal width instead of defaulting to 80

Fixes #670