### PR TITLE
Fix: <Static> remount via key change drops new items

### DIFF
--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -295,7 +295,18 @@ export default createReconciler<
 		removeChildNode(node, removeNode);
 		cleanupYogaNode(removeNode.yogaNode);
 
-		if (removeNode.internal_static && currentRootNode) {
+		// Only clear staticNode if the node being removed is the one the root
+		// currently points at. React processes insertions before deletions in
+		// a single commit, so when <Static> is remounted via a `key` change the
+		// new staticNode is registered by createInstance BEFORE this removal
+		// fires for the old node. Clearing unconditionally would clobber the
+		// fresh pointer and the renderer would emit no static output for the
+		// new Static instance.
+		if (
+			removeNode.internal_static &&
+			currentRootNode &&
+			currentRootNode.staticNode === removeNode
+		) {
 			currentRootNode.staticNode = undefined;
 		}
 	},
@@ -351,7 +362,13 @@ export default createReconciler<
 		removeChildNode(node, removeNode);
 		cleanupYogaNode(removeNode.yogaNode);
 
-		if (removeNode.internal_static && currentRootNode) {
+		// See removeChildFromContainer above for the rationale on the
+		// `currentRootNode.staticNode === removeNode` guard.
+		if (
+			removeNode.internal_static &&
+			currentRootNode &&
+			currentRootNode.staticNode === removeNode
+		) {
 			currentRootNode.staticNode = undefined;
 		}
 	},

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -304,8 +304,7 @@ export default createReconciler<
 		// new Static instance.
 		if (
 			removeNode.internal_static &&
-			currentRootNode &&
-			currentRootNode.staticNode === removeNode
+			currentRootNode?.staticNode === removeNode
 		) {
 			currentRootNode.staticNode = undefined;
 		}
@@ -366,8 +365,7 @@ export default createReconciler<
 		// `currentRootNode.staticNode === removeNode` guard.
 		if (
 			removeNode.internal_static &&
-			currentRootNode &&
-			currentRootNode.staticNode === removeNode
+			currentRootNode?.staticNode === removeNode
 		) {
 			currentRootNode.staticNode = undefined;
 		}

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -555,6 +555,62 @@ test('static output stops accumulating after Static unmounts (#904)', t => {
 	t.true(outputAfterChurn.includes('Dynamic'));
 });
 
