### PR TITLE
Add wrap-anywhere option for Text component

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -366,12 +366,12 @@ Invert background and foreground colors.
 #### wrap
 
 Type: `string`\
-Allowed values: `wrap` `wrap-anywhere` `truncate` `truncate-start` `truncate-middle` `truncate-end`\
+Allowed values: `wrap` `hard` `truncate` `truncate-start` `truncate-middle` `truncate-end`\
 Default: `wrap`
 
 This property tells Ink to wrap or truncate text if its width is larger than the container.
 If `wrap` is passed (the default), Ink will wrap text and split it into multiple lines.
-If `wrap-anywhere` is passed, Ink will fill each line to the full column width, breaking words as necessary.
+If `hard` is passed, Ink will fill each line to the full column width, breaking words as necessary.
 If `truncate-*` is passed, Ink will truncate text instead, resulting in one line of text with the rest cut off.
 
 ```jsx
@@ -381,7 +381,7 @@ If `truncate-*` is passed, Ink will truncate text instead, resulting in one line
 //=> 'Hello\nWorld'
 
 <Box width={7}>
-	<Text wrap="wrap-anywhere">Hello World</Text>
+	<Text wrap="hard">Hello World</Text>
 </Box>
 //=> 'Hello W\norld'
 

--- a/readme.md
+++ b/readme.md
@@ -366,11 +366,12 @@ Invert background and foreground colors.
 #### wrap
 
 Type: `string`\
-Allowed values: `wrap` `truncate` `truncate-start` `truncate-middle` `truncate-end`\
+Allowed values: `wrap` `wrap-anywhere` `truncate` `truncate-start` `truncate-middle` `truncate-end`\
 Default: `wrap`
 
 This property tells Ink to wrap or truncate text if its width is larger than the container.
 If `wrap` is passed (the default), Ink will wrap text and split it into multiple lines.
+If `wrap-anywhere` is passed, Ink will fill each line to the full column width, breaking words as necessary.
 If `truncate-*` is passed, Ink will truncate text instead, resulting in one line of text with the rest cut off.
 
 ```jsx
@@ -378,6 +379,11 @@ If `truncate-*` is passed, Ink will truncate text instead, resulting in one line
 	<Text>Hello World</Text>
 </Box>
 //=> 'Hello\nWorld'
