### PR TITLE
feat: auto-detect kitty keyboard protocol via query instead of terminal whitelist

### DIFF
--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -1037,19 +1037,11 @@ export default class Ink {
 			return;
 		}
 
-		// Auto mode: use heuristic precheck, then confirm with protocol query
-		const term = process.env['TERM'] ?? '';
-		const termProgram = process.env['TERM_PROGRAM'] ?? '';
-
-		const isKnownSupportingTerminal =
-			'KITTY_WINDOW_ID' in process.env ||
-			term === 'xterm-kitty' ||
-			termProgram === 'WezTerm' ||
-			termProgram === 'ghostty';
-
-		if (isKnownSupportingTerminal) {
-			this.confirmKittySupport(flags);
-		}
+		// Auto mode: query the terminal for kitty keyboard protocol support.
+		// The CSI ? u query is safe to send to any terminal — unsupporting
+		// terminals simply won't respond, and the 200ms timeout handles that.
+		// This avoids maintaining a hardcoded whitelist of terminal names.
+		this.confirmKittySupport(flags);
 	}
 
 	private confirmKittySupport(flags: KittyFlagName[]): void {


### PR DESCRIPTION
## Summary

In `auto` mode, `initKittyKeyboard()` currently only attempts kitty keyboard protocol detection for a hardcoded list of terminals (kitty, WezTerm, ghostty, and those setting `KITTY_WINDOW_ID`). Any terminal not on this list is silently skipped, even if it fully supports the protocol.

This PR removes the whitelist pre-check and always sends the standard `CSI ? u` query in auto mode. The existing `confirmKittySupport()` method already handles non-supporting terminals gracefully via a 200ms timeout — so the whitelist is unnecessary.

## Why

- The kitty keyboard protocol defines a standard query mechanism (`CSI ? u`) specifically for capability detection. Relying on a whitelist defeats its purpose.
- Every new terminal that adds kitty support currently requires a manual update to Ink's whitelist — this doesn't scale.
- Terminal emulators like [Kova](https://github.com/micktaiwan/kova), Rio, Contour, and others implement the protocol but aren't listed, so their users get degraded key handling.
- The query is safe: non-supporting terminals simply don't respond, and the 200ms timeout already handles that case.

## Change

- Removed the `isKnownSupportingTerminal` whitelist check
- Always call `this.confirmKittySupport(flags)` when in auto mode with interactive TTY

## Risk

Minimal. The only behavioral change is that terminals NOT on the old whitelist will now receive a single `CSI ? u` query at startup. Terminals that don't support the protocol will ignore it (or not respond), and the 200ms timeout cleans up. No visible side effects.