### PR TITLE
docs: add Deepcode CLI to who uses ink list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,7 +131,7 @@ render(<Counter />);
 - [instagram-cli](https://github.com/supreme-gg-gg/instagram-cli) - Instagram client.
 - [ElevenLabs CLI](https://github.com/elevenlabs/cli) - ElevenLabs agents client.
 - [SSH AI Chat](https://github.com/miantiao-me/ssh-ai-chat) - Chat with AI over SSH.
-- [Deepcode CLI](https://github.com/lessweb/deepcode-cli) - AI coding assistant optimized for the DeepSeek model.
+- [Deep Code CLI](https://github.com/lessweb/deepcode-cli) - AI coding assistant optimized for the DeepSeek model.
 
 _(PRs welcome. Append new entries at the end. Repos must have 100+ stars and showcase Ink beyond a basic list picker.)_
 

--- a/readme.md
+++ b/readme.md
@@ -131,7 +131,7 @@ render(<Counter />);
 - [instagram-cli](https://github.com/supreme-gg-gg/instagram-cli) - Instagram client.
 - [ElevenLabs CLI](https://github.com/elevenlabs/cli) - ElevenLabs agents client.
 - [SSH AI Chat](https://github.com/miantiao-me/ssh-ai-chat) - Chat with AI over SSH.
-- [Deepcode CLI](https://github.com/lessweb/deepcode-cli) - Deep Code is a terminal AI coding assistant optimized for the `deepseek-v4` model, with support for deep thinking, reasoning effort control, and Agent Skills.
+- [Deepcode CLI](https://github.com/lessweb/deepcode-cli) - AI coding assistant optimized for the DeepSeek model.
 
 _(PRs welcome. Append new entries at the end. Repos must have 100+ stars and showcase Ink beyond a basic list picker.)_
 

--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,7 @@ render(<Counter />);
 - [instagram-cli](https://github.com/supreme-gg-gg/instagram-cli) - Instagram client.
 - [ElevenLabs CLI](https://github.com/elevenlabs/cli) - ElevenLabs agents client.
 - [SSH AI Chat](https://github.com/miantiao-me/ssh-ai-chat) - Chat with AI over SSH.
+- [Deepcode CLI](https://github.com/lessweb/deepcode-cli) - Deep Code is a terminal AI coding assistant optimized for the `deepseek-v4` model, with support for deep thinking, reasoning effort control, and Agent Skills.
 
 _(PRs welcome. Append new entries at the end. Repos must have 100+ stars and showcase Ink beyond a basic list picker.)_
 


### PR DESCRIPTION
# Deep Code CLI

[Deep Code](https://github.com/lessweb/deepcode-cli) is a terminal AI coding assistant optimized for the `deepseek-v4` model, with support for deep thinking, reasoning effort control, and Agent Skills.