### PR TITLE
Fix `useBoxMetrics` not accepting ref objects with an initial null value

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2080,7 +2080,7 @@ Use `hasMeasured` to detect when the currently tracked element has been measured
 
 #### ref
 
-Type: `React.RefObject<DOMElement>`
+Type: `React.RefObject<DOMElement | null>`
 
 A ref to the `<Box>` element to track.
 

--- a/src/hooks/use-box-metrics.ts
+++ b/src/hooks/use-box-metrics.ts
@@ -44,7 +44,8 @@ const emptyMetrics: BoxMetrics = {
 	top: 0,
 };
 
-const findRootNode = (node?: DOMElement): DOMElement | undefined => {
+// eslint-disable-next-line @typescript-eslint/no-restricted-types
+const findRootNode = (node: DOMElement | null): DOMElement | undefined => {
 	if (!node) {
 		return undefined;
 	}
@@ -82,7 +83,12 @@ const Example = () => {
 };
 ```
 */
-const useBoxMetrics = (ref: RefObject<DOMElement>): UseBoxMetricsResult => {
+const useBoxMetrics = (
+	/* eslint-disable-next-line @typescript-eslint/no-restricted-types --
+		Creating a ref object with an initial null, especially when the ref object
+		will be passed to a DOM node's ref attribute, is common in React. */
+	ref: RefObject<DOMElement | null>,
+): UseBoxMetricsResult => {
 	const [metrics, setMetrics] = useState(emptyMetrics);
 	const [hasMeasured, setHasMeasured] = useState(false);
 	const {stdout} = useStdout();


### PR DESCRIPTION
This pull request hopes to change the current behaviours below to the expected behaviours.

Current Behaviours
--

With `complierOptions.strictNullChecks: true` set in `tsconfig.json`, compilation with the below code in the project always fails due to `useBoxMetrics` only accepting `RefObject<DOMElement>` and not also `RefObject<DOMElement | null>`.

```ts
const ref = useRef<DOMElement>(null);
const {...} = useBoxMetrics(ref);
```

Further, VSCode highlights a type error regardless of the compiler options sets:
    <img width="788" height="254" alt="Image" src="https://github.com/user-attachments/assets/1aa6ff93-3826-4e53-9c88-6db048460056" />

Expected Behaviours
--

1. When `complierOptions.strictNullChecks: true` is set in `tsconfig.json`, the code above shouldn't cause compilation to fail.
2. `useBoxMetrics` should be able to accept `RefObject<DOMElement | null>` since it's common for a ref object (especially one that will be passed to a DOM node's ref attribute) to be created with an initial `null` value.
3.  VSCode shouldn't report a type error.