### PR TITLE
Fix: drop stale <Static> output from fullStaticOutput on identity change

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -66,9 +66,17 @@ export type DOMElement = {
 	// Internal properties
 	isStaticDirty?: boolean;
 	staticNode?: DOMElement;
+	// Identity of `staticNode` at the end of the previous commit. Used by the
+	// reconciler to detect when the live <Static> instance has been replaced
+	// (key-driven remount), removed (no longer in the React tree) or added
+	// (first <Static> mount). On any identity change, ink resets its
+	// accumulated `fullStaticOutput` so future clearTerminal rewrites don't
+	// replay items that are no longer owned by the current React tree.
+	previousStaticNode?: DOMElement;
 	onComputeLayout?: () => void;
 	onRender?: () => void;
 	onImmediateRender?: () => void;
+	onStaticChange?: () => void;
 	internal_layoutListeners?: Set<LayoutListener>;
 } & InkNode;
 

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -360,6 +360,7 @@ export default class Ink {
 		}
 
 		this.rootNode.onImmediateRender = this.onRender;
+		this.rootNode.onStaticChange = this.handleStaticChange;
 		this.log = logUpdate.create(options.stdout, {
 			incremental: options.incrementalRendering,
 		});
@@ -515,6 +516,17 @@ export default class Ink {
 			undefined,
 			Yoga.DIRECTION_LTR,
 		);
