### PR TITLE
test: add regression test for variation selector emoji border alignment

### DIFF
--- a/test/borders.tsx
+++ b/test/borders.tsx
@@ -65,6 +65,17 @@ test('single node - fit-content box with emojis', t => {
 	t.is(output, boxen('🌊🌊', {borderStyle: 'round'}));
 });
 
+// Issue #733: Emojis with variation selectors (FE0F) should align properly
+test('single node - fit-content box with variation selector emojis', t => {
+	const output = renderToString(
+		<Box borderStyle="round" alignSelf="flex-start">
+			<Text>🌡️⚠️✅</Text>
+		</Box>,
+	);
+
+	t.is(output, boxen('🌡️⚠️✅', {borderStyle: 'round'}));
+});
+
 test('single node - fixed width box', t => {
 	const output = renderToString(
 		<Box borderStyle="round" width={20}>


### PR DESCRIPTION
## Summary

Adds a regression test for emojis with variation selectors (U+FE0F) to prevent future issues with box border alignment.

This follows up on the maintainer's request in #861 to "reduce the PR to just the test" after the dependency update in commit 0a685a76 fixed the underlying issue by upgrading `widest-line` to v6.0.0.

## Test Case

Tests that emojis like 🌡️⚠️✅ (which contain the invisible variation selector character) properly align with box borders.

## Related

- Ref: #733 (original issue)
- Ref: #861 (original PR, closed in favor of dependency upgrade)
- Ref: 0a685a76 (maintainer's fix via widest-line upgrade)