### PR TITLE
Refactor: Split App component into smaller modules

### DIFF
--- a/src/components/AnimationContext.ts
+++ b/src/components/AnimationContext.ts
@@ -1,6 +1,6 @@
 import {createContext} from 'react';
 
-type AnimationContextValue = {
+export type AnimationContextValue = {
 	readonly renderThrottleMs: number;
 	readonly subscribe: (
 		callback: (currentTime: number) => void,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -9,7 +9,6 @@ import React, {
 	useEffect,
 } from 'react';
 import cliCursor from 'cli-cursor';
-import {type CursorPosition} from '../log-update.js';
 import {createInputParser} from '../input-parser.js';
 import AppContext from './AppContext.js';
 import StdinContext from './StdinContext.js';
@@ -17,7 +16,8 @@ import StdoutContext from './StdoutContext.js';
 import StderrContext from './StderrContext.js';
 import FocusContext from './FocusContext.js';
 import AnimationContext from './AnimationContext.js';
-import CursorContext from './CursorContext.js';
+import CursorContextProvider from './internal/CursorContextProvider.js';
+import {type CursorContextValue} from './CursorContext.js';
 import ErrorBoundary from './ErrorBoundary.js';
 
 const tab = '\t';
@@ -41,7 +41,7 @@ type Props = {
 	readonly exitOnCtrlC: boolean;
 	readonly onExit: (errorOrResult?: unknown) => void;
 	readonly onWaitUntilRenderFlush: () => Promise<void>;
-	readonly setCursorPosition: (position: CursorPosition | undefined) => void;
+	readonly setCursorPosition: CursorContextValue['setCursorPosition'];
 	readonly interactive: boolean;
 	readonly renderThrottleMs: number;
 };
@@ -640,13 +640,6 @@ function App({
 		[stderr, writeToStderr],
 	);
 
-	const cursorContextValue = useMemo(
-		() => ({
-			setCursorPosition,
-		}),
-		[setCursorPosition],
-	);
-
 	const focusContextValue = useMemo(
 		() => ({
 			activeId: activeFocusId,
@@ -689,9 +682,9 @@ function App({
 					<StderrContext.Provider value={stderrContextValue}>
 						<FocusContext.Provider value={focusContextValue}>
 							<AnimationContext.Provider value={animationContextValue}>
-								<CursorContext.Provider value={cursorContextValue}>
+								<CursorContextProvider setCursorPosition={setCursorPosition}>
 									<ErrorBoundary onError={handleExit}>{children}</ErrorBoundary>
-								</CursorContext.Provider>
+								</CursorContextProvider>
 							</AnimationContext.Provider>
 						</FocusContext.Provider>
 					</StderrContext.Provider>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -11,7 +11,8 @@ import cliCursor from 'cli-cursor';
 import {createInputParser} from '../input-parser.js';
 import AppContext from './AppContext.js';
 import StdinContext from './StdinContext.js';
-import StdoutContext from './StdoutContext.js';
+import StdoutContextProvider from './internal/StdoutContextProvider.js';
+import {type Props as StdoutContextProps} from './StdoutContext.js';
 import StderrContextProvider from './internal/StderrContextProvider.js';
 import {type Props as StderrContextProps} from './StderrContext.js';
 import FocusContextProvider from './internal/FocusContextProvider.js';
@@ -24,9 +25,9 @@ import ErrorBoundary from './ErrorBoundary.js';
 type Props = {
 	readonly children: ReactNode;
 	readonly stdin: NodeJS.ReadStream;
-	readonly stdout: NodeJS.WriteStream;
+	readonly stdout: StdoutContextProps['stdout'];
 	readonly stderr: StderrContextProps['stderr'];
-	readonly writeToStdout: (data: string) => void;
+	readonly writeToStdout: StdoutContextProps['write'];
 	readonly writeToStderr: StderrContextProps['write'];
 	readonly exitOnCtrlC: boolean;
 	readonly onExit: (errorOrResult?: unknown) => void;
@@ -289,18 +290,10 @@ function App({
 		],
 	);
 
-	const stdoutContextValue = useMemo(
-		() => ({
-			stdout,
-			write: writeToStdout,
-		}),
-		[stdout, writeToStdout],
-	);
-
 	return (
 		<AppContext.Provider value={appContextValue}>
 			<StdinContext.Provider value={stdinContextValue}>
-				<StdoutContext.Provider value={stdoutContextValue}>
+				<StdoutContextProvider stdout={stdout} writeToStdout={writeToStdout}>
 					<StderrContextProvider stderr={stderr} writeToStderr={writeToStderr}>
 						<FocusContextProvider eventEmitter={internal_eventEmitter.current}>
 							<AnimationContextProvider renderThrottleMs={renderThrottleMs}>
@@ -310,7 +303,7 @@ function App({
 							</AnimationContextProvider>
 						</FocusContextProvider>
 					</StderrContextProvider>
-				</StdoutContext.Provider>
+				</StdoutContextProvider>
 			</StdinContext.Provider>
 		</AppContext.Provider>
 	);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -12,7 +12,8 @@ import {createInputParser} from '../input-parser.js';
 import AppContext from './AppContext.js';
 import StdinContext from './StdinContext.js';
 import StdoutContext from './StdoutContext.js';
-import StderrContext from './StderrContext.js';
+import StderrContextProvider from './internal/StderrContextProvider.js';
+import {type Props as StderrContextProps} from './StderrContext.js';
 import FocusContextProvider from './internal/FocusContextProvider.js';
 import AnimationContextProvider from './internal/AnimationContextProvider.js';
 import {type AnimationContextValue} from './AnimationContext.js';
@@ -24,9 +25,9 @@ type Props = {
 	readonly children: ReactNode;
 	readonly stdin: NodeJS.ReadStream;
 	readonly stdout: NodeJS.WriteStream;
-	readonly stderr: NodeJS.WriteStream;
+	readonly stderr: StderrContextProps['stderr'];
 	readonly writeToStdout: (data: string) => void;
-	readonly writeToStderr: (data: string) => void;
+	readonly writeToStderr: StderrContextProps['write'];
 	readonly exitOnCtrlC: boolean;
 	readonly onExit: (errorOrResult?: unknown) => void;
 	readonly onWaitUntilRenderFlush: () => Promise<void>;
@@ -296,19 +297,11 @@ function App({
 		[stdout, writeToStdout],
 	);
 
-	const stderrContextValue = useMemo(
-		() => ({
-			stderr,
-			write: writeToStderr,
-		}),
-		[stderr, writeToStderr],
-	);
-
 	return (
 		<AppContext.Provider value={appContextValue}>
 			<StdinContext.Provider value={stdinContextValue}>
 				<StdoutContext.Provider value={stdoutContextValue}>
-					<StderrContext.Provider value={stderrContextValue}>
+					<StderrContextProvider stderr={stderr} writeToStderr={writeToStderr}>
 						<FocusContextProvider eventEmitter={internal_eventEmitter.current}>
 							<AnimationContextProvider renderThrottleMs={renderThrottleMs}>
 								<CursorContextProvider setCursorPosition={setCursorPosition}>
@@ -316,7 +309,7 @@ function App({
 								</CursorContextProvider>
 							</AnimationContextProvider>
 						</FocusContextProvider>
-					</StderrContext.Provider>
+					</StderrContextProvider>
 				</StdoutContext.Provider>
 			</StdinContext.Provider>
 		</AppContext.Provider>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -15,7 +15,8 @@ import StdinContext from './StdinContext.js';
 import StdoutContext from './StdoutContext.js';
 import StderrContext from './StderrContext.js';
 import FocusContext from './FocusContext.js';
-import AnimationContext from './AnimationContext.js';
+import AnimationContextProvider from './internal/AnimationContextProvider.js';
+import {type AnimationContextValue} from './AnimationContext.js';
 import CursorContextProvider from './internal/CursorContextProvider.js';
 import {type CursorContextValue} from './CursorContext.js';
 import ErrorBoundary from './ErrorBoundary.js';
@@ -23,13 +24,6 @@ import ErrorBoundary from './ErrorBoundary.js';
 const tab = '\t';
 const shiftTab = '\u001B[Z';
 const escape = '\u001B';
-
-type AnimationSubscriber = {
-	readonly callback: (currentTime: number) => void;
-	readonly interval: number;
-	readonly startTime: number;
-	nextDueTime: number;
-};
 
 type Props = {
 	readonly children: ReactNode;
@@ -43,7 +37,7 @@ type Props = {
 	readonly onWaitUntilRenderFlush: () => Promise<void>;
 	readonly setCursorPosition: CursorContextValue['setCursorPosition'];
 	readonly interactive: boolean;
-	readonly renderThrottleMs: number;
+	readonly renderThrottleMs: AnimationContextValue['renderThrottleMs'];
 };
 
 type Focusable = {
@@ -77,12 +71,6 @@ function App({
 	const [, setFocusables] = useState<Focusable[]>([]);
 	// Track focusables count for tab navigation check (avoids stale closure)
 	const focusablesCountRef = useRef(0);
-	const animationSubscribersRef = useRef(
-		new Map<(currentTime: number) => void, AnimationSubscriber>(),
-	);
-	const animationTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
-		undefined,
-	);
 	// Count how many components enabled raw mode to avoid disabling
 	// raw mode until all components don't need it anymore
 	const rawModeEnabledCount = useRef(0);
@@ -107,94 +95,6 @@ function App({
 		clearTimeout(pendingInputFlushRef.current);
 		pendingInputFlushRef.current = undefined;
 	}, []);
-
-	const clearAnimationTimer = useCallback((): void => {
-		if (!animationTimerRef.current) {
-			return;
-		}
-
-		clearTimeout(animationTimerRef.current);
-		animationTimerRef.current = undefined;
-	}, []);
-
-	const scheduleAnimationTick = useCallback((): void => {
-		clearAnimationTimer();
-
-		if (animationSubscribersRef.current.size === 0) {
-			return;
-		}
-
-		let nextDueTime = Number.POSITIVE_INFINITY;
-
-		for (const subscriber of animationSubscribersRef.current.values()) {
-			// One shared timer is enough as long as it wakes at the earliest
-			// subscriber deadline and lets slower animations skip that tick.
-			nextDueTime = Math.min(nextDueTime, subscriber.nextDueTime);
-		}
-
-		const delay = Math.max(0, nextDueTime - performance.now());
-		animationTimerRef.current = setTimeout(() => {
-			animationTimerRef.current = undefined;
-			const currentTime = performance.now();
-
-			for (const subscriber of animationSubscribersRef.current.values()) {
-				if (currentTime < subscriber.nextDueTime) {
-					continue;
-				}
-
-				subscriber.callback(currentTime);
-				const elapsedTime = currentTime - subscriber.startTime;
-				const elapsedFrames = Math.floor(elapsedTime / subscriber.interval) + 1;
-				// Advance from elapsed time rather than callback count so delayed
-				// ticks catch up instead of stretching the animation timeline.
-				subscriber.nextDueTime =
-					subscriber.startTime + elapsedFrames * subscriber.interval;
-			}
-
-			scheduleAnimationTick();
-		}, delay);
-		// Keep the timer ref'd while animations are active so `useAnimation()`
-		// can drive process lifetime in both interactive and non-interactive apps.
-	}, [clearAnimationTimer]);
-
-	const animationSubscribe = useCallback(
-		(
-			callback: (currentTime: number) => void,
-			interval: number,
-		): {readonly startTime: number; readonly unsubscribe: () => void} => {
-			const startTime = performance.now();
-			// The scheduler owns the start timestamp so hooks can derive frames from
-			// the exact same origin that determines each subscriber's due time.
-			animationSubscribersRef.current.set(callback, {
-				callback,
-				interval,
-				startTime,
-				nextDueTime: startTime + interval,
-			});
-			scheduleAnimationTick();
-
-			return {
-				startTime,
-				unsubscribe() {
-					animationSubscribersRef.current.delete(callback);
-
-					if (animationSubscribersRef.current.size === 0) {
-						clearAnimationTimer();
-						return;
-					}
-
-					scheduleAnimationTick();
-				},
-			};
-		},
-		[clearAnimationTimer, scheduleAnimationTick],
-	);
-
-	useEffect(() => {
-		return () => {
-			clearAnimationTimer();
-		};
-	}, [clearAnimationTimer]);
 
 	// Determines if TTY is supported on the provided stdin
 	const isRawModeSupported = stdin.isTTY;
@@ -667,25 +567,17 @@ function App({
 		],
 	);
 
-	const animationContextValue = useMemo(
-		() => ({
-			renderThrottleMs,
-			subscribe: animationSubscribe,
-		}),
-		[animationSubscribe, renderThrottleMs],
-	);
-
 	return (
 		<AppContext.Provider value={appContextValue}>
 			<StdinContext.Provider value={stdinContextValue}>
 				<StdoutContext.Provider value={stdoutContextValue}>
 					<StderrContext.Provider value={stderrContextValue}>
 						<FocusContext.Provider value={focusContextValue}>
-							<AnimationContext.Provider value={animationContextValue}>
+							<AnimationContextProvider renderThrottleMs={renderThrottleMs}>
 								<CursorContextProvider setCursorPosition={setCursorPosition}>
 									<ErrorBoundary onError={handleExit}>{children}</ErrorBoundary>
 								</CursorContextProvider>
-							</AnimationContext.Provider>
+							</AnimationContextProvider>
 						</FocusContext.Provider>
 					</StderrContext.Provider>
 				</StdoutContext.Provider>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,40 +1,28 @@
 import {EventEmitter} from 'node:events';
-import process from 'node:process';
-import React, {
-	type ReactNode,
-	useRef,
-	useCallback,
-	useMemo,
-	useEffect,
-} from 'react';
-import cliCursor from 'cli-cursor';
-import {createInputParser} from '../input-parser.js';
-import AppContext from './AppContext.js';
+import React, {type ReactNode, useRef} from 'react';
+import {type CursorPosition} from '../log-update.js';
+import AppContextProvider from './internal/AppContextProvider.js';
 import StdinContextProvider from './internal/StdinContextProvider.js';
 import StdoutContextProvider from './internal/StdoutContextProvider.js';
-import {type Props as StdoutContextProps} from './StdoutContext.js';
 import StderrContextProvider from './internal/StderrContextProvider.js';
-import {type Props as StderrContextProps} from './StderrContext.js';
 import FocusContextProvider from './internal/FocusContextProvider.js';
 import AnimationContextProvider from './internal/AnimationContextProvider.js';
-import {type AnimationContextValue} from './AnimationContext.js';
 import CursorContextProvider from './internal/CursorContextProvider.js';
-import {type CursorContextValue} from './CursorContext.js';
 import ErrorBoundary from './ErrorBoundary.js';
 
 type Props = {
 	readonly children: ReactNode;
 	readonly stdin: NodeJS.ReadStream;
-	readonly stdout: StdoutContextProps['stdout'];
-	readonly stderr: StderrContextProps['stderr'];
-	readonly writeToStdout: StdoutContextProps['write'];
-	readonly writeToStderr: StderrContextProps['write'];
+	readonly stdout: NodeJS.WriteStream;
+	readonly stderr: NodeJS.WriteStream;
+	readonly writeToStdout: (data: string) => void;
+	readonly writeToStderr: (data: string) => void;
 	readonly exitOnCtrlC: boolean;
 	readonly onExit: (errorOrResult?: unknown) => void;
 	readonly onWaitUntilRenderFlush: () => Promise<void>;
-	readonly setCursorPosition: CursorContextValue['setCursorPosition'];
+	readonly setCursorPosition: (position: CursorPosition | undefined) => void;
 	readonly interactive: boolean;
-	readonly renderThrottleMs: AnimationContextValue['renderThrottleMs'];
+	readonly renderThrottleMs: number;
 };
 
 // Root component for all Ink apps
@@ -54,254 +42,33 @@ function App({
 	interactive,
 	renderThrottleMs,
 }: Props): React.ReactNode {
-	// Count how many components enabled raw mode to avoid disabling
-	// raw mode until all components don't need it anymore
-	const rawModeEnabledCount = useRef(0);
-	// Count how many components enabled bracketed paste mode
-	const bracketedPasteModeEnabledCount = useRef(0);
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	const internal_eventEmitter = useRef(new EventEmitter());
-	// Each useInput hook adds a listener, so the count can legitimately exceed the default limit of 10.
-	internal_eventEmitter.current.setMaxListeners(Infinity);
-	// Store the currently attached readable listener to avoid stale closure issues
-	const readableListenerRef = useRef<(() => void) | undefined>(undefined);
-	const inputParserRef = useRef(createInputParser());
-	const pendingInputFlushRef = useRef<NodeJS.Timeout | undefined>(undefined);
-	// Small delay to let chunked escape sequences complete before flushing as literal input.
-	const pendingInputFlushDelayMilliseconds = 20;
-
-	const clearPendingInputFlush = useCallback((): void => {
-		if (!pendingInputFlushRef.current) {
-			return;
-		}
-
-		clearTimeout(pendingInputFlushRef.current);
-		pendingInputFlushRef.current = undefined;
-	}, []);
-
-	// Determines if TTY is supported on the provided stdin
-	const isRawModeSupported = stdin.isTTY;
-
-	const detachReadableListener = useCallback((): void => {
-		if (!readableListenerRef.current) {
-			return;
-		}
-
-		stdin.removeListener('readable', readableListenerRef.current);
-		readableListenerRef.current = undefined;
-	}, [stdin]);
-
-	const disableRawMode = useCallback((): void => {
-		stdin.setRawMode(false);
-		detachReadableListener();
-		stdin.unref();
-		rawModeEnabledCount.current = 0;
-		inputParserRef.current.reset();
-		clearPendingInputFlush();
-	}, [stdin, detachReadableListener, clearPendingInputFlush]);
-
-	const handleExit = useCallback(
-		(errorOrResult?: unknown): void => {
-			if (isRawModeSupported && rawModeEnabledCount.current > 0) {
-				disableRawMode();
-			}
-
-			onExit(errorOrResult);
-		},
-		[isRawModeSupported, disableRawMode, onExit],
-	);
-
-	const handleInput = useCallback(
-		(input: string): void => {
-			// Exit on Ctrl+C
-			// eslint-disable-next-line unicorn/no-hex-escape
-			if (input === '\x03' && exitOnCtrlC) {
-				handleExit();
-			}
-		},
-		[exitOnCtrlC, handleExit],
-	);
-
-	const emitInput = useCallback(
-		(input: string): void => {
-			handleInput(input);
-			internal_eventEmitter.current.emit('input', input);
-		},
-		[handleInput],
-	);
-
-	const schedulePendingInputFlush = useCallback((): void => {
-		clearPendingInputFlush();
-		pendingInputFlushRef.current = setTimeout(() => {
-			pendingInputFlushRef.current = undefined;
-			const pendingEscape = inputParserRef.current.flushPendingEscape();
-			if (!pendingEscape) {
-				return;
-			}
-
-			emitInput(pendingEscape);
-		}, pendingInputFlushDelayMilliseconds);
-	}, [clearPendingInputFlush, emitInput]);
-
-	const handleReadable = useCallback((): void => {
-		clearPendingInputFlush();
-		let chunk;
-		// eslint-disable-next-line @typescript-eslint/no-restricted-types
-		while ((chunk = stdin.read() as string | null) !== null) {
-			const inputEvents = inputParserRef.current.push(chunk);
-			for (const event of inputEvents) {
-				if (typeof event === 'string') {
-					emitInput(event);
-				} else {
-					// Keep paste on a separate channel from `useInput` so key handlers
-					// don't need to branch on mixed key-vs-paste event shapes.
-					if (internal_eventEmitter.current.listenerCount('paste') === 0) {
-						emitInput(event.paste);
-						continue;
-					}
-
-					internal_eventEmitter.current.emit('paste', event.paste);
-				}
-			}
-		}
-
-		if (inputParserRef.current.hasPendingEscape()) {
-			schedulePendingInputFlush();
-		}
-	}, [stdin, emitInput, clearPendingInputFlush, schedulePendingInputFlush]);
-
-	const handleSetRawMode = useCallback(
-		(isEnabled: boolean): void => {
-			if (!isRawModeSupported) {
-				if (stdin === process.stdin) {
-					throw new Error(
-						'Raw mode is not supported on the current process.stdin, which Ink uses as input stream by default.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported',
-					);
-				} else {
-					throw new Error(
-						'Raw mode is not supported on the stdin provided to Ink.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported',
-					);
-				}
-			}
-
-			stdin.setEncoding('utf8');
-
-			if (isEnabled) {
-				// Ensure raw mode is enabled only once
-				if (rawModeEnabledCount.current === 0) {
-					stdin.ref();
-					stdin.setRawMode(true);
-					// Store the listener reference to avoid stale closure when removing
-					readableListenerRef.current = handleReadable;
-					stdin.addListener('readable', handleReadable);
-				}
-
-				rawModeEnabledCount.current++;
-				return;
-			}
-
-			// Disable raw mode only when no components left that are using it
-			if (rawModeEnabledCount.current === 0) {
-				return;
-			}
-
-			if (--rawModeEnabledCount.current === 0) {
-				disableRawMode();
-			}
-		},
-		[isRawModeSupported, stdin, handleReadable, disableRawMode],
-	);
-
-	const handleSetBracketedPasteMode = useCallback(
-		(isEnabled: boolean): void => {
-			if (!stdout.isTTY) {
-				return;
-			}
-
-			if (isEnabled) {
-				if (bracketedPasteModeEnabledCount.current === 0) {
-					stdout.write('\u001B[?2004h');
-				}
-
-				bracketedPasteModeEnabledCount.current++;
-				return;
-			}
-
-			if (bracketedPasteModeEnabledCount.current === 0) {
-				return;
-			}
-
-			if (--bracketedPasteModeEnabledCount.current === 0) {
-				stdout.write('\u001B[?2004l');
-			}
-		},
-		[stdout],
-	);
-
-	// Handle cursor visibility, raw mode, and bracketed paste mode cleanup on unmount
-	useEffect(() => {
-		return () => {
-			const canWriteToStdout = !stdout.destroyed && !stdout.writableEnded;
-
-			if (interactive && canWriteToStdout) {
-				cliCursor.show(stdout);
-			}
-
-			if (isRawModeSupported && rawModeEnabledCount.current > 0) {
-				disableRawMode();
-			}
-
-			if (bracketedPasteModeEnabledCount.current > 0) {
-				if (stdout.isTTY && canWriteToStdout) {
-					stdout.write('\u001B[?2004l');
-				}
-
-				bracketedPasteModeEnabledCount.current = 0;
-			}
-		};
-	}, [stdout, isRawModeSupported, disableRawMode, interactive]);
-
-	// Memoize context values to prevent unnecessary re-renders
-	const appContextValue = useMemo(
-		() => ({
-			exit: handleExit,
-			waitUntilRenderFlush: onWaitUntilRenderFlush,
-			stdin,
-			handleSetRawMode,
-			handleSetBracketedPasteMode,
-			isRawModeSupported,
-			// eslint-disable-next-line @typescript-eslint/naming-convention
-			internal_exitOnCtrlC: exitOnCtrlC,
-			// eslint-disable-next-line @typescript-eslint/naming-convention
-			internal_eventEmitter: internal_eventEmitter.current,
-		}),
-		[
-			handleExit,
-			onWaitUntilRenderFlush,
-			exitOnCtrlC,
-			handleSetBracketedPasteMode,
-			handleSetRawMode,
-			isRawModeSupported,
-			stdin,
-		],
-	);
 
 	return (
-		<AppContext.Provider value={appContextValue}>
+		<AppContextProvider
+			stdin={stdin}
+			stdout={stdout}
+			exitOnCtrlC={exitOnCtrlC}
+			interactive={interactive}
+			eventEmitter={internal_eventEmitter.current}
+			onExit={onExit}
+			onWaitUntilRenderFlush={onWaitUntilRenderFlush}
+		>
 			<StdinContextProvider>
 				<StdoutContextProvider stdout={stdout} writeToStdout={writeToStdout}>
 					<StderrContextProvider stderr={stderr} writeToStderr={writeToStderr}>
 						<FocusContextProvider eventEmitter={internal_eventEmitter.current}>
 							<AnimationContextProvider renderThrottleMs={renderThrottleMs}>
 								<CursorContextProvider setCursorPosition={setCursorPosition}>
-									<ErrorBoundary onError={handleExit}>{children}</ErrorBoundary>
+									<ErrorBoundary>{children}</ErrorBoundary>
 								</CursorContextProvider>
 							</AnimationContextProvider>
 						</FocusContextProvider>
 					</StderrContextProvider>
 				</StdoutContextProvider>
 			</StdinContextProvider>
-		</AppContext.Provider>
+		</AppContextProvider>
 	);
 }
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -10,7 +10,7 @@ import React, {
 import cliCursor from 'cli-cursor';
 import {createInputParser} from '../input-parser.js';
 import AppContext from './AppContext.js';
-import StdinContext from './StdinContext.js';
+import StdinContextProvider from './internal/StdinContextProvider.js';
 import StdoutContextProvider from './internal/StdoutContextProvider.js';
 import {type Props as StdoutContextProps} from './StdoutContext.js';
 import StderrContextProvider from './internal/StderrContextProvider.js';
@@ -266,15 +266,9 @@ function App({
 		() => ({
 			exit: handleExit,
 			waitUntilRenderFlush: onWaitUntilRenderFlush,
-		}),
-		[handleExit, onWaitUntilRenderFlush],
-	);
-
-	const stdinContextValue = useMemo(
-		() => ({
 			stdin,
-			setRawMode: handleSetRawMode,
-			setBracketedPasteMode: handleSetBracketedPasteMode,
+			handleSetRawMode,
+			handleSetBracketedPasteMode,
 			isRawModeSupported,
 			// eslint-disable-next-line @typescript-eslint/naming-convention
 			internal_exitOnCtrlC: exitOnCtrlC,
@@ -282,17 +276,19 @@ function App({
 			internal_eventEmitter: internal_eventEmitter.current,
 		}),
 		[
-			stdin,
-			handleSetRawMode,
-			handleSetBracketedPasteMode,
-			isRawModeSupported,
+			handleExit,
+			onWaitUntilRenderFlush,
 			exitOnCtrlC,
+			handleSetBracketedPasteMode,
+			handleSetRawMode,
+			isRawModeSupported,
+			stdin,
 		],
 	);
 
 	return (
 		<AppContext.Provider value={appContextValue}>
-			<StdinContext.Provider value={stdinContextValue}>
+			<StdinContextProvider>
 				<StdoutContextProvider stdout={stdout} writeToStdout={writeToStdout}>
 					<StderrContextProvider stderr={stderr} writeToStderr={writeToStderr}>
 						<FocusContextProvider eventEmitter={internal_eventEmitter.current}>
@@ -304,7 +300,7 @@ function App({
 						</FocusContextProvider>
 					</StderrContextProvider>
 				</StdoutContextProvider>
-			</StdinContext.Provider>
+			</StdinContextProvider>
 		</AppContext.Provider>
 	);
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2,7 +2,6 @@ import {EventEmitter} from 'node:events';
 import process from 'node:process';
 import React, {
 	type ReactNode,
-	useState,
 	useRef,
 	useCallback,
 	useMemo,
@@ -14,16 +13,12 @@ import AppContext from './AppContext.js';
 import StdinContext from './StdinContext.js';
 import StdoutContext from './StdoutContext.js';
 import StderrContext from './StderrContext.js';
-import FocusContext from './FocusContext.js';
+import FocusContextProvider from './internal/FocusContextProvider.js';
 import AnimationContextProvider from './internal/AnimationContextProvider.js';
 import {type AnimationContextValue} from './AnimationContext.js';
 import CursorContextProvider from './internal/CursorContextProvider.js';
 import {type CursorContextValue} from './CursorContext.js';
 import ErrorBoundary from './ErrorBoundary.js';
-
-const tab = '\t';
-const shiftTab = '\u001B[Z';
-const escape = '\u001B';
 
 type Props = {
 	readonly children: ReactNode;
@@ -38,11 +33,6 @@ type Props = {
 	readonly setCursorPosition: CursorContextValue['setCursorPosition'];
 	readonly interactive: boolean;
 	readonly renderThrottleMs: AnimationContextValue['renderThrottleMs'];
-};
-
-type Focusable = {
-	readonly id: string;
-	readonly isActive: boolean;
 };
 
 // Root component for all Ink apps
@@ -62,15 +52,6 @@ function App({
 	interactive,
 	renderThrottleMs,
 }: Props): React.ReactNode {
-	const [isFocusEnabled, setIsFocusEnabled] = useState(true);
-	const [activeFocusId, setActiveFocusId] = useState<string | undefined>(
-		undefined,
-	);
-	// Focusables array is managed internally via setFocusables callback pattern
-	// eslint-disable-next-line react/hook-use-state
-	const [, setFocusables] = useState<Focusable[]>([]);
-	// Track focusables count for tab navigation check (avoids stale closure)
-	const focusablesCountRef = useRef(0);
 	// Count how many components enabled raw mode to avoid disabling
 	// raw mode until all components don't need it anymore
 	const rawModeEnabledCount = useRef(0);
@@ -134,15 +115,9 @@ function App({
 			// eslint-disable-next-line unicorn/no-hex-escape
 			if (input === '\x03' && exitOnCtrlC) {
 				handleExit();
-				return;
-			}
-
-			// Reset focus when there's an active focused component on Esc
-			if (input === escape && isFocusEnabled) {
-				setActiveFocusId(undefined);
 			}
 		},
-		[exitOnCtrlC, handleExit, isFocusEnabled],
+		[exitOnCtrlC, handleExit],
 	);
 
 	const emitInput = useCallback(
@@ -261,217 +236,6 @@ function App({
 		[stdout],
 	);
 
-	// Focus navigation helpers
-	const findNextFocusable = useCallback(
-		(
-			currentFocusables: Focusable[],
-			currentActiveFocusId: string | undefined,
-		): string | undefined => {
-			const activeIndex = currentFocusables.findIndex(focusable => {
-				return focusable.id === currentActiveFocusId;
-			});
-
-			for (
-				let index = activeIndex + 1;
-				index < currentFocusables.length;
-				index++
-			) {
-				const focusable = currentFocusables[index];
-
-				if (focusable?.isActive) {
-					return focusable.id;
-				}
-			}
-
-			return undefined;
-		},
-		[],
-	);
-
-	const findPreviousFocusable = useCallback(
-		(
-			currentFocusables: Focusable[],
-			currentActiveFocusId: string | undefined,
-		): string | undefined => {
-			const activeIndex = currentFocusables.findIndex(focusable => {
-				return focusable.id === currentActiveFocusId;
-			});
-
-			for (let index = activeIndex - 1; index >= 0; index--) {
-				const focusable = currentFocusables[index];
-
-				if (focusable?.isActive) {
-					return focusable.id;
-				}
-			}
-
-			return undefined;
-		},
-		[],
-	);
-
-	const focusNext = useCallback((): void => {
-		setFocusables(currentFocusables => {
-			setActiveFocusId(currentActiveFocusId => {
-				const firstFocusableId = currentFocusables.find(
-					focusable => focusable.isActive,
-				)?.id;
-				const nextFocusableId = findNextFocusable(
-					currentFocusables,
-					currentActiveFocusId,
-				);
-
-				return nextFocusableId ?? firstFocusableId;
-			});
-			return currentFocusables;
-		});
-	}, [findNextFocusable]);
-
-	const focusPrevious = useCallback((): void => {
-		setFocusables(currentFocusables => {
-			setActiveFocusId(currentActiveFocusId => {
-				const lastFocusableId = currentFocusables.findLast(
-					focusable => focusable.isActive,
-				)?.id;
-				const previousFocusableId = findPreviousFocusable(
-					currentFocusables,
-					currentActiveFocusId,
-				);
-
-				return previousFocusableId ?? lastFocusableId;
-			});
-			return currentFocusables;
-		});
-	}, [findPreviousFocusable]);
-
-	// Handle tab navigation via effect that subscribes to input events
-	useEffect(() => {
-		const handleTabNavigation = (input: string): void => {
-			if (!isFocusEnabled || focusablesCountRef.current === 0) return;
-
-			if (input === tab) {
-				focusNext();
-			}
-
-			if (input === shiftTab) {
-				focusPrevious();
-			}
-		};
-
-		internal_eventEmitter.current.on('input', handleTabNavigation);
-		const emitter = internal_eventEmitter.current;
-
-		return () => {
-			emitter.off('input', handleTabNavigation);
-		};
-	}, [isFocusEnabled, focusNext, focusPrevious]);
-
-	const enableFocus = useCallback((): void => {
-		setIsFocusEnabled(true);
-	}, []);
-
-	const disableFocus = useCallback((): void => {
-		setIsFocusEnabled(false);
-	}, []);
-
-	const focus = useCallback((id: string): void => {
-		setFocusables(currentFocusables => {
-			const hasFocusableId = currentFocusables.some(
-				focusable => focusable?.id === id,
-			);
-
-			if (hasFocusableId) {
-				setActiveFocusId(id);
-			}
-
-			return currentFocusables;
-		});
-	}, []);
-
-	const addFocusable = useCallback(
-		(id: string, {autoFocus}: {autoFocus: boolean}): void => {
-			setFocusables(currentFocusables => {
-				focusablesCountRef.current = currentFocusables.length + 1;
-
-				return [
-					...currentFocusables,
-					{
-						id,
-						isActive: true,
-					},
-				];
-			});
-
-			if (autoFocus) {
-				setActiveFocusId(currentActiveFocusId => {
-					if (!currentActiveFocusId) {
-						return id;
-					}
-
-					return currentActiveFocusId;
-				});
-			}
-		},
-		[],
-	);
-
-	const removeFocusable = useCallback((id: string): void => {
-		setActiveFocusId(currentActiveFocusId => {
-			if (currentActiveFocusId === id) {
-				return undefined;
-			}
-
-			return currentActiveFocusId;
-		});
-
-		setFocusables(currentFocusables => {
-			const filtered = currentFocusables.filter(focusable => {
-				return focusable.id !== id;
-			});
-			focusablesCountRef.current = filtered.length;
-
-			return filtered;
-		});
-	}, []);
-
-	const activateFocusable = useCallback((id: string): void => {
-		setFocusables(currentFocusables =>
-			currentFocusables.map(focusable => {
-				if (focusable.id !== id) {
-					return focusable;
-				}
-
-				return {
-					id,
-					isActive: true,
-				};
-			}),
-		);
-	}, []);
-
-	const deactivateFocusable = useCallback((id: string): void => {
-		setActiveFocusId(currentActiveFocusId => {
-			if (currentActiveFocusId === id) {
-				return undefined;
-			}
-
-			return currentActiveFocusId;
-		});
-
-		setFocusables(currentFocusables =>
-			currentFocusables.map(focusable => {
-				if (focusable.id !== id) {
-					return focusable;
-				}
-
-				return {
-					id,
-					isActive: false,
-				};
-			}),
-		);
-	}, []);
-
 	// Handle cursor visibility, raw mode, and bracketed paste mode cleanup on unmount
 	useEffect(() => {
 		return () => {
@@ -540,45 +304,18 @@ function App({
 		[stderr, writeToStderr],
 	);
 
-	const focusContextValue = useMemo(
-		() => ({
-			activeId: activeFocusId,
-			add: addFocusable,
-			remove: removeFocusable,
-			activate: activateFocusable,
-			deactivate: deactivateFocusable,
-			enableFocus,
-			disableFocus,
-			focusNext,
-			focusPrevious,
-			focus,
-		}),
-		[
-			activeFocusId,
-			addFocusable,
-			removeFocusable,
-			activateFocusable,
-			deactivateFocusable,
-			enableFocus,
-			disableFocus,
-			focusNext,
-			focusPrevious,
-			focus,
-		],
-	);
-
 	return (
 		<AppContext.Provider value={appContextValue}>
 			<StdinContext.Provider value={stdinContextValue}>
 				<StdoutContext.Provider value={stdoutContextValue}>
 					<StderrContext.Provider value={stderrContextValue}>
-						<FocusContext.Provider value={focusContextValue}>
+						<FocusContextProvider eventEmitter={internal_eventEmitter.current}>
 							<AnimationContextProvider renderThrottleMs={renderThrottleMs}>
 								<CursorContextProvider setCursorPosition={setCursorPosition}>
 									<ErrorBoundary onError={handleExit}>{children}</ErrorBoundary>
 								</CursorContextProvider>
 							</AnimationContextProvider>
-						</FocusContext.Provider>
+						</FocusContextProvider>
 					</StderrContext.Provider>
 				</StdoutContext.Provider>
 			</StdinContext.Provider>

--- a/src/components/AppContext.ts
+++ b/src/components/AppContext.ts
@@ -1,3 +1,5 @@
+import {EventEmitter} from 'node:events';
+import process from 'node:process';
 import {createContext} from 'react';
 
 export type Props = {
@@ -35,17 +37,35 @@ export type Props = {
 	readonly waitUntilRenderFlush: () => Promise<void>;
 };
 
+export type InternalProps = Props & {
+	stdin: NodeJS.ReadStream;
+	handleSetRawMode: (value: boolean) => void;
+	handleSetBracketedPasteMode: (value: boolean) => void;
+	isRawModeSupported: boolean;
+	internal_exitOnCtrlC: boolean;
+	internal_eventEmitter: EventEmitter;
+};
+
 /**
-`AppContext` is a React context that exposes lifecycle methods for the app.
+`AppContext` is a React context that exposes lifecycle methods for the app externally,
+and internal helpers for other internal context providers.
 */
 // Keep the default value typed so `useApp()` preserves the public `exit(errorOrResult?)` signature.
-const defaultValue: Props = {
+const defaultValue: InternalProps = {
 	exit(_errorOrResult?: Error | unknown) {},
 	async waitUntilRenderFlush() {},
+	stdin: process.stdin,
+	handleSetRawMode() {},
+	handleSetBracketedPasteMode() {},
+	isRawModeSupported: false,
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	internal_exitOnCtrlC: true,
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	internal_eventEmitter: new EventEmitter(),
 };
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const AppContext = createContext(defaultValue);
+const AppContext = createContext<InternalProps>(defaultValue);
 
 AppContext.displayName = 'InternalAppContext';
 

--- a/src/components/CursorContext.ts
+++ b/src/components/CursorContext.ts
@@ -1,7 +1,7 @@
 import {createContext} from 'react';
 import {type CursorPosition} from '../log-update.js';
 
-export type Props = {
+export type CursorContextValue = {
 	/**
 	Set the cursor position relative to the Ink output.
 
@@ -11,7 +11,7 @@ export type Props = {
 };
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const CursorContext = createContext<Props>({
+const CursorContext = createContext<CursorContextValue>({
 	setCursorPosition() {},
 });
 

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,8 +1,12 @@
 import React, {PureComponent, type ReactNode} from 'react';
+import {useAppInternal} from '../hooks/use-app.js';
 import ErrorOverview from './ErrorOverview.js';
 
 type Props = {
 	readonly children: ReactNode;
+};
+
+type ClassProps = Props & {
 	readonly onError: (error: Error) => void;
 };
 
@@ -12,7 +16,7 @@ type State = {
 
 // Error boundary must be a class component since getDerivedStateFromError
 // and componentDidCatch are not available as hooks
-export default class ErrorBoundary extends PureComponent<Props, State> {
+class ErrorBoundaryClass extends PureComponent<ClassProps, State> {
 	static displayName = 'InternalErrorBoundary';
 
 	static getDerivedStateFromError(error: Error) {
@@ -34,4 +38,9 @@ export default class ErrorBoundary extends PureComponent<Props, State> {
 
 		return this.props.children;
 	}
+}
+
+export default function ErrorBoundary({children}: Props): ReactNode {
+	const {exit} = useAppInternal();
+	return <ErrorBoundaryClass onError={exit}>{children}</ErrorBoundaryClass>;
 }

--- a/src/components/internal/AnimationContextProvider.tsx
+++ b/src/components/internal/AnimationContextProvider.tsx
@@ -1,0 +1,136 @@
+import React, {
+	type ReactNode,
+	useRef,
+	useCallback,
+	useMemo,
+	useEffect,
+} from 'react';
+import AnimationContext from '../AnimationContext.js';
+
+type AnimationSubscriber = {
+	readonly callback: (currentTime: number) => void;
+	readonly interval: number;
+	readonly startTime: number;
+	nextDueTime: number;
+};
+
+type Props = {
+	readonly children: ReactNode;
+	readonly renderThrottleMs: number;
+};
+
+function AnimationContextProvider({
+	children,
+	renderThrottleMs,
+}: Props): React.ReactNode {
+	const animationSubscribersRef = useRef(
+		new Map<(currentTime: number) => void, AnimationSubscriber>(),
+	);
+	const animationTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+		undefined,
+	);
+
+	const clearAnimationTimer = useCallback((): void => {
+		if (!animationTimerRef.current) {
+			return;
+		}
+
+		clearTimeout(animationTimerRef.current);
+		animationTimerRef.current = undefined;
+	}, []);
+
+	const scheduleAnimationTick = useCallback((): void => {
+		clearAnimationTimer();
+
+		if (animationSubscribersRef.current.size === 0) {
+			return;
+		}
+
+		let nextDueTime = Number.POSITIVE_INFINITY;
+
+		for (const subscriber of animationSubscribersRef.current.values()) {
+			// One shared timer is enough as long as it wakes at the earliest
+			// subscriber deadline and lets slower animations skip that tick.
+			nextDueTime = Math.min(nextDueTime, subscriber.nextDueTime);
+		}
+
+		const delay = Math.max(0, nextDueTime - performance.now());
+		animationTimerRef.current = setTimeout(() => {
+			animationTimerRef.current = undefined;
+			const currentTime = performance.now();
+
+			for (const subscriber of animationSubscribersRef.current.values()) {
+				if (currentTime < subscriber.nextDueTime) {
+					continue;
+				}
+
+				subscriber.callback(currentTime);
+				const elapsedTime = currentTime - subscriber.startTime;
+				const elapsedFrames = Math.floor(elapsedTime / subscriber.interval) + 1;
+				// Advance from elapsed time rather than callback count so delayed
+				// ticks catch up instead of stretching the animation timeline.
+				subscriber.nextDueTime =
+					subscriber.startTime + elapsedFrames * subscriber.interval;
+			}
+
+			scheduleAnimationTick();
+		}, delay);
+		// Keep the timer ref'd while animations are active so `useAnimation()`
+		// can drive process lifetime in both interactive and non-interactive apps.
+	}, [clearAnimationTimer]);
+
+	const animationSubscribe = useCallback(
+		(
+			callback: (currentTime: number) => void,
+			interval: number,
+		): {readonly startTime: number; readonly unsubscribe: () => void} => {
+			const startTime = performance.now();
+			// The scheduler owns the start timestamp so hooks can derive frames from
+			// the exact same origin that determines each subscriber's due time.
+			animationSubscribersRef.current.set(callback, {
+				callback,
+				interval,
+				startTime,
+				nextDueTime: startTime + interval,
+			});
+			scheduleAnimationTick();
+
+			return {
+				startTime,
+				unsubscribe() {
+					animationSubscribersRef.current.delete(callback);
+
+					if (animationSubscribersRef.current.size === 0) {
+						clearAnimationTimer();
+						return;
+					}
+
+					scheduleAnimationTick();
+				},
+			};
+		},
+		[clearAnimationTimer, scheduleAnimationTick],
+	);
+
+	useEffect(() => {
+		return () => {
+			clearAnimationTimer();
+		};
+	}, [clearAnimationTimer]);
+
+	const animationContextValue = useMemo(
+		() => ({
+			renderThrottleMs,
+			subscribe: animationSubscribe,
+		}),
+		[animationSubscribe, renderThrottleMs],
+	);
+
+	return (
+		<AnimationContext.Provider value={animationContextValue}>
+			{children}
+		</AnimationContext.Provider>
+	);
+}
+
+export default AnimationContextProvider;

--- a/src/components/internal/AppContextProvider.tsx
+++ b/src/components/internal/AppContextProvider.tsx
@@ -1,5 +1,4 @@
 import {type EventEmitter} from 'node:events';
-import process from 'node:process';
 import React, {
 	type ReactNode,
 	useRef,
@@ -7,9 +6,9 @@ import React, {
 	useMemo,
 	useEffect,
 } from 'react';
-import {createInputParser} from '../../input-parser.js';
 import AppContext from '../AppContext.js';
 import StdoutHelper from './StdoutHelper.js';
+import StdinHelper from './StdinHelper.js';
 
 type Props = {
 	readonly children: ReactNode;
@@ -32,167 +31,23 @@ function AppContextProvider({
 	onExit,
 	onWaitUntilRenderFlush,
 }: Props): React.ReactNode {
-	// Count how many components enabled raw mode to avoid disabling
-	// raw mode until all components don't need it anymore
-	const rawModeEnabledCount = useRef(0);
-
+	const stdinHelper = useRef(
+		new StdinHelper(stdin, eventEmitter, onExit, exitOnCtrlC),
+	);
 	const stdoutHelper = useRef(new StdoutHelper(stdout, interactive));
-
-	// Each useInput hook adds a listener, so the count can legitimately exceed the default limit of 10.
-	eventEmitter.setMaxListeners(Infinity);
-	// Store the currently attached readable listener to avoid stale closure issues
-	const readableListenerRef = useRef<(() => void) | undefined>(undefined);
-	const inputParserRef = useRef(createInputParser());
-	const pendingInputFlushRef = useRef<NodeJS.Timeout | undefined>(undefined);
-	// Small delay to let chunked escape sequences complete before flushing as literal input.
-	const pendingInputFlushDelayMilliseconds = 20;
-
-	const clearPendingInputFlush = useCallback((): void => {
-		if (!pendingInputFlushRef.current) {
-			return;
-		}
-
-		clearTimeout(pendingInputFlushRef.current);
-		pendingInputFlushRef.current = undefined;
-	}, []);
-
-	// Determines if TTY is supported on the provided stdin
-	const isRawModeSupported = stdin.isTTY;
-
-	const detachReadableListener = useCallback((): void => {
-		if (!readableListenerRef.current) {
-			return;
-		}
-
-		stdin.removeListener('readable', readableListenerRef.current);
-		readableListenerRef.current = undefined;
-	}, [stdin]);
-
-	const disableRawMode = useCallback((): void => {
-		stdin.setRawMode(false);
-		detachReadableListener();
-		stdin.unref();
-		rawModeEnabledCount.current = 0;
-		inputParserRef.current.reset();
-		clearPendingInputFlush();
-	}, [stdin, detachReadableListener, clearPendingInputFlush]);
 
 	const handleExit = useCallback(
 		(errorOrResult?: unknown): void => {
-			if (isRawModeSupported && rawModeEnabledCount.current > 0) {
-				disableRawMode();
-			}
-
-			onExit(errorOrResult);
+			stdinHelper.current.handleExit(errorOrResult);
 		},
-		[isRawModeSupported, disableRawMode, onExit],
+		[stdinHelper],
 	);
-
-	const handleInput = useCallback(
-		(input: string): void => {
-			// Exit on Ctrl+C
-			// eslint-disable-next-line unicorn/no-hex-escape
-			if (input === '\x03' && exitOnCtrlC) {
-				handleExit();
-			}
-		},
-		[exitOnCtrlC, handleExit],
-	);
-
-	const emitInput = useCallback(
-		(input: string): void => {
-			handleInput(input);
-			eventEmitter.emit('input', input);
-		},
-		[handleInput, eventEmitter],
-	);
-
-	const schedulePendingInputFlush = useCallback((): void => {
-		clearPendingInputFlush();
-		pendingInputFlushRef.current = setTimeout(() => {
-			pendingInputFlushRef.current = undefined;
-			const pendingEscape = inputParserRef.current.flushPendingEscape();
-			if (!pendingEscape) {
-				return;
-			}
-
-			emitInput(pendingEscape);
-		}, pendingInputFlushDelayMilliseconds);
-	}, [clearPendingInputFlush, emitInput]);
-
-	const handleReadable = useCallback((): void => {
-		clearPendingInputFlush();
-		let chunk;
-		// eslint-disable-next-line @typescript-eslint/no-restricted-types
-		while ((chunk = stdin.read() as string | null) !== null) {
-			const inputEvents = inputParserRef.current.push(chunk);
-			for (const event of inputEvents) {
-				if (typeof event === 'string') {
-					emitInput(event);
-				} else {
-					// Keep paste on a separate channel from `useInput` so key handlers
-					// don't need to branch on mixed key-vs-paste event shapes.
-					if (eventEmitter.listenerCount('paste') === 0) {
-						emitInput(event.paste);
-						continue;
-					}
-
-					eventEmitter.emit('paste', event.paste);
-				}
-			}
-		}
-
-		if (inputParserRef.current.hasPendingEscape()) {
-			schedulePendingInputFlush();
-		}
-	}, [
-		stdin,
-		emitInput,
-		clearPendingInputFlush,
-		schedulePendingInputFlush,
-		eventEmitter,
-	]);
 
 	const handleSetRawMode = useCallback(
 		(isEnabled: boolean): void => {
-			if (!isRawModeSupported) {
-				if (stdin === process.stdin) {
-					throw new Error(
-						'Raw mode is not supported on the current process.stdin, which Ink uses as input stream by default.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported',
-					);
-				} else {
-					throw new Error(
-						'Raw mode is not supported on the stdin provided to Ink.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported',
-					);
-				}
-			}
-
-			stdin.setEncoding('utf8');
-
-			if (isEnabled) {
-				// Ensure raw mode is enabled only once
-				if (rawModeEnabledCount.current === 0) {
-					stdin.ref();
-					stdin.setRawMode(true);
-					// Store the listener reference to avoid stale closure when removing
-					readableListenerRef.current = handleReadable;
-					stdin.addListener('readable', handleReadable);
-				}
-
-				rawModeEnabledCount.current++;
-				return;
-			}
-
-			// Disable raw mode only when no components left that are using it
-			if (rawModeEnabledCount.current === 0) {
-				return;
-			}
-
-			if (--rawModeEnabledCount.current === 0) {
-				disableRawMode();
-			}
+			stdinHelper.current.handleSetRawMode(isEnabled);
 		},
-		[isRawModeSupported, stdin, handleReadable, disableRawMode],
+		[stdinHelper],
 	);
 
 	const handleSetBracketedPasteMode = useCallback(
@@ -204,15 +59,13 @@ function AppContextProvider({
 
 	// Handle cursor visibility, raw mode, and bracketed paste mode cleanup on unmount
 	useEffect(() => {
+		const currentStdinHelper = stdinHelper.current;
 		const currentStdoutHelper = stdoutHelper.current;
 		return () => {
-			if (isRawModeSupported && rawModeEnabledCount.current > 0) {
-				disableRawMode();
-			}
-
+			currentStdinHelper.handleUnmount();
 			currentStdoutHelper.handleUnmount();
 		};
-	}, [isRawModeSupported, disableRawMode, stdoutHelper]);
+	}, [stdinHelper, stdoutHelper]);
 
 	// Memoize context values to prevent unnecessary re-renders
 	const appContextValue = useMemo(
@@ -222,7 +75,7 @@ function AppContextProvider({
 			stdin,
 			handleSetRawMode,
 			handleSetBracketedPasteMode,
-			isRawModeSupported,
+			isRawModeSupported: stdinHelper.current.isRawModeSupported,
 			// eslint-disable-next-line @typescript-eslint/naming-convention
 			internal_exitOnCtrlC: exitOnCtrlC,
 			// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -234,7 +87,6 @@ function AppContextProvider({
 			exitOnCtrlC,
 			handleSetRawMode,
 			handleSetBracketedPasteMode,
-			isRawModeSupported,
 			stdin,
 			eventEmitter,
 		],

--- a/src/components/internal/AppContextProvider.tsx
+++ b/src/components/internal/AppContextProvider.tsx
@@ -1,0 +1,281 @@
+import {type EventEmitter} from 'node:events';
+import process from 'node:process';
+import React, {
+	type ReactNode,
+	useRef,
+	useCallback,
+	useMemo,
+	useEffect,
+} from 'react';
+import cliCursor from 'cli-cursor';
+import {createInputParser} from '../../input-parser.js';
+import AppContext from '../AppContext.js';
+
+type Props = {
+	readonly children: ReactNode;
+	readonly stdin: NodeJS.ReadStream;
+	readonly stdout: NodeJS.WriteStream;
+	readonly exitOnCtrlC: boolean;
+	readonly interactive: boolean;
+	readonly eventEmitter: EventEmitter;
+	readonly onExit: (errorOrResult?: unknown) => void;
+	readonly onWaitUntilRenderFlush: () => Promise<void>;
+};
+
+function AppContextProvider({
+	children,
+	stdin,
+	stdout,
+	exitOnCtrlC,
+	interactive,
+	eventEmitter,
+	onExit,
+	onWaitUntilRenderFlush,
+}: Props): React.ReactNode {
+	// Count how many components enabled raw mode to avoid disabling
+	// raw mode until all components don't need it anymore
+	const rawModeEnabledCount = useRef(0);
+	// Count how many components enabled bracketed paste mode
+	const bracketedPasteModeEnabledCount = useRef(0);
+	// Each useInput hook adds a listener, so the count can legitimately exceed the default limit of 10.
+	eventEmitter.setMaxListeners(Infinity);
+	// Store the currently attached readable listener to avoid stale closure issues
+	const readableListenerRef = useRef<(() => void) | undefined>(undefined);
+	const inputParserRef = useRef(createInputParser());
+	const pendingInputFlushRef = useRef<NodeJS.Timeout | undefined>(undefined);
+	// Small delay to let chunked escape sequences complete before flushing as literal input.
+	const pendingInputFlushDelayMilliseconds = 20;
+
+	const clearPendingInputFlush = useCallback((): void => {
+		if (!pendingInputFlushRef.current) {
+			return;
+		}
+
+		clearTimeout(pendingInputFlushRef.current);
+		pendingInputFlushRef.current = undefined;
+	}, []);
+
+	// Determines if TTY is supported on the provided stdin
+	const isRawModeSupported = stdin.isTTY;
+
+	const detachReadableListener = useCallback((): void => {
+		if (!readableListenerRef.current) {
+			return;
+		}
+
+		stdin.removeListener('readable', readableListenerRef.current);
+		readableListenerRef.current = undefined;
+	}, [stdin]);
+
+	const disableRawMode = useCallback((): void => {
+		stdin.setRawMode(false);
+		detachReadableListener();
+		stdin.unref();
+		rawModeEnabledCount.current = 0;
+		inputParserRef.current.reset();
+		clearPendingInputFlush();
+	}, [stdin, detachReadableListener, clearPendingInputFlush]);
+
+	const handleExit = useCallback(
+		(errorOrResult?: unknown): void => {
+			if (isRawModeSupported && rawModeEnabledCount.current > 0) {
+				disableRawMode();
+			}
+
+			onExit(errorOrResult);
+		},
+		[isRawModeSupported, disableRawMode, onExit],
+	);
+
+	const handleInput = useCallback(
+		(input: string): void => {
+			// Exit on Ctrl+C
+			// eslint-disable-next-line unicorn/no-hex-escape
+			if (input === '\x03' && exitOnCtrlC) {
+				handleExit();
+			}
+		},
+		[exitOnCtrlC, handleExit],
+	);
+
+	const emitInput = useCallback(
+		(input: string): void => {
+			handleInput(input);
+			eventEmitter.emit('input', input);
+		},
+		[handleInput, eventEmitter],
+	);
+
+	const schedulePendingInputFlush = useCallback((): void => {
+		clearPendingInputFlush();
+		pendingInputFlushRef.current = setTimeout(() => {
+			pendingInputFlushRef.current = undefined;
+			const pendingEscape = inputParserRef.current.flushPendingEscape();
+			if (!pendingEscape) {
+				return;
+			}
+
+			emitInput(pendingEscape);
+		}, pendingInputFlushDelayMilliseconds);
+	}, [clearPendingInputFlush, emitInput]);
+
+	const handleReadable = useCallback((): void => {
+		clearPendingInputFlush();
+		let chunk;
+		// eslint-disable-next-line @typescript-eslint/no-restricted-types
+		while ((chunk = stdin.read() as string | null) !== null) {
+			const inputEvents = inputParserRef.current.push(chunk);
+			for (const event of inputEvents) {
+				if (typeof event === 'string') {
+					emitInput(event);
+				} else {
+					// Keep paste on a separate channel from `useInput` so key handlers
+					// don't need to branch on mixed key-vs-paste event shapes.
+					if (eventEmitter.listenerCount('paste') === 0) {
+						emitInput(event.paste);
+						continue;
+					}
+
+					eventEmitter.emit('paste', event.paste);
+				}
+			}
+		}
+
+		if (inputParserRef.current.hasPendingEscape()) {
+			schedulePendingInputFlush();
+		}
+	}, [
+		stdin,
+		emitInput,
+		clearPendingInputFlush,
+		schedulePendingInputFlush,
+		eventEmitter,
+	]);
+
+	const handleSetRawMode = useCallback(
+		(isEnabled: boolean): void => {
+			if (!isRawModeSupported) {
+				if (stdin === process.stdin) {
+					throw new Error(
+						'Raw mode is not supported on the current process.stdin, which Ink uses as input stream by default.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported',
+					);
+				} else {
+					throw new Error(
+						'Raw mode is not supported on the stdin provided to Ink.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported',
+					);
+				}
+			}
+
+			stdin.setEncoding('utf8');
+
+			if (isEnabled) {
+				// Ensure raw mode is enabled only once
+				if (rawModeEnabledCount.current === 0) {
+					stdin.ref();
+					stdin.setRawMode(true);
+					// Store the listener reference to avoid stale closure when removing
+					readableListenerRef.current = handleReadable;
+					stdin.addListener('readable', handleReadable);
+				}
+
+				rawModeEnabledCount.current++;
+				return;
+			}
+
+			// Disable raw mode only when no components left that are using it
+			if (rawModeEnabledCount.current === 0) {
+				return;
+			}
+
+			if (--rawModeEnabledCount.current === 0) {
+				disableRawMode();
+			}
+		},
+		[isRawModeSupported, stdin, handleReadable, disableRawMode],
+	);
+
+	const handleSetBracketedPasteMode = useCallback(
+		(isEnabled: boolean): void => {
+			if (!stdout.isTTY) {
+				return;
+			}
+
+			if (isEnabled) {
+				if (bracketedPasteModeEnabledCount.current === 0) {
+					stdout.write('\u001B[?2004h');
+				}
+
+				bracketedPasteModeEnabledCount.current++;
+				return;
+			}
+
+			if (bracketedPasteModeEnabledCount.current === 0) {
+				return;
+			}
+
+			if (--bracketedPasteModeEnabledCount.current === 0) {
+				stdout.write('\u001B[?2004l');
+			}
+		},
+		[stdout],
+	);
+
+	// Handle cursor visibility, raw mode, and bracketed paste mode cleanup on unmount
+	useEffect(() => {
+		return () => {
+			const canWriteToStdout = !stdout.destroyed && !stdout.writableEnded;
+
+			if (interactive && canWriteToStdout) {
+				cliCursor.show(stdout);
+			}
+
+			if (isRawModeSupported && rawModeEnabledCount.current > 0) {
+				disableRawMode();
+			}
+
+			if (bracketedPasteModeEnabledCount.current > 0) {
+				if (stdout.isTTY && canWriteToStdout) {
+					stdout.write('\u001B[?2004l');
+				}
+
+				bracketedPasteModeEnabledCount.current = 0;
+			}
+		};
+	}, [stdout, isRawModeSupported, disableRawMode, interactive]);
+
+	// Memoize context values to prevent unnecessary re-renders
+	const appContextValue = useMemo(
+		() => ({
+			exit: handleExit,
+			waitUntilRenderFlush: onWaitUntilRenderFlush,
+			stdin,
+			handleSetRawMode,
+			handleSetBracketedPasteMode,
+			isRawModeSupported,
+			// eslint-disable-next-line @typescript-eslint/naming-convention
+			internal_exitOnCtrlC: exitOnCtrlC,
+			// eslint-disable-next-line @typescript-eslint/naming-convention
+			internal_eventEmitter: eventEmitter,
+		}),
+		[
+			handleExit,
+			onWaitUntilRenderFlush,
+			exitOnCtrlC,
+			handleSetBracketedPasteMode,
+			handleSetRawMode,
+			isRawModeSupported,
+			stdin,
+			eventEmitter,
+		],
+	);
+
+	return (
+		<AppContext.Provider value={appContextValue}>
+			{children}
+		</AppContext.Provider>
+	);
+}
+
+AppContextProvider.displayName = 'InternalAppContextProvider';
+
+export default AppContextProvider;

--- a/src/components/internal/AppContextProvider.tsx
+++ b/src/components/internal/AppContextProvider.tsx
@@ -7,9 +7,9 @@ import React, {
 	useMemo,
 	useEffect,
 } from 'react';
-import cliCursor from 'cli-cursor';
 import {createInputParser} from '../../input-parser.js';
 import AppContext from '../AppContext.js';
+import StdoutHelper from './StdoutHelper.js';
 
 type Props = {
 	readonly children: ReactNode;
@@ -35,8 +35,9 @@ function AppContextProvider({
 	// Count how many components enabled raw mode to avoid disabling
 	// raw mode until all components don't need it anymore
 	const rawModeEnabledCount = useRef(0);
-	// Count how many components enabled bracketed paste mode
-	const bracketedPasteModeEnabledCount = useRef(0);
+
+	const stdoutHelper = useRef(new StdoutHelper(stdout, interactive));
+
 	// Each useInput hook adds a listener, so the count can legitimately exceed the default limit of 10.
 	eventEmitter.setMaxListeners(Infinity);
 	// Store the currently attached readable listener to avoid stale closure issues
@@ -195,53 +196,23 @@ function AppContextProvider({
 	);
 
 	const handleSetBracketedPasteMode = useCallback(
-		(isEnabled: boolean): void => {
-			if (!stdout.isTTY) {
-				return;
-			}
-
-			if (isEnabled) {
-				if (bracketedPasteModeEnabledCount.current === 0) {
-					stdout.write('\u001B[?2004h');
-				}
-
-				bracketedPasteModeEnabledCount.current++;
-				return;
-			}
-
-			if (bracketedPasteModeEnabledCount.current === 0) {
-				return;
-			}
-
-			if (--bracketedPasteModeEnabledCount.current === 0) {
-				stdout.write('\u001B[?2004l');
-			}
+		(isEnabled: boolean) => {
+			stdoutHelper.current.handleSetBracketedPasteMode(isEnabled);
 		},
-		[stdout],
+		[stdoutHelper],
 	);
 
 	// Handle cursor visibility, raw mode, and bracketed paste mode cleanup on unmount
 	useEffect(() => {
+		const currentStdoutHelper = stdoutHelper.current;
 		return () => {
-			const canWriteToStdout = !stdout.destroyed && !stdout.writableEnded;
-
-			if (interactive && canWriteToStdout) {
-				cliCursor.show(stdout);
-			}
-
 			if (isRawModeSupported && rawModeEnabledCount.current > 0) {
 				disableRawMode();
 			}
 
-			if (bracketedPasteModeEnabledCount.current > 0) {
-				if (stdout.isTTY && canWriteToStdout) {
-					stdout.write('\u001B[?2004l');
-				}
-
-				bracketedPasteModeEnabledCount.current = 0;
-			}
+			currentStdoutHelper.handleUnmount();
 		};
-	}, [stdout, isRawModeSupported, disableRawMode, interactive]);
+	}, [isRawModeSupported, disableRawMode, stdoutHelper]);
 
 	// Memoize context values to prevent unnecessary re-renders
 	const appContextValue = useMemo(
@@ -261,8 +232,8 @@ function AppContextProvider({
 			handleExit,
 			onWaitUntilRenderFlush,
 			exitOnCtrlC,
-			handleSetBracketedPasteMode,
 			handleSetRawMode,
+			handleSetBracketedPasteMode,
 			isRawModeSupported,
 			stdin,
 			eventEmitter,

--- a/src/components/internal/CursorContextProvider.tsx
+++ b/src/components/internal/CursorContextProvider.tsx
@@ -1,0 +1,27 @@
+import React, {type ReactNode, useMemo} from 'react';
+import CursorContext, {type CursorContextValue} from '../CursorContext.js';
+
+type Props = {
+	readonly children: ReactNode;
+	readonly setCursorPosition: CursorContextValue['setCursorPosition'];
+};
+
+function CursorContextProvider({
+	children,
+	setCursorPosition,
+}: Props): React.ReactNode {
+	const cursorContextValue = useMemo(
+		() => ({
+			setCursorPosition,
+		}),
+		[setCursorPosition],
+	);
+
+	return (
+		<CursorContext.Provider value={cursorContextValue}>
+			{children}
+		</CursorContext.Provider>
+	);
+}
+
+export default CursorContextProvider;

--- a/src/components/internal/FocusContextProvider.tsx
+++ b/src/components/internal/FocusContextProvider.tsx
@@ -1,0 +1,289 @@
+import {type EventEmitter} from 'node:events';
+import React, {
+	type ReactNode,
+	useState,
+	useRef,
+	useCallback,
+	useMemo,
+	useEffect,
+} from 'react';
+import FocusContext from '../FocusContext.js';
+
+const tab = '\t';
+const shiftTab = '\u001B[Z';
+const escape = '\u001B';
+
+type Props = {
+	readonly children: ReactNode;
+	readonly eventEmitter: EventEmitter;
+};
+
+type Focusable = {
+	readonly id: string;
+	readonly isActive: boolean;
+};
+
+function FocusContextProvider({
+	children,
+	eventEmitter,
+}: Props): React.ReactNode {
+	const [isFocusEnabled, setIsFocusEnabled] = useState(true);
+	const [activeFocusId, setActiveFocusId] = useState<string | undefined>(
+		undefined,
+	);
+	// Focusables array is managed internally via setFocusables callback pattern
+	// eslint-disable-next-line react/hook-use-state
+	const [, setFocusables] = useState<Focusable[]>([]);
+	// Track focusables count for tab navigation check (avoids stale closure)
+	const focusablesCountRef = useRef(0);
+
+	// Focus navigation helpers
+	const findNextFocusable = useCallback(
+		(
+			currentFocusables: Focusable[],
+			currentActiveFocusId: string | undefined,
+		): string | undefined => {
+			const activeIndex = currentFocusables.findIndex(focusable => {
+				return focusable.id === currentActiveFocusId;
+			});
+
+			for (
+				let index = activeIndex + 1;
+				index < currentFocusables.length;
+				index++
+			) {
+				const focusable = currentFocusables[index];
+
+				if (focusable?.isActive) {
+					return focusable.id;
+				}
+			}
+
+			return undefined;
+		},
+		[],
+	);
+
+	const findPreviousFocusable = useCallback(
+		(
+			currentFocusables: Focusable[],
+			currentActiveFocusId: string | undefined,
+		): string | undefined => {
+			const activeIndex = currentFocusables.findIndex(focusable => {
+				return focusable.id === currentActiveFocusId;
+			});
+
+			for (let index = activeIndex - 1; index >= 0; index--) {
+				const focusable = currentFocusables[index];
+
+				if (focusable?.isActive) {
+					return focusable.id;
+				}
+			}
+
+			return undefined;
+		},
+		[],
+	);
+
+	const focusNext = useCallback((): void => {
+		setFocusables(currentFocusables => {
+			setActiveFocusId(currentActiveFocusId => {
+				const firstFocusableId = currentFocusables.find(
+					focusable => focusable.isActive,
+				)?.id;
+				const nextFocusableId = findNextFocusable(
+					currentFocusables,
+					currentActiveFocusId,
+				);
+
+				return nextFocusableId ?? firstFocusableId;
+			});
+			return currentFocusables;
+		});
+	}, [findNextFocusable]);
+
+	const focusPrevious = useCallback((): void => {
+		setFocusables(currentFocusables => {
+			setActiveFocusId(currentActiveFocusId => {
+				const lastFocusableId = currentFocusables.findLast(
+					focusable => focusable.isActive,
+				)?.id;
+				const previousFocusableId = findPreviousFocusable(
+					currentFocusables,
+					currentActiveFocusId,
+				);
+
+				return previousFocusableId ?? lastFocusableId;
+			});
+			return currentFocusables;
+		});
+	}, [findPreviousFocusable]);
+
+	// Handle tab navigation via effect that subscribes to input events
+	useEffect(() => {
+		const handleTabNavigation = (input: string): void => {
+			if (!isFocusEnabled || focusablesCountRef.current === 0) return;
+
+			if (input === tab) {
+				focusNext();
+			}
+
+			if (input === shiftTab) {
+				focusPrevious();
+			}
+
+			// Reset focus when there's an active focused component on Esc
+			if (input === escape && isFocusEnabled) {
+				setActiveFocusId(undefined);
+			}
+		};
+
+		eventEmitter.on('input', handleTabNavigation);
+
+		return () => {
+			eventEmitter.off('input', handleTabNavigation);
+		};
+	}, [eventEmitter, isFocusEnabled, focusNext, focusPrevious]);
+
+	const enableFocus = useCallback((): void => {
+		setIsFocusEnabled(true);
+	}, []);
+
+	const disableFocus = useCallback((): void => {
+		setIsFocusEnabled(false);
+	}, []);
+
+	const focus = useCallback((id: string): void => {
+		setFocusables(currentFocusables => {
+			const hasFocusableId = currentFocusables.some(
+				focusable => focusable?.id === id,
+			);
+
+			if (hasFocusableId) {
+				setActiveFocusId(id);
+			}
+
+			return currentFocusables;
+		});
+	}, []);
+
+	const addFocusable = useCallback(
+		(id: string, {autoFocus}: {autoFocus: boolean}): void => {
+			setFocusables(currentFocusables => {
+				focusablesCountRef.current = currentFocusables.length + 1;
+
+				return [
+					...currentFocusables,
+					{
+						id,
+						isActive: true,
+					},
+				];
+			});
+
+			if (autoFocus) {
+				setActiveFocusId(currentActiveFocusId => {
+					if (!currentActiveFocusId) {
+						return id;
+					}
+
+					return currentActiveFocusId;
+				});
+			}
+		},
+		[],
+	);
+
+	const removeFocusable = useCallback((id: string): void => {
+		setActiveFocusId(currentActiveFocusId => {
+			if (currentActiveFocusId === id) {
+				return undefined;
+			}
+
+			return currentActiveFocusId;
+		});
+
+		setFocusables(currentFocusables => {
+			const filtered = currentFocusables.filter(focusable => {
+				return focusable.id !== id;
+			});
+			focusablesCountRef.current = filtered.length;
+
+			return filtered;
+		});
+	}, []);
+
+	const activateFocusable = useCallback((id: string): void => {
+		setFocusables(currentFocusables =>
+			currentFocusables.map(focusable => {
+				if (focusable.id !== id) {
+					return focusable;
+				}
+
+				return {
+					id,
+					isActive: true,
+				};
+			}),
+		);
+	}, []);
+
+	const deactivateFocusable = useCallback((id: string): void => {
+		setActiveFocusId(currentActiveFocusId => {
+			if (currentActiveFocusId === id) {
+				return undefined;
+			}
+
+			return currentActiveFocusId;
+		});
+
+		setFocusables(currentFocusables =>
+			currentFocusables.map(focusable => {
+				if (focusable.id !== id) {
+					return focusable;
+				}
+
+				return {
+					id,
+					isActive: false,
+				};
+			}),
+		);
+	}, []);
+
+	const focusContextValue = useMemo(
+		() => ({
+			activeId: activeFocusId,
+			add: addFocusable,
+			remove: removeFocusable,
+			activate: activateFocusable,
+			deactivate: deactivateFocusable,
+			enableFocus,
+			disableFocus,
+			focusNext,
+			focusPrevious,
+			focus,
+		}),
+		[
+			activeFocusId,
+			addFocusable,
+			removeFocusable,
+			activateFocusable,
+			deactivateFocusable,
+			enableFocus,
+			disableFocus,
+			focusNext,
+			focusPrevious,
+			focus,
+		],
+	);
+
+	return (
+		<FocusContext.Provider value={focusContextValue}>
+			{children}
+		</FocusContext.Provider>
+	);
+}
+
+export default FocusContextProvider;

--- a/src/components/internal/StderrContextProvider.tsx
+++ b/src/components/internal/StderrContextProvider.tsx
@@ -1,0 +1,32 @@
+import React, {type ReactNode, useMemo} from 'react';
+import StderrContext, {
+	type Props as StderrContextProps,
+} from '../StderrContext.js';
+
+type Props = {
+	readonly children: ReactNode;
+	readonly stderr: StderrContextProps['stderr'];
+	readonly writeToStderr: StderrContextProps['write'];
+};
+
+function StderrContextProvider({
+	children,
+	stderr,
+	writeToStderr,
+}: Props): React.ReactNode {
+	const stderrContextValue = useMemo(
+		() => ({
+			stderr,
+			write: writeToStderr,
+		}),
+		[stderr, writeToStderr],
+	);
+
+	return (
+		<StderrContext.Provider value={stderrContextValue}>
+			{children}
+		</StderrContext.Provider>
+	);
+}
+
+export default StderrContextProvider;

--- a/src/components/internal/StdinContextProvider.tsx
+++ b/src/components/internal/StdinContextProvider.tsx
@@ -1,0 +1,49 @@
+import React, {type ReactNode, useMemo} from 'react';
+import {useAppInternal} from '../../hooks/use-app.js';
+import StdinContext from '../StdinContext.js';
+
+type Props = {
+	readonly children: ReactNode;
+};
+
+function StdinContextProvider({children}: Props): React.ReactNode {
+	const {
+		stdin,
+		handleSetRawMode,
+		handleSetBracketedPasteMode,
+		isRawModeSupported,
+		// eslint-disable-next-line @typescript-eslint/naming-convention
+		internal_exitOnCtrlC,
+		// eslint-disable-next-line @typescript-eslint/naming-convention
+		internal_eventEmitter,
+	} = useAppInternal();
+
+	const stdinContextValue = useMemo(
+		() => ({
+			stdin,
+			setRawMode: handleSetRawMode,
+			setBracketedPasteMode: handleSetBracketedPasteMode,
+			isRawModeSupported,
+			// eslint-disable-next-line @typescript-eslint/naming-convention
+			internal_exitOnCtrlC,
+			// eslint-disable-next-line @typescript-eslint/naming-convention
+			internal_eventEmitter,
+		}),
+		[
+			stdin,
+			handleSetRawMode,
+			handleSetBracketedPasteMode,
+			internal_eventEmitter,
+			internal_exitOnCtrlC,
+			isRawModeSupported,
+		],
+	);
+
+	return (
+		<StdinContext.Provider value={stdinContextValue}>
+			{children}
+		</StdinContext.Provider>
+	);
+}
+
+export default StdinContextProvider;

--- a/src/components/internal/StdinHelper.tsx
+++ b/src/components/internal/StdinHelper.tsx
@@ -1,0 +1,180 @@
+import {type EventEmitter} from 'node:events';
+import process from 'node:process';
+import {type InputParser, createInputParser} from '../../input-parser.js';
+
+export default class StdinHelper {
+	readonly isRawModeSupported: boolean;
+	// eslint-disable-next-line @typescript-eslint/parameter-properties
+	private readonly stdin: NodeJS.ReadStream;
+	// eslint-disable-next-line @typescript-eslint/parameter-properties
+	private readonly eventEmitter: EventEmitter;
+	private rawModeEnabledCount: number;
+	private readableListener: (() => void) | undefined;
+	private readonly inputParser: InputParser;
+	private pendingInputFlush: NodeJS.Timeout | undefined;
+	private readonly pendingInputFlushDelayMilliseconds: number;
+	private readonly onExit: (errorOrResult?: unknown) => void;
+	private readonly exitOnCtrlC: boolean;
+
+	constructor(
+		stdin: NodeJS.ReadStream,
+		eventEmitter: EventEmitter,
+		onExit: (errorOrResult?: unknown) => void,
+		exitOnCtrlC: boolean,
+	) {
+		this.stdin = stdin;
+		this.eventEmitter = eventEmitter;
+		// Each useInput hook adds a listener, so the count can legitimately exceed the default limit of 10.
+		this.eventEmitter.setMaxListeners(Infinity);
+		// Count how many components enabled raw mode to avoid disabling
+		// raw mode until all components don't need it anymore
+		this.rawModeEnabledCount = 0;
+
+		// Store the currently attached readable listener to avoid stale closure issues
+		this.readableListener = undefined;
+		this.inputParser = createInputParser();
+		this.pendingInputFlush = undefined;
+		// Small delay to let chunked escape sequences complete before flushing as literal input.
+		this.pendingInputFlushDelayMilliseconds = 20;
+		// Determines if TTY is supported on the provided stdin
+		this.isRawModeSupported = stdin.isTTY;
+		this.onExit = onExit;
+		this.exitOnCtrlC = exitOnCtrlC;
+	}
+
+	clearPendingInputFlush(): void {
+		if (!this.pendingInputFlush) {
+			return;
+		}
+
+		clearTimeout(this.pendingInputFlush);
+		this.pendingInputFlush = undefined;
+	}
+
+	detachReadableListener(): void {
+		if (!this.readableListener) {
+			return;
+		}
+
+		this.stdin.removeListener('readable', this.readableListener);
+		this.readableListener = undefined;
+	}
+
+	disableRawMode(): void {
+		this.stdin.setRawMode(false);
+		this.detachReadableListener();
+		this.stdin.unref();
+		this.rawModeEnabledCount = 0;
+		this.inputParser.reset();
+		this.clearPendingInputFlush();
+	}
+
+	handleExit(errorOrResult?: unknown): void {
+		if (this.isRawModeSupported && this.rawModeEnabledCount > 0) {
+			this.disableRawMode();
+		}
+
+		this.onExit(errorOrResult);
+	}
+
+	handleInput(input: string): void {
+		// Exit on Ctrl+C
+		// eslint-disable-next-line unicorn/no-hex-escape
+		if (input === '\x03' && this.exitOnCtrlC) {
+			this.handleExit();
+		}
+	}
+
+	emitInput(input: string): void {
+		this.handleInput(input);
+		this.eventEmitter.emit('input', input);
+	}
+
+	schedulePendingInputFlush(): void {
+		this.clearPendingInputFlush();
+		this.pendingInputFlush = setTimeout(() => {
+			this.pendingInputFlush = undefined;
+			const pendingEscape = this.inputParser.flushPendingEscape();
+			if (!pendingEscape) {
+				return;
+			}
+
+			this.emitInput(pendingEscape);
+		}, this.pendingInputFlushDelayMilliseconds);
+	}
+
+	// Note: Must be an ES6 arrow function, so that when invoked, `this` references
+	// this instance, not the eventEmitter.
+	// See https://nodejs.org/api/events.html#passing-arguments-and-this-to-listeners
+	handleReadable = (): void => {
+		this.clearPendingInputFlush();
+		let chunk;
+		// eslint-disable-next-line @typescript-eslint/no-restricted-types
+		while ((chunk = this.stdin.read() as string | null) !== null) {
+			const inputEvents = this.inputParser.push(chunk);
+			for (const event of inputEvents) {
+				if (typeof event === 'string') {
+					this.emitInput(event);
+				} else {
+					// Keep paste on a separate channel from `useInput` so key handlers
+					// don't need to branch on mixed key-vs-paste event shapes.
+					if (this.eventEmitter.listenerCount('paste') === 0) {
+						this.emitInput(event.paste);
+						continue;
+					}
+
+					this.eventEmitter.emit('paste', event.paste);
+				}
+			}
+		}
+
+		if (this.inputParser.hasPendingEscape()) {
+			this.schedulePendingInputFlush();
+		}
+	};
+
+	handleSetRawMode(isEnabled: boolean): void {
+		if (!this.isRawModeSupported) {
+			if (this.stdin === process.stdin) {
+				throw new Error(
+					'Raw mode is not supported on the current process.stdin, which Ink uses as input stream by default.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported',
+				);
+			} else {
+				throw new Error(
+					'Raw mode is not supported on the stdin provided to Ink.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported',
+				);
+			}
+		}
+
+		this.stdin.setEncoding('utf8');
+
+		if (isEnabled) {
+			// Ensure raw mode is enabled only once
+			if (this.rawModeEnabledCount === 0) {
+				this.stdin.ref();
+				this.stdin.setRawMode(true);
+				// Store the listener reference to avoid stale closure when removing
+				this.readableListener = this.handleReadable;
+				this.stdin.addListener('readable', this.handleReadable);
+			}
+
+			this.rawModeEnabledCount++;
+			return;
+		}
+
+		// Disable raw mode only when no components left that are using it
+		if (this.rawModeEnabledCount === 0) {
+			return;
+		}
+
+		if (--this.rawModeEnabledCount === 0) {
+			this.disableRawMode();
+		}
+	}
+
+	handleUnmount() {
+		if (this.isRawModeSupported && this.rawModeEnabledCount > 0) {
+			this.disableRawMode();
+		}
+	}
+}

--- a/src/components/internal/StdoutContextProvider.tsx
+++ b/src/components/internal/StdoutContextProvider.tsx
@@ -1,0 +1,32 @@
+import React, {type ReactNode, useMemo} from 'react';
+import StdoutContext, {
+	type Props as StdoutContextProps,
+} from '../StdoutContext.js';
+
+type Props = {
+	readonly children: ReactNode;
+	readonly stdout: StdoutContextProps['stdout'];
+	readonly writeToStdout: StdoutContextProps['write'];
+};
+
+function StdoutContextProvider({
+	children,
+	stdout,
+	writeToStdout,
+}: Props): React.ReactNode {
+	const stdoutContextValue = useMemo(
+		() => ({
+			stdout,
+			write: writeToStdout,
+		}),
+		[stdout, writeToStdout],
+	);
+
+	return (
+		<StdoutContext.Provider value={stdoutContextValue}>
+			{children}
+		</StdoutContext.Provider>
+	);
+}
+
+export default StdoutContextProvider;

--- a/src/components/internal/StdoutHelper.tsx
+++ b/src/components/internal/StdoutHelper.tsx
@@ -1,0 +1,71 @@
+import cliCursor from 'cli-cursor';
+
+export default class StdoutHelper {
+	// eslint-disable-next-line @typescript-eslint/parameter-properties
+	private readonly stdout: NodeJS.WriteStream;
+	// eslint-disable-next-line @typescript-eslint/parameter-properties
+	private readonly interactive: boolean;
+	// Count how many components enabled bracketed paste mode
+	private bracketedPasteModeEnabledCount: number;
+
+	constructor(stdout: NodeJS.WriteStream, interactive: boolean) {
+		this.stdout = stdout;
+		this.interactive = interactive;
+		this.bracketedPasteModeEnabledCount = 0;
+	}
+
+	showCursorIfInteractive(): void {
+		const canWriteToStdout =
+			!this.stdout.destroyed && !this.stdout.writableEnded;
+		if (this.interactive && canWriteToStdout) {
+			cliCursor.show(this.stdout);
+		}
+	}
+
+	disableBracketedPasteMode() {
+		const canWriteToStdout =
+			!this.stdout.destroyed && !this.stdout.writableEnded;
+
+		if (this.bracketedPasteModeEnabledCount > 0) {
+			if (this.stdout.isTTY && canWriteToStdout) {
+				this.stdout.write('\u001B[?2004l');
+			}
+
+			this.bracketedPasteModeEnabledCount = 0;
+		}
+	}
+
+	handleSetBracketedPasteMode(isEnabled: boolean) {
+		if (!this.stdout.isTTY) {
+			return;
+		}
+
+		if (isEnabled) {
+			if (this.bracketedPasteModeEnabledCount === 0) {
+				this.stdout.write('\u001B[?2004h');
+			}
+
+			this.bracketedPasteModeEnabledCount++;
+			return;
+		}
+
+		if (this.bracketedPasteModeEnabledCount === 0) {
+			return;
+		}
+
+		if (--this.bracketedPasteModeEnabledCount === 0) {
+			this.stdout.write('\u001B[?2004l');
+		}
+	}
+
+	handleUnmount() {
+		const canWriteToStdout =
+			!this.stdout.destroyed && !this.stdout.writableEnded;
+
+		if (this.interactive && canWriteToStdout) {
+			cliCursor.show(this.stdout);
+		}
+
+		this.disableBracketedPasteMode();
+	}
+}

--- a/src/hooks/use-app.ts
+++ b/src/hooks/use-app.ts
@@ -1,8 +1,17 @@
 import {useContext} from 'react';
-import AppContext from '../components/AppContext.js';
+import AppContext, {
+	type Props,
+	type InternalProps,
+} from '../components/AppContext.js';
 
 /**
 A React hook that returns app lifecycle methods like `exit()` and `waitUntilRenderFlush()`.
 */
-const useApp = () => useContext(AppContext);
+const useApp = (): Props => useContext(AppContext);
+
+/**
+A React hook that returns internal app concerns.
+*/
+export const useAppInternal = (): InternalProps => useContext(AppContext);
+
 export default useApp;

--- a/src/hooks/use-input.ts
+++ b/src/hooks/use-input.ts
@@ -265,7 +265,7 @@ const useInput = (inputHandler: Handler, options: Options = {}) => {
 		return () => {
 			internal_eventEmitter.removeListener('input', handleData);
 		};
-	}, [options.isActive, internal_eventEmitter]);
+	}, [options.isActive, internal_eventEmitter, handleData]);
 };
 
 export default useInput;

--- a/src/hooks/use-paste.ts
+++ b/src/hooks/use-paste.ts
@@ -77,7 +77,7 @@ const usePaste = (
 		return () => {
 			internal_eventEmitter.removeListener('paste', handlePaste);
 		};
-	}, [options.isActive, internal_eventEmitter]);
+	}, [options.isActive, internal_eventEmitter, handlePaste]);
 };
 
 export default usePaste;

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -1100,21 +1100,23 @@ test.serial(
 	'primary screen - cleanup console output follows the native console during unmount',
 	async t => {
 		const stdout = createStdout(100, true);
-		const processStdoutWriteStub = stub(process.stdout, 'write').callsFake(((
-			_chunk: string | Uint8Array,
-			encoding?: BufferEncoding | ((error?: Error) => void),
-			callback?: (error?: Error) => void,
-		) => {
-			if (typeof encoding === 'function') {
-				encoding();
-			}
+		const processStdoutWriteStub = stub(process.stdout, 'write').callsFake(
+			(
+				_chunk: string | Uint8Array,
+				encoding?: BufferEncoding | ((error?: Error) => void),
+				callback?: (error?: Error) => void,
+			) => {
+				if (typeof encoding === 'function') {
+					encoding();
+				}
 
-			if (typeof callback === 'function') {
-				callback();
-			}
+				if (typeof callback === 'function') {
+					callback();
+				}
 
-			return true;
-		}) as typeof process.stdout.write);
+				return true;
+			},
+		);
 		t.teardown(() => {
 			processStdoutWriteStub.restore();
 		});
@@ -1239,21 +1241,23 @@ test.serial(
 	'alternate screen - cleanup console output follows the native console during unmount',
 	async t => {
 		const stdout = createStdout(100, true);
-		const processStdoutWriteStub = stub(process.stdout, 'write').callsFake(((
-			_chunk: string | Uint8Array,
-			encoding?: BufferEncoding | ((error?: Error) => void),
-			callback?: (error?: Error) => void,
-		) => {
-			if (typeof encoding === 'function') {
-				encoding();
-			}
+		const processStdoutWriteStub = stub(process.stdout, 'write').callsFake(
+			(
+				_chunk: string | Uint8Array,
+				encoding?: BufferEncoding | ((error?: Error) => void),
+				callback?: (error?: Error) => void,
+			) => {
+				if (typeof encoding === 'function') {
+					encoding();
+				}
 
-			if (typeof callback === 'function') {
-				callback();
-			}
+				if (typeof callback === 'function') {
+					callback();
+				}
 
-			return true;
-		}) as typeof process.stdout.write);
+				return true;
+			},
+		);
 		t.teardown(() => {
 			processStdoutWriteStub.restore();
 		});
@@ -1346,21 +1350,23 @@ test.serial(
 
 test('render warns when stdout is reused before unmount', async t => {
 	const stdout = createStdout(100, true);
-	const processStderrWriteStub = stub(process.stderr, 'write').callsFake(((
-		_chunk: string | Uint8Array,
-		encoding?: BufferEncoding | ((error?: Error) => void),
-		callback?: (error?: Error) => void,
-	) => {
-		if (typeof encoding === 'function') {
-			encoding();
-		}
+	const processStderrWriteStub = stub(process.stderr, 'write').callsFake(
+		(
+			_chunk: string | Uint8Array,
+			encoding?: BufferEncoding | ((error?: Error) => void),
+			callback?: (error?: Error) => void,
+		) => {
+			if (typeof encoding === 'function') {
+				encoding();
+			}
 
-		if (typeof callback === 'function') {
-			callback();
-		}
+			if (typeof callback === 'function') {
+				callback();
+			}
 
-		return true;
-	}) as typeof process.stderr.write);
+			return true;
+		},
+	);
 	t.teardown(() => {
 		processStderrWriteStub.restore();
 	});

--- a/test/kitty-keyboard.tsx
+++ b/test/kitty-keyboard.tsx
@@ -698,14 +698,14 @@ test.serial(
 
 		// Override stdout.write to synchronously emit the response on stdin
 		// when the query sequence is written, simulating a fast terminal
-		stdout.write = ((data: string) => {
+		stdout.write = (data: string) => {
 			writtenStrings.push(data);
 			if (data === '\u001B[?u') {
 				stdin.emit('data', '\u001B[?1u');
 			}
 
 			return true;
-		}) as typeof stdout.write;
+		};
 
 		const origKittyId = process.env['KITTY_WINDOW_ID'];
 		process.env['KITTY_WINDOW_ID'] = '1';


### PR DESCRIPTION
This PR splits the top-level `App` component into a set of smaller, more specialised ContextProviders. This is a pure refactor with no changes to public hook signatures, and all tests passing without changes.

The main motivation here was readability. Whilst creating another Ink-based application, I needed to create a different way of handling `focus`. It was difficult to discover whether I could re-use and/or customise the included `use-focus` and `use-focus-manager` because so many different concerns were included in the `App` component. In the new structure, it's now evident that the `eventEmitter` is the only cross-cutting dependency in the `FocusContext`.

The new ContextProviders are: `AppContextProvider`, `AnimationContextProvider`, `CursorContextProvider`, `FocusContextProvider`, `StdinContextProvider` ,`StdoutContextProvider`, `StderrContextProvider`.

Additionally, some of the raw `stdin` and `stdout` functionality is factored out into two helper classes:`StdinHelper` and `StdoutHelper`. These help to separate out the pure console/tty concerns from the React framework concerns.
