### PR TITLE
feat: add configurable submit key behavior (Enter vs Ctrl+Enter)

### DIFF
--- a/examples/configurable-submit/README.md
+++ b/examples/configurable-submit/README.md
@@ -1,0 +1,26 @@
+# Configurable Submit Behavior Example
+
+Demonstrates the `submitKeyBehavior` option with two input submission modes.
+
+## Submit Modes
+
+### Enter Mode (default)
+- **Enter** submits the message
+
+### Ctrl+Enter Mode
+- **Enter** adds a newline
+- **Ctrl+Enter** submits the message
+
+## Running
+
+```bash
+# Enter mode (default)
+npm run example examples/configurable-submit/index.ts
+
+# Ctrl+Enter mode
+SUBMIT_MODE=ctrl-enter npm run example examples/configurable-submit/index.ts
+```
+
+## Note
+
+Ctrl+Enter detection requires the [Kitty Keyboard Protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/). This example enables it via `kittyKeyboard: { mode: 'enabled' }`. Supported terminals include Kitty, Alacritty, WezTerm, and Ghostty.

--- a/examples/configurable-submit/configurable-submit.tsx
+++ b/examples/configurable-submit/configurable-submit.tsx
@@ -1,0 +1,113 @@
+import process from 'node:process';
+import React, {useState} from 'react';
+import {
+	render,
+	Text,
+	Box,
+	useInput,
+	useStdin,
+	useApp,
+} from '../../src/index.js';
+
+let messageId = 0;
+
+function ConfigurableSubmitDemo() {
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	const {internal_submitKeyBehavior} = useStdin();
+	const {exit} = useApp();
+	const [input, setInput] = useState('');
+	const [messages, setMessages] = useState<
+		Array<{
+			id: number;
+			text: string;
+		}>
+	>([]);
+
+	useInput((character, key) => {
+		if (character === 'c' && key.ctrl) {
+			exit();
+			return;
+		}
+
+		const shouldSubmit =
+			internal_submitKeyBehavior === 'enter'
+				? key.return && !key.ctrl
+				: key.return && key.ctrl;
+
+		if (shouldSubmit) {
+			if (input.trim()) {
+				setMessages(previousMessages => [
+					...previousMessages,
+					{
+						id: messageId++,
+						text: `User: ${input}`,
+					},
+				]);
+				setInput('');
+			}
+		} else if (
+			key.return &&
+			!key.ctrl &&
+			internal_submitKeyBehavior === 'ctrl-enter'
+		) {
+			setInput(currentInput => currentInput + '\n');
+		} else if (key.backspace || key.delete) {
+			setInput(currentInput => currentInput.slice(0, -1));
+		} else if (character === 'q' && input === '') {
+			exit();
+		} else if (character && character !== '\r' && character !== '\n') {
+			setInput(currentInput => currentInput + character);
+		}
+	});
+
+	const inputLines = input.split('\n');
+
+	return (
+		<Box flexDirection="column" padding={1}>
+			<Box flexDirection="column" marginBottom={1}>
+				<Text bold>
+					Submit Mode:{' '}
+					{internal_submitKeyBehavior === 'enter' ? '[Enter]' : '[Ctrl+Enter]'}
+				</Text>
+				<Text dimColor>
+					{internal_submitKeyBehavior === 'enter'
+						? 'Press Enter to submit'
+						: 'Press Ctrl+Enter to submit, Enter for newline'}
+				</Text>
+			</Box>
+
+			<Box flexDirection="column">
+				{messages.map(message => (
+					<Text key={message.id}>{message.text}</Text>
+				))}
+			</Box>
+
+			<Box
+				marginTop={1}
+				flexDirection="column"
+				borderStyle="single"
+				borderColor="yellow"
+				paddingX={1}
+			>
+				<Text bold color="yellow">
+					Input:
+				</Text>
+				{inputLines.map((line, lineIndex) => (
+					<Text key={`line-${lineIndex}`}>{line || ' '}</Text> // eslint-disable-line react/no-array-index-key
+				))}
+			</Box>
+		</Box>
+	);
+}
+
+const submitBehavior =
+	process.env['SUBMIT_MODE'] === 'ctrl-enter' ? 'ctrl-enter' : 'enter';
+
+render(<ConfigurableSubmitDemo />, {
+	submitKeyBehavior: submitBehavior,
+	exitOnCtrlC: false,
+	kittyKeyboard: {
+		mode: 'enabled',
+		flags: ['disambiguateEscapeCodes'],
+	},
+});

