### PR TITLE
Add security policy

### DIFF
--- a/security.md
+++ b/security.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| 6.x     | ✅        |
+| < 6     | ❌        |
+
+## Reporting a Vulnerability
+
+To report a security vulnerability, please use the [GitHub Security Advisory](https://github.com/vadimdemedes/ink/security/advisories/new) feature, which allows for private disclosure.
+
+Please do **not** open a public issue for security vulnerabilities.
+
+You should receive a response within a few days. If the vulnerability is confirmed, a patch will be released as soon as possible.


### PR DESCRIPTION
## Summary

- Add `security.md` with supported versions and vulnerability reporting instructions
- Directs reporters to use GitHub Security Advisories for private disclosure

## Note

Private vulnerability reporting will need to be enabled in the repo settings (Settings → Security → Private vulnerability reporting) for the advisory link to work.