### PR TITLE
docs(cursor-ime): enhance IME example with full-featured TextInput

### DIFF
--- a/examples/cursor-ime/cursor-ime.tsx
+++ b/examples/cursor-ime/cursor-ime.tsx
@@ -1,35 +1,102 @@
+/**
+ * IME-Compatible TextInput Example for Ink
+ *
+ * Demonstrates how to build a text input that works correctly with IME
+ * (Input Method Editor) for Korean, Japanese, and Chinese.
+ *
+ * Key concepts:
+ *  1. useCursor() — Positions the REAL terminal cursor. IME composition
+ *     windows anchor to the real cursor, so fake cursors (chalk.inverse)
+ *     break CJK input completely.
+ *  2. stringWidth() — CJK characters occupy 2 terminal columns but are
+ *     1 character in JavaScript. Use stringWidth for correct column offset.
+ *  3. Middle insertion — Arrow keys move the cursor; text inserts at cursor.
+ *
+ * Try it:
+ *   npx tsx examples/cursor-ime/cursor-ime.tsx
+ *
+ * Switch your OS keyboard to Korean (한국어) and type. You should see
+ * Hangul composition (ㅎ → 하 → 한) happening naturally at the cursor.
+ */
+
 import React, {useState} from 'react';
 import stringWidth from 'string-width';
 import {render, Box, Text, useInput, useCursor} from '../../src/index.js';
 
