### PR TITLE
docs: ink-color-picker added to useful components list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2564,6 +2564,7 @@ For a practical example of building an accessible component, see the [ARIA examp
 - [ink-scroll-list](https://github.com/ByteLandTechnology/ink-scroll-list) - Scrollable list.
 - [ink-stepper](https://github.com/archcorsair/ink-stepper) - Step-by-step wizard.
 - [ink-virtual-list](https://github.com/archcorsair/ink-virtual-list) - Virtualized list that renders only visible items for performance.
+- [ink-color-picker](https://github.com/sina-byn/ink-color-picker) - Color picker.
 
 ## Useful Hooks
 


### PR DESCRIPTION
add `ink-color-picker` to the list of useful components inside readme.md.

follow up pull request on the linked issue - @sindresorhus 

Closes #690 