### PR TITLE
Fix linting errors, warnings

### DIFF
--- a/src/hooks/use-input.ts
+++ b/src/hooks/use-input.ts
@@ -265,7 +265,7 @@ const useInput = (inputHandler: Handler, options: Options = {}) => {
 		return () => {
 			internal_eventEmitter.removeListener('input', handleData);
 		};
-	}, [options.isActive, internal_eventEmitter]);
+	}, [options.isActive, internal_eventEmitter, handleData]);
 };
 
 export default useInput;

--- a/src/hooks/use-paste.ts
+++ b/src/hooks/use-paste.ts
@@ -77,7 +77,7 @@ const usePaste = (
 		return () => {
 			internal_eventEmitter.removeListener('paste', handlePaste);
 		};
-	}, [options.isActive, internal_eventEmitter]);
+	}, [options.isActive, internal_eventEmitter, handlePaste]);
 };
 
 export default usePaste;

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -1100,21 +1100,23 @@ test.serial(
 	'primary screen - cleanup console output follows the native console during unmount',
 	async t => {
 		const stdout = createStdout(100, true);
-		const processStdoutWriteStub = stub(process.stdout, 'write').callsFake(((
-			_chunk: string | Uint8Array,
-			encoding?: BufferEncoding | ((error?: Error) => void),
-			callback?: (error?: Error) => void,
-		) => {
-			if (typeof encoding === 'function') {
-				encoding();
-			}
+		const processStdoutWriteStub = stub(process.stdout, 'write').callsFake(
+			(
+				_chunk: string | Uint8Array,
+				encoding?: BufferEncoding | ((error?: Error) => void),
+				callback?: (error?: Error) => void,
+			) => {
+				if (typeof encoding === 'function') {
+					encoding();
+				}
 
-			if (typeof callback === 'function') {
-				callback();
-			}
+				if (typeof callback === 'function') {
+					callback();
+				}
 
-			return true;
-		}) as typeof process.stdout.write);
+				return true;
+			},
+		);
 		t.teardown(() => {
 			processStdoutWriteStub.restore();
 		});
@@ -1239,21 +1241,23 @@ test.serial(
 	'alternate screen - cleanup console output follows the native console during unmount',
 	async t => {
 		const stdout = createStdout(100, true);
-		const processStdoutWriteStub = stub(process.stdout, 'write').callsFake(((
-			_chunk: string | Uint8Array,
-			encoding?: BufferEncoding | ((error?: Error) => void),
-			callback?: (error?: Error) => void,
-		) => {
-			if (typeof encoding === 'function') {
-				encoding();
-			}
+		const processStdoutWriteStub = stub(process.stdout, 'write').callsFake(
+			(
+				_chunk: string | Uint8Array,
+				encoding?: BufferEncoding | ((error?: Error) => void),
+				callback?: (error?: Error) => void,
+			) => {
+				if (typeof encoding === 'function') {
+					encoding();
+				}
 
-			if (typeof callback === 'function') {
-				callback();
-			}
+				if (typeof callback === 'function') {
+					callback();
+				}
 
-			return true;
-		}) as typeof process.stdout.write);
+				return true;
+			},
+		);
 		t.teardown(() => {
 			processStdoutWriteStub.restore();
 		});
@@ -1346,21 +1350,23 @@ test.serial(
 
 test('render warns when stdout is reused before unmount', async t => {
 	const stdout = createStdout(100, true);
-	const processStderrWriteStub = stub(process.stderr, 'write').callsFake(((
-		_chunk: string | Uint8Array,
-		encoding?: BufferEncoding | ((error?: Error) => void),
-		callback?: (error?: Error) => void,
-	) => {
-		if (typeof encoding === 'function') {
-			encoding();
-		}
+	const processStderrWriteStub = stub(process.stderr, 'write').callsFake(
+		(
+			_chunk: string | Uint8Array,
+			encoding?: BufferEncoding | ((error?: Error) => void),
+			callback?: (error?: Error) => void,
+		) => {
+			if (typeof encoding === 'function') {
+				encoding();
+			}
 
-		if (typeof callback === 'function') {
-			callback();
-		}
+			if (typeof callback === 'function') {
+				callback();
+			}
 
-		return true;
-	}) as typeof process.stderr.write);
+			return true;
+		},
+	);
 	t.teardown(() => {
 		processStderrWriteStub.restore();
 	});

--- a/test/kitty-keyboard.tsx
+++ b/test/kitty-keyboard.tsx
@@ -698,14 +698,14 @@ test.serial(
 
 		// Override stdout.write to synchronously emit the response on stdin
 		// when the query sequence is written, simulating a fast terminal
-		stdout.write = ((data: string) => {
+		stdout.write = (data: string) => {
 			writtenStrings.push(data);
 			if (data === '\u001B[?u') {
 				stdin.emit('data', '\u001B[?1u');
 			}
 
 			return true;
-		}) as typeof stdout.write;
+		};
 
 		const origKittyId = process.env['KITTY_WINDOW_ID'];
 		process.env['KITTY_WINDOW_ID'] = '1';


### PR DESCRIPTION
This PR fixes the master branch CI build which is currently failing with linting errors in two test files:
* test/components.tsx
* test/kitty-keyboard.tsx

The transgression was `@typescript-eslint/no-unnecessary-type-assertion` with message "This assertion is unnecessary since the receiver accepts the original type of the expression." 

Fixes are also included for `react-hooks/exhaustive-deps` prettier warnings introduced  in commit cfaebbb.

