### PR TITLE
Fix build output and add tests

### DIFF
--- a/test/build-output.ts
+++ b/test/build-output.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import url from 'node:url';
+import {execSync} from 'node:child_process';
+import test from 'ava';
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+const rootDir = path.join(__dirname, '..');
+const buildDir = path.join(rootDir, 'build');
+const packageJson = JSON.parse(
+	fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'),
+);
+
+test.before(() => {
+	execSync('npm run build', {cwd: rootDir, stdio: 'pipe'});
+});
+
+test('build output files are not nested under build/src/', t => {
+	t.false(
+		fs.existsSync(path.join(buildDir, 'src')),
+		'build/src/ should not exist — files should be directly in build/',
+	);
+});
+
+test('package.json export paths resolve to existing files', t => {
+	const exports = packageJson.exports;
+	const typesPath = path.join(rootDir, exports.types);
+	const defaultPath = path.join(rootDir, exports.default);
+
+	t.true(
+		fs.existsSync(typesPath),
+		`Types export path does not exist: ${exports.types}`,
+	);
+	t.true(
+		fs.existsSync(defaultPath),
+		`Default export path does not exist: ${exports.default}`,
+	);
+});
+
+test('build/index.js and build/index.d.ts exist', t => {
+	t.true(
+		fs.existsSync(path.join(buildDir, 'index.js')),
+		'build/index.js should exist',
+	);
+	t.true(
+		fs.existsSync(path.join(buildDir, 'index.d.ts')),
+		'build/index.d.ts should exist',
+	);
+});
+
+test('tsconfig.json include only contains src', t => {
+	const tsconfig = JSON.parse(
+		fs.readFileSync(path.join(rootDir, 'tsconfig.json'), 'utf8'),
+	);
+
+	t.deepEqual(
+		tsconfig.include,
+		['src'],
+		'tsconfig.json include should only contain "src" to avoid nested build output',
+	);
+});

--- a/test/build-output.ts
+++ b/test/build-output.ts
@@ -7,9 +7,12 @@ import test from 'ava';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 const rootDir = path.join(__dirname, '..');
 const buildDir = path.join(rootDir, 'build');
+
 const packageJson = JSON.parse(
 	fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8'),
-);
+) as {
+	exports: {types: string; default: string};
+};
 
 test.before(() => {
 	execSync('npm run build', {cwd: rootDir, stdio: 'pipe'});
@@ -23,7 +26,7 @@ test('build output files are not nested under build/src/', t => {
 });
 
 test('package.json export paths resolve to existing files', t => {
-	const exports = packageJson.exports;
+	const {exports} = packageJson;
 	const typesPath = path.join(rootDir, exports.types);
 	const defaultPath = path.join(rootDir, exports.default);
 
@@ -51,7 +54,7 @@ test('build/index.js and build/index.d.ts exist', t => {
 test('tsconfig.json include only contains src', t => {
 	const tsconfig = JSON.parse(
 		fs.readFileSync(path.join(rootDir, 'tsconfig.json'), 'utf8'),
-	);
+	) as {include: string[]};
 
 	t.deepEqual(
 		tsconfig.include,

--- a/test/build-output.ts
+++ b/test/build-output.ts
@@ -15,6 +15,7 @@ const packageJson = JSON.parse(
 };
 
 test.before(() => {
+	fs.rmSync(buildDir, {recursive: true, force: true});
 	execSync('npm run build', {cwd: rootDir, stdio: 'pipe'});
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
 		"jsx": "react",
 		"isolatedModules": true
 	},
-	"include": ["src", "media"]
+	"include": ["src"]
 }

--- a/xo.config.ts
+++ b/xo.config.ts
@@ -39,7 +39,11 @@ const xoConfig: FlatXoConfig = [
 		},
 	},
 	{
-		files: ['examples/**/*.{ts,tsx}', 'benchmark/**/*.{ts,tsx}'],
+		files: [
+			'examples/**/*.{ts,tsx}',
+			'benchmark/**/*.{ts,tsx}',
+			'media/**/*.{ts,tsx}',
+		],
 		rules: {
 			'import-x/no-unassigned-import': 'off',
 			'@typescript-eslint/no-unsafe-call': 'off',


### PR DESCRIPTION
Introduce tests to verify the build output structure and ensure that the TypeScript configuration only includes the source directory, preventing nested build outputs.

closes #918