### PR TITLE
Fix fullscreen flicker when incrementalRendering is enabled

### DIFF
--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -959,6 +959,18 @@ export default class Ink {
 		});
 
 		if (shouldClearTerminal) {
+			// skip clearTerminal in incremental mode to avoid erase-then-redraw flicker
+			if (this.options.incrementalRendering) {
+				if (output !== this.lastOutput || this.log.isCursorDirty()) {
+					this.throttledLog(outputToRender);
+				}
+
+				this.lastOutput = output;
+				this.lastOutputToRender = outputToRender;
+				this.lastOutputHeight = outputHeight;
+				return;
+			}
+
 			const sync = this.shouldSync();
 			if (sync) {
 				this.options.stdout.write(bsu);

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -959,7 +959,7 @@ export default class Ink {
 		});
 
 		if (shouldClearTerminal) {
-			// skip clearTerminal in incremental mode to avoid erase-then-redraw flicker
+			// Skip clearTerminal in incremental mode to avoid erase-then-redraw flicker
 			if (this.options.incrementalRendering) {
 				if (output !== this.lastOutput || this.log.isCursorDirty()) {
 					this.throttledLog(outputToRender);

--- a/test/fixtures/issue-450-incremental-fullscreen-rerender.tsx
+++ b/test/fixtures/issue-450-incremental-fullscreen-rerender.tsx
@@ -1,0 +1,43 @@
+import process from 'node:process';
+import React, {useEffect, useState} from 'react';
+import {Box, Text, render, useApp} from '../../src/index.js';
+
+function App({rows}: {readonly rows: number}) {
+	const {exit} = useApp();
+	const [frame, setFrame] = useState(0);
+
+	useEffect(() => {
+		if (frame >= 8) {
+			const timer = setTimeout(() => {
+				exit();
+			}, 0);
+
+			return () => {
+				clearTimeout(timer);
+			};
+		}
+
+		const timer = setTimeout(() => {
+			setFrame(prev => prev + 1);
+		}, 100);
+
+		return () => {
+			clearTimeout(timer);
+		};
+	}, [exit, frame]);
+
+	return (
+		<Box height={rows} flexDirection="column">
+			<Text>#450 top</Text>
+			<Box flexGrow={1}>
+				<Text>{`frame ${frame}`}</Text>
+			</Box>
+			<Text>#450 bottom</Text>
+		</Box>
+	);
+}
+
+const rows = Number(process.argv[2]) || 6;
+process.stdout.rows = rows;
+
+render(<App rows={rows} />, {incrementalRendering: true});

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -166,7 +166,8 @@ type Issue450Fixture =
 	| 'issue-450-grow-to-fullscreen-rerender'
 	| 'issue-450-shrink-from-fullscreen-rerender'
 	| 'issue-450-shrink-from-overflow-rerender'
-	| 'issue-450-static-shrink-from-fullscreen-rerender';
+	| 'issue-450-static-shrink-from-fullscreen-rerender'
+	| 'issue-450-incremental-fullscreen-rerender';
 
 const runIssue450Fixture = async (
 	fixture: Issue450Fixture,
@@ -533,6 +534,28 @@ test.serial(
 			eraseLineCount > 0,
 			'Expected incremental erase sequences for non-fullscreen rerenders',
 		);
+	},
+);
+
+test.serial(
+	'#450: incremental rendering should not clearTerminal for fullscreen rerenders',
+	async t => {
+		const output = await runIssue450Fixture(
+			'issue-450-incremental-fullscreen-rerender',
+		);
+
+		const {clearTerminalCount} =
+			getIssue450ControlSequenceCounts(output);
+
+		t.is(
+			clearTerminalCount,
+			0,
+			'incrementalRendering should skip clearTerminal for fullscreen frames',
+		);
+
+		const stripped = stripAnsi(output);
+		t.true(stripped.includes('#450 top'));
+		t.true(stripped.includes('#450 bottom'));
 	},
 );
 

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -543,16 +543,11 @@ test.serial(
 		const output = await runIssue450Fixture(
 			'issue-450-incremental-fullscreen-rerender',
 		);
-
+		
 		const {clearTerminalCount} =
 			getIssue450ControlSequenceCounts(output);
-
-		t.is(
-			clearTerminalCount,
-			0,
-			'incrementalRendering should skip clearTerminal for fullscreen frames',
-		);
-
+		t.is(clearTerminalCount, 0, 'incrementalRendering should skip clearTerminal for fullscreen frames');
+		
 		const stripped = stripAnsi(output);
 		t.true(stripped.includes('#450 top'));
 		t.true(stripped.includes('#450 bottom'));


### PR DESCRIPTION
The fullscreen code path in `renderInteractiveFrame` unconditionally uses `clearTerminal`, even when `incrementalRendering` is turned on. This means any app whose output fills the terminal gets a full screen wipe on every re-render, making incrementalRendering effectively broken for real-world fullscreen apps.

The fix routes fullscreen frames through the incremental line-diff renderer when the option is set, so only changed lines are rewritten. The `clearTerminal` path is preserved as-is for standard mode.

Adds a test + fixture for the incremental fullscreen case.