+	};
+
+	// Called from the reconciler when the live <Static> identity changes
+	// (first mount, last unmount, or key-driven remount). The previously
+	// accumulated `fullStaticOutput` belongs to a Static instance that is no
+	// longer in the React tree, so future `shouldClearTerminalForFrame`
+	// rewrites must not replay it. The new instance (if any) will re-emit
+	// its items into a fresh `fullStaticOutput` on the immediate render that
+	// follows this callback.
+	handleStaticChange = (): void => {
+		this.fullStaticOutput = '';
 	};
 
 	onRender: () => void = () => {

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -164,6 +164,22 @@ export default createReconciler<
 
 		emitLayoutListeners(rootNode);
 
+		// Detect <Static> identity change for this commit: first mount,
+		// last unmount, or key-driven remount. Fire `onStaticChange` BEFORE
+		// `onImmediateRender` so ink can drop any accumulated static output
+		// from the previous Static instance before the new instance emits.
+		// Without this, items belonging to the unmounted/replaced Static
+		// stay in `fullStaticOutput` forever and get replayed on the next
+		// `shouldClearTerminalForFrame` rewrite (overflow / leaving
+		// fullscreen / unmount), surfacing as "cleared history reappears"
+		// for apps that drive Static via key bumps.
+		if (rootNode.staticNode !== rootNode.previousStaticNode) {
+			rootNode.previousStaticNode = rootNode.staticNode;
+			if (typeof rootNode.onStaticChange === 'function') {
+				rootNode.onStaticChange();
+			}
+		}
+
 		// Since renders are throttled at the instance level and <Static> component children
 		// are rendered only once and then get deleted, we need an escape hatch to
 		// trigger an immediate render to ensure <Static> children are written to output before they get erased

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -555,6 +555,60 @@ test('static output stops accumulating after Static unmounts (#904)', t => {
 	t.true(outputAfterChurn.includes('Dynamic'));
 });
 
+test('fullStaticOutput is reset when <Static> unmounts so stale items are not replayed', t => {
+	// In debug mode each stdout.write is `fullStaticOutput + dynamicOutput`.
+	// Before the fix, the items emitted by a Static that has since been
+	// unmounted stayed in `fullStaticOutput` forever and reappeared on every
+	// subsequent write (and on any `shouldClearTerminalForFrame` rewrite at
+	// runtime). After the fix, dropping the <Static> resets the
+	// accumulator so its items leave both the React tree and the output
+	// stream.
+	const stdout = createStdout();
+
+	function App({show, dynamicLabel}: {
+		readonly show: boolean;
+		readonly dynamicLabel: string;
+	}) {
+		return (
+			<Box>
+				{show ? (
+					<Static items={['HISTORY-A', 'HISTORY-B']}>
+						{item => <Text key={item}>{item}</Text>}
+					</Static>
+				) : null}
+				<Text>{dynamicLabel}</Text>
+			</Box>
+		);
+	}
+
+	const {rerender} = render(<App show dynamicLabel="d1" />, {
+		stdout,
+		debug: true,
+	});
+
+	const afterMount = (stdout.write as any).lastCall.args[0] as string;
+	t.true(
+		afterMount.includes('HISTORY-A') && afterMount.includes('HISTORY-B'),
+		'Static items must be emitted on first mount',
+	);
+
+	rerender(<App show={false} dynamicLabel="d2" />);
+
+	const afterUnmount = (stdout.write as any).lastCall.args[0] as string;
+	t.false(
+		afterUnmount.includes('HISTORY-A'),
+		'fullStaticOutput must NOT replay HISTORY-A after Static unmount',
+	);
+	t.false(
+		afterUnmount.includes('HISTORY-B'),
+		'fullStaticOutput must NOT replay HISTORY-B after Static unmount',
+	);
+	t.true(
+		afterUnmount.includes('d2'),
+		'new dynamic output must still render',
+	);
+});
+
 test('render only new items in static output on final render', t => {
 	const stdout = createStdout();
 

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -565,7 +565,10 @@ test('fullStaticOutput is reset when <Static> unmounts so stale items are not re
 	// stream.
 	const stdout = createStdout();
 
-	function App({show, dynamicLabel}: {
+	function App({
+		show,
+		dynamicLabel,
+	}: {
 		readonly show: boolean;
 		readonly dynamicLabel: string;
 	}) {
@@ -603,10 +606,7 @@ test('fullStaticOutput is reset when <Static> unmounts so stale items are not re
 		afterUnmount.includes('HISTORY-B'),
 		'fullStaticOutput must NOT replay HISTORY-B after Static unmount',
 	);
-	t.true(
-		afterUnmount.includes('d2'),
-		'new dynamic output must still render',
-	);
+	t.true(afterUnmount.includes('d2'), 'new dynamic output must still render');
 });
 
 test('render only new items in static output on final render', t => {


### PR DESCRIPTION
Fixes #949.

## Summary

\`Ink#fullStaticOutput\` is the running concatenation of everything every \`<Static>\` instance has ever emitted during the lifetime of an Ink renderer. It is initialised to \`''\` in the constructor and only ever grows — no code path shrinks or resets it. When \`shouldClearTerminalForFrame\` later fires (overflow, leaving fullscreen, fullscreen unmount), Ink writes \`clearTerminal + fullStaticOutput + output\`, which means any item emitted by a \`<Static>\` that has since been unmounted/replaced **re-materialises** above the current viewport even though it no longer exists in the React tree.

Real-world symptom: \"cleared history reappears after a long response scrolls the viewport\" in TUIs that drive a Static replay via a remount key (Gemini CLI, qwen-code, …). End-to-end repro thread: https://github.com/QwenLM/qwen-code/pull/4083.

## Fix

Track \`rootNode.previousStaticNode\` across commits. When \`resetAfterCommit\` detects that \`rootNode.staticNode\` has changed identity (first mount, last unmount, or remount via key), fire a new \`onStaticChange\` hook on the root node **before** \`onImmediateRender\`. Ink installs an \`onStaticChange\` handler that resets \`this.fullStaticOutput = ''\`. The new instance (if any) re-emits its items into a fresh accumulator on the immediate render that follows.

\`\`\`diff
 // resetAfterCommit, src/reconciler.ts
+  if (rootNode.staticNode !== rootNode.previousStaticNode) {
+    rootNode.previousStaticNode = rootNode.staticNode;
+    if (typeof rootNode.onStaticChange === 'function') {
+      rootNode.onStaticChange();
+    }
+  }
\`\`\`

\`\`\`diff
 // constructor wiring, src/ink.tsx
   this.rootNode.onImmediateRender = this.onRender;
+  this.rootNode.onStaticChange = this.handleStaticChange;
 ...
+  handleStaticChange = (): void => {
+    this.fullStaticOutput = '';
+  };
\`\`\`

## Scope (no behaviour change for the classic case)

- The **Tap-style \"one Static mounted for the lifetime of the app, items keep getting appended\"** use case is untouched: \`staticNode\` identity never changes → \`onStaticChange\` never fires → \`fullStaticOutput\` keeps accumulating exactly as today.
- The **#904 / #905 unmount path** is strengthened: in addition to clearing \`rootNode.staticNode\` (so the renderer stops walking a freed Yoga tree), Ink now also drops the now-orphan output from \`fullStaticOutput\`, so a later overflow-driven \`clearTerminal\` rewrite does not resurrect the unmounted Static's items.
- The original \`static output stops accumulating after Static unmounts (#904)\` regression test still passes — its length-stability assertion (\`outputAfterChurn.length === outputAfterUnmount.length\`) holds whether \`fullStaticOutput\` is left intact at unmount or reset at unmount; this PR doesn't change that invariant.

## Test

Adds \`fullStaticOutput is reset when <Static> unmounts so stale items are not replayed\` to \`test/components.tsx\`. Mounts a \`<Static items={['HISTORY-A', 'HISTORY-B']} />\` in debug mode (every \`stdout.write\` is \`fullStaticOutput + dynamicOutput\`), unmounts it, asserts that the subsequent write does NOT include \`HISTORY-A\` or \`HISTORY-B\`. Without the fix the assertion fails; with the fix it passes.

The **companion remount-via-key case** is intentionally NOT tested here because it additionally depends on the \`staticNode\`-pointer-clobbered-on-remount bug fixed by #948. Each fix stands alone; **this PR is independent of #948** and can be merged in either order. The two fixes compose to give the full \"remount produces only new items, no resurrected old items\" behaviour.

Verified:
- New test **fails** on \`master\` (\`76d221c\`) — confirms the bug
- New test **passes** with this patch
- Existing Static tests all pass (\`static output\`, \`skip previous output when rendering new static output\`, \`static output stops accumulating after Static unmounts (#904)\`, \`render only new items in static output on final render\`, non-interactive mode, concurrent mode)
- Other test failures in the full suite (\`cursor moves on space input\`, \`measure-element\`-related, \`wrap-ansi doesn't trim leading whitespace\`) reproduce on \`master\` without this patch and are unrelated.

## Why a hook on the root node and not inline in the reconciler

The reconciler owns the React → DOM mapping; \`fullStaticOutput\` is a private Ink-instance writer-side accumulator. A hook keeps the layering intact: the reconciler reports an identity change, Ink decides what to do with it. The same pattern is already used for \`onRender\`, \`onImmediateRender\`, and \`onComputeLayout\`.