### PR TITLE
Upgrade slice-ansi to v8 for hyperlink-aware slicing

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"react-reconciler": "^0.33.0",
 		"scheduler": "^0.27.0",
 		"signal-exit": "^3.0.7",
-		"slice-ansi": "^7.1.0",
+		"slice-ansi": "^8.0.0",
 		"stack-utils": "^2.0.6",
 		"string-width": "^8.1.1",
 		"terminal-size": "^4.0.1",


### PR DESCRIPTION
## Summary

- Upgrades `slice-ansi` from `^7.1.0` to `^8.0.0`
- v8.0.0 adds hyperlink-aware slicing, fixing links that render incorrectly when used with `flexDirection="row"`

The root cause was that `slice-ansi` didn't understand terminal hyperlink escape sequences (OSC 8), producing invalid output when Ink's layout engine clips text horizontally. This was tracked upstream in [chalk/slice-ansi#31](https://github.com/chalk/slice-ansi/issues/31), which has now been resolved.

No breaking changes for Ink — the API surface of `slice-ansi` is unchanged (`sliceAnsi(string, start, end)`), and Ink already requires Node.js >=20 which matches slice-ansi v8's engine requirement.

All 722 existing tests pass.

Fixes #269