--- a/examples/configurable-submit/index.ts
+++ b/examples/configurable-submit/index.ts
@@ -1,0 +1,1 @@
+import './configurable-submit.js';

--- a/readme.md
+++ b/readme.md
@@ -1508,6 +1508,47 @@ const UserInput = () => {
 };
 ```
 
+#### Configurable Submit Behavior
+
+Ink supports configurable submit key behavior via the `submitKeyBehavior` option:
+
+```jsx
+import {render, useInput, useStdin} from 'ink';
+
+function MyApp() {
+	const {internal_submitKeyBehavior} = useStdin();
+
+	useInput((input, key) => {
+		const shouldSubmit =
+			internal_submitKeyBehavior === 'enter'
+				? key.return && !key.ctrl
+				: key.return && key.ctrl;
+
+		if (shouldSubmit) {
+			// Handle submission
+		} else if (key.return && internal_submitKeyBehavior === 'ctrl-enter') {
+			// In Ctrl+Enter mode, plain Enter adds newlines
+		}
+	});
+
+	return …
+}
+
+render(<MyApp />, {
+	submitKeyBehavior: 'ctrl-enter',
+	kittyKeyboard: {mode: 'enabled', flags: ['disambiguateEscapeCodes']},
+});
+```
+
+**Options:**
+
+- `'enter'` (default): Enter key submits
+- `'ctrl-enter'`: Ctrl+Enter submits, Enter can be used for newlines
+
+**Note:** Ctrl+Enter detection requires the [kitty keyboard protocol](#kittykeyboard) to be enabled. Without it, most terminals cannot distinguish Ctrl+Enter from Enter.
+
+See the [configurable-submit example](examples/configurable-submit) for a complete implementation.
+
 #### inputHandler(input, key)
 
 Type: `Function`
@@ -2140,6 +2181,31 @@ Default: `true`
 
 Configure whether Ink should listen for Ctrl+C keyboard input and exit the app.
 This is needed in case `process.stdin` is in [raw mode](https://nodejs.org/api/tty.html#tty_readstream_setrawmode_mode), because then Ctrl+C is ignored by default and the process is expected to handle it manually.
+
+###### submitKeyBehavior
+
+Type: `'enter' | 'ctrl-enter'`\
+Default: `'enter'`
+
+Configure submit key behavior for text input applications.
+
+- `'enter'`: Enter key triggers submit (traditional behavior)
+- `'ctrl-enter'`: Ctrl+Enter triggers submit, allowing Enter for newlines
+
+This option is made available to your application via `useStdin()` hook as `internal_submitKeyBehavior`. Your application code must implement the actual submit logic using this configuration.
+
+**Note:** Ctrl+Enter detection requires the [kitty keyboard protocol](#kittykeyboard) to be enabled.
+
+```jsx
+import {render} from 'ink';
+
+render(<MyApp />, {
+	submitKeyBehavior: 'ctrl-enter',
+	kittyKeyboard: {mode: 'enabled', flags: ['disambiguateEscapeCodes']},
+});
+```
+
+See the [configurable-submit example](examples/configurable-submit) for a complete implementation.
 
 ###### patchConsole
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -31,6 +31,7 @@ type Props = {
 	readonly writeToStdout: (data: string) => void;
 	readonly writeToStderr: (data: string) => void;
 	readonly exitOnCtrlC: boolean;
+	readonly submitKeyBehavior: 'enter' | 'ctrl-enter';
 	readonly onExit: (errorOrResult?: unknown) => void;
 	readonly setCursorPosition: (position: CursorPosition | undefined) => void;
 };
@@ -51,6 +52,7 @@ function App({
 	writeToStdout,
 	writeToStderr,
 	exitOnCtrlC,
+	submitKeyBehavior,
 	onExit,
 	setCursorPosition,
 }: Props): React.ReactNode {
@@ -456,9 +458,17 @@ function App({
 			// eslint-disable-next-line @typescript-eslint/naming-convention
 			internal_exitOnCtrlC: exitOnCtrlC,
 			// eslint-disable-next-line @typescript-eslint/naming-convention
+			internal_submitKeyBehavior: submitKeyBehavior,
+			// eslint-disable-next-line @typescript-eslint/naming-convention
 			internal_eventEmitter: internal_eventEmitter.current,
 		}),
-		[stdin, handleSetRawMode, isRawModeSupported, exitOnCtrlC],
+		[
+			stdin,
+			handleSetRawMode,
+			isRawModeSupported,
+			exitOnCtrlC,
+			submitKeyBehavior,
+		],
 	);
 
 	const stdoutContextValue = useMemo(

--- a/src/components/StdinContext.ts
+++ b/src/components/StdinContext.ts
@@ -20,6 +20,8 @@ export type Props = {
 
 	readonly internal_exitOnCtrlC: boolean;
 
+	readonly internal_submitKeyBehavior: 'enter' | 'ctrl-enter';
+
 	readonly internal_eventEmitter: EventEmitter;
 };
 
@@ -35,6 +37,8 @@ const StdinContext = createContext<Props>({
 	isRawModeSupported: false,
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	internal_exitOnCtrlC: true,
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	internal_submitKeyBehavior: 'enter',
 });
 
 StdinContext.displayName = 'InternalStdinContext';

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -153,6 +153,7 @@ export type Options = {
 	*/
 	concurrent?: boolean;
 	kittyKeyboard?: KittyKeyboardOptions;
+	submitKeyBehavior: 'enter' | 'ctrl-enter';
 };
 
 export default class Ink {
@@ -541,6 +542,7 @@ export default class Ink {
 					stdout={this.options.stdout}
 					stderr={this.options.stderr}
 					exitOnCtrlC={this.options.exitOnCtrlC}
+					submitKeyBehavior={this.options.submitKeyBehavior}
 					writeToStdout={this.writeToStdout}
 					writeToStderr={this.writeToStderr}
 					setCursorPosition={this.setCursorPosition}

--- a/src/render.ts
+++ b/src/render.ts
@@ -98,6 +98,22 @@ export type RenderOptions = {
 	@see https://sw.kovidgoyal.net/kitty/keyboard-protocol/
 	*/
 	kittyKeyboard?: KittyKeyboardOptions;
+
+	/**
+	Configure submit key behavior for text input.
+	- 'enter': Enter key alone triggers submit (traditional behavior)
+	- 'ctrl-enter': Ctrl+Enter triggers submit, Enter can be used for newlines
+
+	This option is made available to your application via useStdin() hook.
+	Your application code must implement the actual submit logic.
+
+	@default 'enter'
+	@example
+	```tsx
+	render(<MyApp />, { submitKeyBehavior: 'ctrl-enter' });
+	```
+	*/
+	submitKeyBehavior?: 'enter' | 'ctrl-enter';
 };
 
 export type Instance = {
@@ -152,6 +168,7 @@ const render = (
 		maxFps: 30,
 		incrementalRendering: false,
 		concurrent: false,
+		submitKeyBehavior: 'enter',
 		...getOptions(options),
 	};
 


### PR DESCRIPTION
## Summary

- Add `submitKeyBehavior` option to `render()` allowing apps to choose between Enter (default) and Ctrl+Enter for submission
- Follow the existing `exitOnCtrlC` pattern: propagate through `InkOptions` → `App` → `StdinContext`, accessible via `useStdin()` hook as `internal_submitKeyBehavior`
- Add `examples/configurable-submit/` demonstrating both modes with Kitty Keyboard Protocol enabled
- Document the feature in README including the Kitty protocol requirement

## Motivation

CLI applications like chat interfaces and text editors benefit from Ctrl+Enter submission, allowing Enter to insert newlines for multi-line input. This is a common UX pattern in modern chat applications.

## Implementation

The new `submitKeyBehavior` option accepts `'enter'` (default) or `'ctrl-enter'`. It is a low-level primitive — the application implements the actual submit logic using the configuration value from `useStdin()`:

```tsx
const {internal_submitKeyBehavior} = useStdin();

useInput((character, key) => {
  const shouldSubmit =
    internal_submitKeyBehavior === 'enter'
      ? key.return && !key.ctrl
      : key.return && key.ctrl;

  if (shouldSubmit) {
    // Handle submission
  }
});

render(<App />, {
  submitKeyBehavior: 'ctrl-enter',
  kittyKeyboard: { mode: 'enabled', flags: ['disambiguateEscapeCodes'] },
});
```

**Note:** Ctrl+Enter detection requires the [Kitty Keyboard Protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/). Without it, terminals send identical bytes for Enter and Ctrl+Enter. Supported terminals include Kitty, Alacritty, WezTerm, and Ghostty.

## Backward Compatibility

- Default is `'enter'` — no changes to existing behavior
- All existing tests and APIs remain unchanged
- New option is fully optional

## Test plan

- [x] `tsc --noEmit` compiles without errors
- [x] `xo` lint passes (no new errors)
- [x] All 737 tests pass
- [ ] Run `npm run example examples/configurable-submit/index.ts` — Enter should submit
- [ ] Run `SUBMIT_MODE=ctrl-enter npm run example examples/configurable-submit/index.ts` — Ctrl+Enter should submit, Enter adds newline