+
+<Box width={7}>
+	<Text wrap="wrap-anywhere">Hello World</Text>
+</Box>
+//=> 'Hello W\norld'
 
 // `truncate` is an alias to `truncate-end`
 <Box width={7}>

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -58,7 +58,7 @@ export type Props = {
 	readonly inverse?: boolean;
 
 	/**
-	This property tells Ink to wrap or truncate text if its width is larger than the container. If `wrap` is passed (the default), Ink will wrap text and split it into multiple lines. If `truncate-*` is passed, Ink will truncate text instead, resulting in one line of text with the rest cut off.
+	This property tells Ink to wrap or truncate text if its width is larger than the container. If `wrap` is passed (the default), Ink will wrap text and split it into multiple lines. If `wrap-anywhere` is passed, Ink will fill each line to the full column width, breaking words as necessary. If `truncate-*` is passed, Ink will truncate text instead, resulting in one line of text with the rest cut off.
 	*/
 	readonly wrap?: Styles['textWrap'];
 

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -58,7 +58,7 @@ export type Props = {
 	readonly inverse?: boolean;
 
 	/**
-	This property tells Ink to wrap or truncate text if its width is larger than the container. If `wrap` is passed (the default), Ink will wrap text and split it into multiple lines. If `wrap-anywhere` is passed, Ink will fill each line to the full column width, breaking words as necessary. If `truncate-*` is passed, Ink will truncate text instead, resulting in one line of text with the rest cut off.
+	This property tells Ink to wrap or truncate text if its width is larger than the container. If `wrap` is passed (the default), Ink will wrap text and split it into multiple lines. If `hard` is passed, Ink will fill each line to the full column width, breaking words as necessary. If `truncate-*` is passed, Ink will truncate text instead, resulting in one line of text with the rest cut off.
 	*/
 	readonly wrap?: Styles['textWrap'];
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -7,7 +7,7 @@ import Yoga, {type Node as YogaNode} from 'yoga-layout';
 export type Styles = {
 	readonly textWrap?:
 		| 'wrap'
-		| 'wrap-anywhere'
+		| 'hard'
 		| 'end'
 		| 'middle'
 		| 'truncate-end'

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -7,6 +7,7 @@ import Yoga, {type Node as YogaNode} from 'yoga-layout';
 export type Styles = {
 	readonly textWrap?:
 		| 'wrap'
+		| 'wrap-anywhere'
 		| 'end'
 		| 'middle'
 		| 'truncate-end'

--- a/src/wrap-text.ts
+++ b/src/wrap-text.ts
@@ -25,7 +25,7 @@ const wrapText = (
 		});
 	}
 
-	if (wrapType === 'wrap-anywhere') {
+	if (wrapType === 'hard') {
 		wrappedText = wrapAnsi(text, maxWidth, {
 			trim: false,
 			hard: true,

--- a/src/wrap-text.ts
+++ b/src/wrap-text.ts
@@ -25,6 +25,14 @@ const wrapText = (
 		});
 	}
 
+	if (wrapType === 'wrap-anywhere') {
+		wrappedText = wrapAnsi(text, maxWidth, {
+			trim: false,
+			hard: true,
+			wordWrap: false,
+		});
+	}
+
 	if (wrapType!.startsWith('truncate')) {
 		let position: 'end' | 'middle' | 'start' = 'end';
 

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -124,7 +124,6 @@ test('don’t hard wrap text if there is enough space', t => {
 	t.is(output, 'Hello World');
 });
 
-
 test('truncate text in the end', t => {
 	const output = renderToString(
 		<Box width={7}>

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -94,6 +94,37 @@ test('don’t wrap text if there is enough space', t => {
 	t.is(output, 'Hello World');
 });
 
+test('wrap text anywhere', t => {
+	const output = renderToString(
+		<Box width={7}>
+			<Text wrap="wrap-anywhere">Hello World</Text>
+		</Box>,
+	);
+
+	t.is(output, 'Hello W\norld');
+});
+
+test('wrap-anywhere with long word', t => {
+	const output = renderToString(
+		<Box width={5}>
+			<Text wrap="wrap-anywhere">aaaaaaaaaa</Text>
+		</Box>,
+	);
+
+	t.is(output, 'aaaaa\naaaaa');
+});
+
+test('don’t wrap-anywhere text if there is enough space', t => {
+	const output = renderToString(
+		<Box width={20}>
+			<Text wrap="wrap-anywhere">Hello World</Text>
+		</Box>,
+	);
+
+	t.is(output, 'Hello World');
+});
+
+
 test('truncate text in the end', t => {
 	const output = renderToString(
 		<Box width={7}>

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -94,30 +94,30 @@ test('don’t wrap text if there is enough space', t => {
 	t.is(output, 'Hello World');
 });
 
-test('wrap text anywhere', t => {
+test('hard wrap text', t => {
 	const output = renderToString(
 		<Box width={7}>
-			<Text wrap="wrap-anywhere">Hello World</Text>
+			<Text wrap="hard">Hello World</Text>
 		</Box>,
 	);
 
 	t.is(output, 'Hello W\norld');
 });
 
-test('wrap-anywhere with long word', t => {
+test('hard wrap with long word', t => {
 	const output = renderToString(
 		<Box width={5}>
-			<Text wrap="wrap-anywhere">aaaaaaaaaa</Text>
+			<Text wrap="hard">aaaaaaaaaa</Text>
 		</Box>,
 	);
 
 	t.is(output, 'aaaaa\naaaaa');
 });
 
-test('don’t wrap-anywhere text if there is enough space', t => {
+test('don’t hard wrap text if there is enough space', t => {
 	const output = renderToString(
 		<Box width={20}>
-			<Text wrap="wrap-anywhere">Hello World</Text>
+			<Text wrap="hard">Hello World</Text>
 		</Box>,
 	);
 


### PR DESCRIPTION
Add 'wrap-anywhere' as a new value for the wrap prop on <Text />.

Unlike the default 'wrap' which tries to break at word boundaries, 'wrap-anywhere' fills each line to the full column width, breaking mid-word when needed. Uses wrap-ansi with wordWrap: false.

Closes #741