+test('remounting <Static> via key change emits the new items', t => {
+	// Regression test for the post-#904 follow-up.
+	//
+	// React processes insertions before deletions within a commit. When a
+	// `<Static>` is remounted via a `key` prop change in the same commit:
+	//
+	//   1. createInstance fires for the new internal_static node, which sets
+	//      `rootNode.staticNode = newNode` and marks `isStaticDirty = true`.
+	//   2. appendChildToContainer attaches the new node.
+	//   3. removeChildFromContainer fires for the OLD internal_static node.
+	//
+	// Before this fix, step 3 unconditionally set
+	// `currentRootNode.staticNode = undefined`, clobbering the just-registered
+	// new staticNode pointer. The renderer then saw `staticNode === undefined`,
+	// emitted no static output, and the new Static's items were silently
+	// dropped from stdout. Real-world impact: TUIs that drive a Static
+	// "history replay" via key bumping (gemini-cli / qwen-code's
+	// `historyRemountKey` pattern) saw the history go blank after /clear,
+	// model switches, or any other `refreshStatic()`-equivalent trigger.
+	const stdout = createStdout();
+
+	function App({session}: {readonly session: number}) {
+		const items = session === 1 ? ['old-A', 'old-B'] : ['new-C', 'new-D'];
+		return (
+			<Box>
+				<Static key={session} items={items}>
+					{item => <Text key={item}>{item}</Text>}
+				</Static>
+				<Text>dynamic</Text>
+			</Box>
+		);
+	}
+
+	const {rerender} = render(<App session={1} />, {stdout, debug: true});
+
+	const afterFirstMount = (stdout.write as any).lastCall.args[0] as string;
+	t.true(
+		afterFirstMount.includes('old-A') && afterFirstMount.includes('old-B'),
+		'first mount must emit its Static items',
+	);
+
+	// Key change → React unmounts the old Static and mounts a new one in the
+	// same commit phase. Insertion runs before deletion.
+	rerender(<App session={2} />);
+
+	const afterRemount = (stdout.write as any).lastCall.args[0] as string;
+	t.true(
+		afterRemount.includes('new-C'),
+		'remounted Static must emit its first new item ("new-C") to stdout',
+	);
+	t.true(
+		afterRemount.includes('new-D'),
+		'remounted Static must emit its second new item ("new-D") to stdout',
+	);
+});
+
 test('render only new items in static output on final render', t => {
 	const stdout = createStdout();
 

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -555,25 +555,31 @@ test('static output stops accumulating after Static unmounts (#904)', t => {
 	t.true(outputAfterChurn.includes('Dynamic'));
 });
 
-test('remounting <Static> via key change emits the new items', t => {
-	// Regression test for the post-#904 follow-up.
+test('remounting <Static> via key change emits the new items (nested under <Box>)', t => {
+	// Regression test for the post-#904 follow-up — `removeChild` path.
 	//
-	// React processes insertions before deletions within a commit. When a
-	// `<Static>` is remounted via a `key` prop change in the same commit:
+	// `createInstance` registers the new internal_static node on the root
+	// during the render phase, BEFORE any commit-phase mutations. When
+	// `<Static>` is then remounted via a `key` change, the OLD node is
+	// removed in the commit phase via:
 	//
-	//   1. createInstance fires for the new internal_static node, which sets
-	//      `rootNode.staticNode = newNode` and marks `isStaticDirty = true`.
-	//   2. appendChildToContainer attaches the new node.
-	//   3. removeChildFromContainer fires for the OLD internal_static node.
+	//   - `removeChildFromContainer` if Static is a direct child of the
+	//     container (`ink-root`), OR
+	//   - `removeChild` if Static is nested under any host element (e.g.
+	//     wrapped in a `<Box>`).
 	//
-	// Before this fix, step 3 unconditionally set
-	// `currentRootNode.staticNode = undefined`, clobbering the just-registered
-	// new staticNode pointer. The renderer then saw `staticNode === undefined`,
-	// emitted no static output, and the new Static's items were silently
-	// dropped from stdout. Real-world impact: TUIs that drive a Static
-	// "history replay" via key bumping (gemini-cli / qwen-code's
-	// `historyRemountKey` pattern) saw the history go blank after /clear,
-	// model switches, or any other `refreshStatic()`-equivalent trigger.
+	// Before the fix, BOTH paths unconditionally set
+	// `currentRootNode.staticNode = undefined` whenever the removed node
+	// carried `internal_static`, clobbering the pointer the just-mounted
+	// new node had registered. The renderer then saw `staticNode === undefined`
+	// and emitted nothing for the new Static. Real-world impact: TUIs that
+	// drive a Static "history replay" via key bumping (gemini-cli /
+	// qwen-code's `historyRemountKey` pattern) saw the history go blank
+	// after /clear, model switches, or any other `refreshStatic()`-equivalent
+	// trigger.
+	//
+	// This case wraps Static in a <Box>, so removal goes through
+	// `removeChild(parentBox, oldStaticNode)`.
 	const stdout = createStdout();
 
 	function App({session}: {readonly session: number}) {
@@ -597,7 +603,8 @@ test('remounting <Static> via key change emits the new items', t => {
 	);
 
 	// Key change → React unmounts the old Static and mounts a new one in the
-	// same commit phase. Insertion runs before deletion.
+	// same commit phase. createInstance for the new node ran in render phase,
+	// so by the time removeChild fires the root pointer already points at it.
 	rerender(<App session={2} />);
 
 	const afterRemount = (stdout.write as any).lastCall.args[0] as string;
@@ -608,6 +615,46 @@ test('remounting <Static> via key change emits the new items', t => {
 	t.true(
 		afterRemount.includes('new-D'),
 		'remounted Static must emit its second new item ("new-D") to stdout',
+	);
+});
+
+test('remounting <Static> via key change emits the new items (root-level — removeChildFromContainer)', t => {
+	// Companion to the nested case above. When `<Static>` is the direct
+	// host child of the root container (no wrapping <Box>), removal goes
+	// through `removeChildFromContainer(rootNode, oldStaticNode)` instead
+	// of `removeChild`. The fix has to hold on both paths — this exercises
+	// the container path specifically.
+	const stdout = createStdout();
+
+	function App({session}: {readonly session: number}) {
+		const items = session === 1 ? ['old-A', 'old-B'] : ['new-C', 'new-D'];
+		// No wrapping <Box>: Static is a direct child of `ink-root`, so the
+		// reconciler dispatches to `removeChildFromContainer` on remount.
+		return (
+			<Static key={session} items={items}>
+				{item => <Text key={item}>{item}</Text>}
+			</Static>
+		);
+	}
+
+	const {rerender} = render(<App session={1} />, {stdout, debug: true});
+
+	const afterFirstMount = (stdout.write as any).lastCall.args[0] as string;
+	t.true(
+		afterFirstMount.includes('old-A') && afterFirstMount.includes('old-B'),
+		'first mount must emit its Static items',
+	);
+
+	rerender(<App session={2} />);
+
+	const afterRemount = (stdout.write as any).lastCall.args[0] as string;
+	t.true(
+		afterRemount.includes('new-C'),
+		'remounted Static must emit "new-C" via removeChildFromContainer path',
+	);
+	t.true(
+		afterRemount.includes('new-D'),
+		'remounted Static must emit "new-D" via removeChildFromContainer path',
 	);
 });
 


### PR DESCRIPTION
Fixes #947.

## Summary

\`reconciler.removeChildFromContainer\` / \`removeChild\` unconditionally cleared \`rootNode.staticNode\` whenever the removed node was marked \`internal_static\`. React processes insertions before deletions inside a single commit, so when a \`<Static>\` is remounted via a \`key\` prop change:

1. \`createInstance\` fires for the **new** internal_static node and registers \`rootNode.staticNode = newNode\` (also marking \`isStaticDirty = true\`).
2. \`appendChildToContainer\` attaches the new node.
3. \`removeChildFromContainer\` fires for the **old** internal_static node, sees \`removeNode.internal_static === true\`, and zeroes out \`currentRootNode.staticNode\` — clobbering the pointer the new node just registered.

After that, \`renderer.ts\` sees \`node.staticNode === undefined\`, emits no static output, and the new \`<Static>\`'s items are silently dropped from stdout.

## Fix

Clear \`staticNode\` only when the node being removed is the one the root currently points to. Identical guard added to both \`removeChildFromContainer\` (root-level remount) and \`removeChild\` (nested remount).

\`\`\`diff
- if (removeNode.internal_static && currentRootNode) {
+ if (
+   removeNode.internal_static &&
+   currentRootNode &&
+   currentRootNode.staticNode === removeNode
+ ) {
    currentRootNode.staticNode = undefined;
  }
\`\`\`

The existing #904 / #905 path (pure unmount → \`staticNode\` should be cleared) is unaffected: in that case \`currentRootNode.staticNode\` still equals \`removeNode\` at removal time, so the guard passes through.

## Test

Adds \`remounting <Static> via key change emits the new items\` to \`test/components.tsx\`. Asserts that after a key-driven remount of \`<Static>\` with a disjoint items array, the new items reach stdout.

Verified:
- New test **fails** on \`master\` (\`1510851\`) — confirms the regression
- New test **passes** with this patch
- Existing Static tests all pass — including the #904 \`stops accumulating after Static unmounts\` regression (the pure-unmount path is preserved)
- Full \`ava\` suite shows no new failures vs. \`master\` baseline (two pre-existing flaky failures on \`cursor\` and \`wrap-ansi doesn't trim leading whitespace\` are unrelated and reproduce on \`master\` without this patch)

## Real-world impact

Both Gemini CLI and qwen-code use a \`<Static key={historyRemountKey}>\` pattern to force a full replay of the chat history after \`/clear\`, model switch, Ctrl+O, etc. After upgrading to ink 7, the entire history pane stops rendering immediately after the first such trigger. End-to-end repro on qwen-code: https://github.com/QwenLM/qwen-code/pull/4083 (currently has to revert ink 7 → 6 as a stop-gap).