### PR TITLE
fix: share useBoxMetrics resize listener via emitLayoutListeners

### DIFF
--- a/src/hooks/use-box-metrics.ts
+++ b/src/hooks/use-box-metrics.ts
@@ -1,6 +1,5 @@
 import {type RefObject, useState, useEffect, useCallback, useMemo} from 'react';
 import {type DOMElement, addLayoutListener} from '../dom.js';
-import useStdout from './use-stdout.js';
 
 // Yoga's `right`/`bottom` are omitted: always `0` for flow layout and unintuitive for absolute positioning.
 /**
@@ -91,7 +90,6 @@ const useBoxMetrics = (
 ): UseBoxMetricsResult => {
 	const [metrics, setMetrics] = useState(emptyMetrics);
 	const [hasMeasured, setHasMeasured] = useState(false);
-	const {stdout} = useStdout();
 
 	const updateMetrics = useCallback(() => {
 		const layout = ref.current?.yogaNode?.getComputedLayout() ?? emptyMetrics;
@@ -124,18 +122,6 @@ const useBoxMetrics = (
 
 		return addLayoutListener(rootNode, updateMetrics);
 	});
-
-	// Terminal resize events do not go through React's render cycle. Ink
-	// recalculates Yoga layout in its own resize handler — registered in the
-	// Ink constructor, before this hook mounts — so by the time the resize
-	// callback runs, Yoga has already computed the post-resize metrics.
-	useEffect(() => {
-		stdout.on('resize', updateMetrics);
-
-		return () => {
-			stdout.off('resize', updateMetrics);
-		};
-	}, [stdout, updateMetrics]);
 
 	return useMemo(
 		() => ({

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -467,6 +467,7 @@ export default class Ink {
 		}
 
 		this.calculateLayout();
+		dom.emitLayoutListeners(this.rootNode);
 		this.onRender();
 
 		this.lastTerminalWidth = currentWidth;


### PR DESCRIPTION
Currently each instance of this hook adds a `stdout.on("resize")`, quickly hitting the max listeners warning.  This errors go through `process.emitWarning()`,  the ink console log patch doesn't catch it and they end up in the terminal output.

A workaround is bumping the max listeners, but I think a better fix is just sharing a single listener.  This change simply emits a layout change on resize.  Looks like only `useBoxMetrics` is using `addLayoutListeners`, so it shouldn't affect any other hooks.

Errors look like this:
```javascript
MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 resize listeners added to [WriteStream]. 
...
    type: "resize",
   count: 11,
```