### PR TITLE
Handle Option+Return (soft return) on macOS

### DIFF
--- a/src/parse-keypress.ts
+++ b/src/parse-keypress.ts
@@ -165,10 +165,11 @@ const parseKeypress = (s: Buffer | string = ''): ParsedKey => {
 
 	key.sequence = key.sequence || s || key.name;
 
-	if (s === '\r') {
-		// carriage return
+	if (s === '\r' || s === '\x1b\r') {
+		// carriage return (or option+return on macOS)
 		key.raw = undefined;
 		key.name = 'return';
+		key.option = s.length === 2;
 	} else if (s === '\n') {
 		// enter, should have been called linefeed
 		key.name = 'enter';

--- a/test/fixtures/use-input.tsx
+++ b/test/fixtures/use-input.tsx
@@ -151,6 +151,11 @@ function UserInput({test}: {readonly test: string | undefined}) {
 			return;
 		}
 
+		if (test === 'returnMeta' && key.return && key.meta) {
+			exit();
+			return;
+		}
+
 		throw new Error('Crash');
 	});
 

--- a/test/hooks.tsx
+++ b/test/hooks.tsx
@@ -274,6 +274,13 @@ test.serial('useInput - handle remove (delete)', async t => {
 	t.true(ps.output.includes('exited'));
 });
 
+test.serial('useInput - handle option + return (macOS)', async t => {
+	const ps = term('use-input', ['returnMeta']);
+	ps.write('\u001B\r');
+	await ps.waitForExit();
+	t.true(ps.output.includes('exited'));
+});
+
 test.serial('useInput - ignore input if not active', async t => {
 	const ps = term('use-input-multiple');
 	ps.write('x');


### PR DESCRIPTION
## Summary

On macOS terminals, Option+Return (the common way to input a "soft return" or newline without submitting) sends the escape sequence `\x1b\r` (ESC + carriage return). This was not being recognized by the keypress parser, causing inconsistent behavior.

This fix:
- Recognizes `\x1b\r` as a return key with the `option` modifier set to `true`
- The existing meta mapping in `use-input.ts` will set `key.meta = true` (since it already includes `keypress.option`)

Users can now distinguish between regular Return and Option+Return:
- Regular Return: `key.return === true`, `key.meta === false`
- Option+Return: `key.return === true`, `key.meta === true`

## Changes

- `src/parse-keypress.ts`: Added handling for `\x1b\r` sequence
- `test/fixtures/use-input.tsx`: Added test case for `returnMeta`
- `test/hooks.tsx`: Added test for Option+Return handling

## Test plan

- [ ] Verify that pressing Return alone sets `key.return = true` and `key.meta = false`
- [ ] Verify that pressing Option+Return sets `key.return = true` and `key.meta = true`
- [ ] Run existing tests to ensure no regressions

Fixes #737

---
Generated with [Claude Code](https://claude.com/claude-code)