### PR TITLE
Update focus handling in `App` component to conditionally reset on Escape

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -238,11 +238,11 @@ function App({
 			}
 
 			// Reset focus when there's an active focused component on Esc
-			if (input === escape) {
+			if (input === escape && isFocusEnabled) {
 				setActiveFocusId(undefined);
 			}
 		},
-		[exitOnCtrlC, handleExit],
+		[exitOnCtrlC, handleExit, isFocusEnabled],
 	);
 
 	const emitInput = useCallback(


### PR DESCRIPTION
We are disabiling focus control with:
```
  const { disableFocus} = useFocusManager();
```
and the start of our CLI because we want manually manage the tab, shift-tab and escape, but while this is effective to disable the automaticaly handling of tab, it is still messing with the escape, leaving the application on a broken state where nothing is focused.

Notice that, in our use case we still wanna use useFocus(), it's a nice abstraction to coordinate focus, and pass it around, we just don't want the "automated" tab/shift-tab/escape handling