### PR TITLE
docs: add inkish

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,7 @@ render(<Counter />);
 - [instagram-cli](https://github.com/supreme-gg-gg/instagram-cli) - Instagram client.
 - [ElevenLabs CLI](https://github.com/elevenlabs/cli) - ElevenLabs agents client.
 - [SSH AI Chat](https://github.com/miantiao-me/ssh-ai-chat) - Chat with AI over SSH.
+- [inkish](https://github.com/cpendery/inkish) - Turn any Ink CLI into an SSH app.
 
 _(PRs welcome. Append new entries at the end. Repos must have 100+ stars and showcase Ink beyond a basic list picker.)_
 


### PR DESCRIPTION
Adding my tool [`inkish`](https://github.com/cpendery/inkish) to the usage list. I know it's under the 100 star limit, but I thought it might be useful to highlight to Ink users since it's similar to the pairing of [`bubbletea`](https://github.com/charmbracelet/bubbletea) & [`wish`](https://github.com/charmbracelet/wish).

I'd also be happy to contribute support for the ssh functionality directly into ink 