### PR TITLE
fix: mark text node dirty on insertBefore to fix stale layout

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -145,17 +145,15 @@ export const insertBeforeNode = (
 		if (newChildNode.yogaNode) {
 			node.yogaNode?.insertChild(newChildNode.yogaNode, index);
 		}
+	} else {
+		node.childNodes.push(newChildNode);
 
-		return;
-	}
-
-	node.childNodes.push(newChildNode);
-
-	if (newChildNode.yogaNode) {
-		node.yogaNode?.insertChild(
-			newChildNode.yogaNode,
-			node.yogaNode.getChildCount(),
-		);
+		if (newChildNode.yogaNode) {
+			node.yogaNode?.insertChild(
+				newChildNode.yogaNode,
+				node.yogaNode.getChildCount(),
+			);
+		}
 	}
 
 	if (node.nodeName === 'ink-text' || node.nodeName === 'ink-virtual-text') {

--- a/test/text.tsx
+++ b/test/text.tsx
@@ -99,6 +99,27 @@ test('text with inversion', t => {
 	t.is(output, chalk.inverse('Test'));
 });
 
+// See https://github.com/vadimdemedes/ink/issues/867
+test('text with empty-to-nonempty sibling does not wrap', t => {
+	function Test({show}: {readonly show?: boolean}) {
+		return (
+			<Box>
+				<Text>
+					{show ? 'x' : ''}
+					{'hello'}
+				</Text>
+			</Box>
+		);
+	}
+
+	const stdout = createStdout();
+	const {rerender} = render(<Test />, {stdout, debug: true});
+	t.is((stdout.write as any).lastCall.args[0], 'hello');
+
+	rerender(<Test show />);
+	t.is((stdout.write as any).lastCall.args[0], 'xhello');
+});
+
 test('remeasure text when text is changed', t => {
 	function Test({add}: {readonly add?: boolean}) {
 		return (


### PR DESCRIPTION
## Summary

Fixes #867

When a string child of `<Text>` transitions from empty (`""`) to non-empty (e.g., `"x"`), the rendered output could be incorrectly truncated because Yoga used a stale cached width from the previous layout.

### Root cause

`insertBeforeNode` in `dom.ts` had an early `return` that skipped the `markNodeAsDirty()` call when the `beforeChild` was found in the parent's `childNodes` (the normal case). This meant that when React inserted a new `#text` node via `insertBefore`, Yoga was never told to re-measure the parent `ink-text` node.

React uses `insertBefore` (rather than `commitTextUpdate`) in this case because empty strings don't produce text nodes during initial render — so transitioning from `""` to `"x"` creates a new text node that gets inserted before the existing sibling.

### Fix

Restructure `insertBeforeNode` to use `if/else` instead of early return, ensuring `markNodeAsDirty` always executes — matching the pattern already used by `appendChildNode` and `removeChildNode`.

### Reproduction

```jsx
function Test({ show }) {
  return (
    <Box>
      <Text>
        {show ? 'x' : ''}
        {'hello'}
      </Text>
    </Box>
  );
}

// Initial render: "hello" ✓
// After rerender with show=true: "xhell" ✗ (expected "xhello")
```

## Test plan

- [x] Added regression test that verifies empty-to-nonempty text transitions render correctly
- [x] All existing tests pass (3 pre-existing failures unrelated to this change)