-function App() {
+function splitAt(str: string, index: number): [string, string] {
+	const chars = [...str];
+	return [chars.slice(0, index).join(''), chars.slice(index).join('')];
+}
+
+function charCount(str: string): number {
+	return [...str].length;
+}
+
+const PROMPT = '> ';
+
+function TextInput() {
 	const [text, setText] = useState('');
+	const [cursorIndex, setCursorIndex] = useState(0);
+	const [submitted, setSubmitted] = useState<string[]>([]);
 	const {setCursorPosition} = useCursor();
 
 	useInput((input, key) => {
+		if (key.return) {
+			if (text.length > 0) {
+				setSubmitted(prev => [...prev, text]);
+				setText('');
+				setCursorIndex(0);
+			}
+			return;
+		}
+
 		if (key.backspace || key.delete) {
-			setText(previous => previous.slice(0, -1));
+			if (cursorIndex > 0) {
+				const [before, after] = splitAt(text, cursorIndex);
+				setText(before.slice(0, -1) + after);
+				setCursorIndex(prev => prev - 1);
+			}
+			return;
+		}
+
+		if (key.leftArrow) {
+			setCursorIndex(prev => Math.max(0, prev - 1));
+			return;
+		}
+		if (key.rightArrow) {
+			setCursorIndex(prev => Math.min(charCount(text), prev + 1));
 			return;
 		}
 
 		if (!key.ctrl && !key.meta && input) {
-			setText(previous => previous + input);
+			const [before, after] = splitAt(text, cursorIndex);
+			setText(before + input + after);
+			setCursorIndex(prev => prev + charCount(input));
 		}
 	});
 
-	// Use stringWidth for correct cursor position with wide characters (Korean, CJK, emoji)
-	const prompt = '> ';
-	setCursorPosition({x: stringWidth(prompt + text), y: 1});
+	// stringWidth: "한글" = 4 columns, "abc" = 3 columns
+	const beforeCursor = splitAt(text, cursorIndex)[0];
+	const cursorColumn = stringWidth(PROMPT + beforeCursor);
+	setCursorPosition({x: cursorColumn, y: 1 + submitted.length});
 
 	return (
 		<Box flexDirection="column">
-			<Text>Type Korean (Ctrl+C to exit):</Text>
 			<Text>
-				{prompt}
+				Korean TextInput Demo — type in Korean or English (Ctrl+C to exit)
+			</Text>
+			{submitted.map((line, i) => (
+				<Text key={i} color="gray">
+					{PROMPT}
+					{line}
+				</Text>
+			))}
+			<Text>
+				{PROMPT}
 				{text}
 			</Text>
 		</Box>
 	);
 }
 
-render(<App />);
+render(<TextInput />);

--- a/examples/cursor-ime/readme.md
+++ b/examples/cursor-ime/readme.md
@@ -1,0 +1,61 @@
+# IME-Compatible TextInput for Ink
+
+## Why CJK input needs special handling
+
+Korean, Japanese, and Chinese use **Input Method Editors (IME)** to compose
+characters. Unlike Latin keyboards where each keypress produces a character
+immediately, CJK input goes through a multi-step composition process.
+
+### How Hangul composition works
+
+When a Korean user types the word "한":
+
+1. Press `ㅎ` — the IME shows the uncommitted consonant **ㅎ**
+2. Press `ㅏ` — the IME *replaces* ㅎ with the syllable **하**
+3. Press `ㄴ` — the IME *replaces* 하 with the completed syllable **한**
+
+During steps 1-3 the character is "composing" — it is not yet confirmed.
+The OS draws this preview **at the terminal's real cursor position**.
+
+### Why fake cursors break IME
+
+Many terminal UI libraries render a cursor character (e.g. `█`) inside
+the React tree and hide the real terminal cursor. This breaks IME because:
+
+- The OS has no idea where the fake cursor is drawn.
+- The composition preview appears at the *real* (hidden) cursor, usually
+  at position (0, 0) or the bottom-left of the terminal.
+- Korean/Japanese/Chinese users see garbled input or nothing at all.
+
+### Why `stringWidth` matters
+
+CJK characters are **fullwidth** — each occupies 2 terminal columns:
+
+| Text   | `.length` | `stringWidth()` | Terminal columns |
+|--------|-----------|------------------|------------------|
+| `abc`  | 3         | 3                | 3                |
+| `한글` | 2         | 4                | 4                |
+| `あ`   | 1         | 2                | 2                |
+
+Using `.length` for cursor positioning causes the cursor to drift left
+after every CJK character.
+
+## How `useCursor` + `stringWidth` solve it
+
+```tsx
+const {setCursorPosition} = useCursor();
+
+const column = stringWidth(prompt + textBeforeCursor);
+setCursorPosition({x: column, y: inputLineRow});
+```
+
+`useCursor` places the **real** terminal cursor at `(x, y)`.
+The OS IME then draws its composition preview at exactly the right spot.
+
+## Running the example
+
+```bash
+npx tsx examples/cursor-ime/cursor-ime.tsx
+```
+
+Switch your OS keyboard to Korean (or Japanese/Chinese) and start typing.


### PR DESCRIPTION
## Summary

The existing `cursor-ime` example is minimal — append-only input with no cursor movement, no backspace at position, no submit. This PR replaces it with a comprehensive, production-quality TextInput that demonstrates all the features needed for correct CJK IME input.

Also adds a `readme.md` explaining **why** CJK input needs special handling, including:
- How Hangul composition works (ㅎ → 하 → 한)
- Why fake cursors (`chalk.inverse`) break IME
- Why `stringWidth` is needed (CJK chars = 2 terminal columns)
- How `useCursor` + `stringWidth` solve the problem

## Changes

| File | Change |
|------|--------|
| `examples/cursor-ime/cursor-ime.tsx` | Full TextInput with cursor movement (←/→), middle insertion, backspace at position, submit on Enter with history, `stringWidth` for CJK column calculation |
| `examples/cursor-ime/readme.md` | New file explaining CJK IME concepts, Hangul composition flow, the fake-cursor problem, and the `useCursor` + `stringWidth` solution |

## Test plan

- [x] Example runs: `npx tsx examples/cursor-ime/cursor-ime.tsx`
- [x] Korean IME composition appears at correct cursor position
- [x] Arrow keys move cursor; typing inserts at cursor position
- [x] Backspace deletes character before cursor
- [x] Enter submits and clears input
- [x] Mixed ASCII + CJK text: cursor stays at correct column

## Related

- `useCursor` hook: #866 (merged in v6.7.0)
- `<Cursor>` component: #872 (in progress)
- Downstream consumers affected: vadimdemedes/ink-text-input#91, vadimdemedes/ink-ui#18

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)