### PR TITLE
Add onClick event support

### DIFF
--- a/examples/on-click/index.ts
+++ b/examples/on-click/index.ts
@@ -1,0 +1,1 @@
+import './on-click.js';

--- a/examples/on-click/on-click.tsx
+++ b/examples/on-click/on-click.tsx
@@ -110,31 +110,36 @@ function OnClickDemo() {
 						position="absolute"
 						left={0}
 						top={0}
-						borderStyle="round"
-						borderColor="red"
-						paddingX={2}
+						width={18}
+						height={3}
+						backgroundColor="red"
+						paddingLeft={2}
+						paddingTop={1}
 						onClick={event => {
 							setBottomOverlayClicks(count => count + 1);
 							describeClick('Bottom overlay', event);
 						}}
 					>
-						<Text color="red">Bottom overlay</Text>
+						<Text color="white">Bottom overlay</Text>
 					</Box>
 
 					<Box
 						position="absolute"
 						left={4}
 						top={0}
+						width={18}
+						height={3}
 						backgroundColor="green"
-						borderStyle="round"
-						borderColor="green"
-						paddingX={2}
+						paddingLeft={2}
+						paddingTop={1}
 						onClick={event => {
 							setTopOverlayClicks(count => count + 1);
 							describeClick('Top overlay', event);
 						}}
 					>
-						<Text color="black">Top overlay</Text>
+						<Text bold color="black">
+							Top overlay
+						</Text>
 					</Box>
 				</Box>
 			</Box>

--- a/examples/on-click/on-click.tsx
+++ b/examples/on-click/on-click.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import {Box, Text, render, useApp, useInput} from '../../src/index.js';
+
+function OnClickDemo() {
+	const {exit} = useApp();
+	const [primaryClicks, setPrimaryClicks] = React.useState(0);
+	const [secondaryClicks, setSecondaryClicks] = React.useState(0);
+	const [textClicks, setTextClicks] = React.useState(0);
+	const [panelClicks, setPanelClicks] = React.useState(0);
+	const [childClicks, setChildClicks] = React.useState(0);
+	const [lastClick, setLastClick] = React.useState('None yet');
+
+	useInput(input => {
+		if (input === 'q') {
+			exit();
+		}
+	});
+
+	const describeClick = (label: string, event: {x: number; y: number}) => {
+		setLastClick(`${label} at x=${event.x}, y=${event.y}`);
+	};
+
+	return (
+		<Box flexDirection="column" gap={1}>
+			<Text>Click any target below. Press “q” to exit.</Text>
+
+			<Box gap={2}>
+				<Box
+					borderStyle="round"
+					borderColor="green"
+					paddingX={2}
+					onClick={event => {
+						setPrimaryClicks(count => count + 1);
+						describeClick('Primary button', event);
+					}}
+				>
+					<Text color="green">Primary</Text>
+				</Box>
+
+				<Box
+					borderStyle="round"
+					borderColor="blue"
+					paddingX={2}
+					onClick={event => {
+						setSecondaryClicks(count => count + 1);
+						describeClick('Secondary button', event);
+					}}
+				>
+					<Text color="blue">Secondary</Text>
+				</Box>
+
+				<Box
+					borderStyle="round"
+					borderColor="red"
+					paddingX={2}
+					onClick={event => {
+						setPrimaryClicks(0);
+						setSecondaryClicks(0);
+						setTextClicks(0);
+						setPanelClicks(0);
+						setChildClicks(0);
+						describeClick('Reset button', event);
+					}}
+				>
+					<Text color="red">Reset</Text>
+				</Box>
+			</Box>
+
+			<Text
+				underline
+				color="yellow"
+				onClick={event => {
+					setTextClicks(count => count + 1);
+					describeClick('Clickable text', event);
+				}}
+			>
+				Clickable text link
+			</Text>
+
+			<Box
+				flexDirection="column"
+				borderStyle="single"
+				borderColor="magenta"
+				paddingX={1}
+				onClick={event => {
+					setPanelClicks(count => count + 1);
+					describeClick('Parent panel', event);
+				}}
+			>
+				<Text color="magenta">Parent panel counts bubbled clicks</Text>
+				<Text
+					color="cyan"
+					onClick={event => {
+						setChildClicks(count => count + 1);
+						describeClick('Child text inside panel', event);
+					}}
+				>
+					Click this child text to increment both child and panel.
+				</Text>
+			</Box>
+
+			<Text>Primary clicks: {primaryClicks}</Text>
+			<Text>Secondary clicks: {secondaryClicks}</Text>
+			<Text>Text clicks: {textClicks}</Text>
+			<Text>Panel clicks: {panelClicks}</Text>
+			<Text>Child clicks: {childClicks}</Text>
+			<Text>Last click: {lastClick}</Text>
+		</Box>
+	);
+}
+
+render(<OnClickDemo />, {
+	alternateScreen: true,
+});

--- a/examples/on-click/on-click.tsx
+++ b/examples/on-click/on-click.tsx
@@ -8,6 +8,8 @@ function OnClickDemo() {
 	const [textClicks, setTextClicks] = React.useState(0);
 	const [panelClicks, setPanelClicks] = React.useState(0);
 	const [childClicks, setChildClicks] = React.useState(0);
+	const [bottomOverlayClicks, setBottomOverlayClicks] = React.useState(0);
+	const [topOverlayClicks, setTopOverlayClicks] = React.useState(0);
 	const [lastClick, setLastClick] = React.useState('None yet');
 
 	useInput(input => {
@@ -59,6 +61,8 @@ function OnClickDemo() {
 						setTextClicks(0);
 						setPanelClicks(0);
 						setChildClicks(0);
+						setBottomOverlayClicks(0);
+						setTopOverlayClicks(0);
 						describeClick('Reset button', event);
 					}}
 				>
@@ -99,11 +103,48 @@ function OnClickDemo() {
 				</Text>
 			</Box>
 
+			<Box flexDirection="column">
+				<Text>Overlapping boxes: only the top box should receive clicks.</Text>
+				<Box width={28} height={3}>
+					<Box
+						position="absolute"
+						left={0}
+						top={0}
+						borderStyle="round"
+						borderColor="red"
+						paddingX={2}
+						onClick={event => {
+							setBottomOverlayClicks(count => count + 1);
+							describeClick('Bottom overlay', event);
+						}}
+					>
+						<Text color="red">Bottom overlay</Text>
+					</Box>
+
+					<Box
+						position="absolute"
+						left={4}
+						top={0}
+						borderStyle="round"
+						borderColor="green"
+						paddingX={2}
+						onClick={event => {
+							setTopOverlayClicks(count => count + 1);
+							describeClick('Top overlay', event);
+						}}
+					>
+						<Text color="green">Top overlay</Text>
+					</Box>
+				</Box>
+			</Box>
+
 			<Text>Primary clicks: {primaryClicks}</Text>
 			<Text>Secondary clicks: {secondaryClicks}</Text>
 			<Text>Text clicks: {textClicks}</Text>
 			<Text>Panel clicks: {panelClicks}</Text>
 			<Text>Child clicks: {childClicks}</Text>
+			<Text>Bottom overlay clicks: {bottomOverlayClicks}</Text>
+			<Text>Top overlay clicks: {topOverlayClicks}</Text>
 			<Text>Last click: {lastClick}</Text>
 		</Box>
 	);

--- a/examples/on-click/on-click.tsx
+++ b/examples/on-click/on-click.tsx
@@ -125,6 +125,7 @@ function OnClickDemo() {
 						position="absolute"
 						left={4}
 						top={0}
+						backgroundColor="green"
 						borderStyle="round"
 						borderColor="green"
 						paddingX={2}
@@ -133,7 +134,7 @@ function OnClickDemo() {
 							describeClick('Top overlay', event);
 						}}
 					>
-						<Text color="green">Top overlay</Text>
+						<Text color="black">Top overlay</Text>
 					</Box>
 				</Box>
 			</Box>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -11,6 +11,15 @@ import React, {
 import cliCursor from 'cli-cursor';
 import {type CursorPosition} from '../log-update.js';
 import {createInputParser} from '../input-parser.js';
+import {type DOMElement} from '../dom.js';
+import {
+	disableMouseTracking,
+	dispatchClick,
+	enableMouseTracking,
+	hasClickHandler,
+	isMouseInput,
+	parseMouseInput,
+} from '../mouse.js';
 import AppContext from './AppContext.js';
 import StdinContext from './StdinContext.js';
 import StdoutContext from './StdoutContext.js';
@@ -33,6 +42,7 @@ type AnimationSubscriber = {
 
 type Props = {
 	readonly children: ReactNode;
+	readonly rootNode: DOMElement;
 	readonly stdin: NodeJS.ReadStream;
 	readonly stdout: NodeJS.WriteStream;
 	readonly stderr: NodeJS.WriteStream;
@@ -56,6 +66,7 @@ type Focusable = {
 // It also handles Ctrl+C exiting and cursor visibility
 function App({
 	children,
+	rootNode,
 	stdin,
 	stdout,
 	stderr,
@@ -97,6 +108,7 @@ function App({
 	const readableListenerRef = useRef<(() => void) | undefined>(undefined);
 	const inputParserRef = useRef(createInputParser());
 	const pendingInputFlushRef = useRef<NodeJS.Timeout | undefined>(undefined);
+	const isMouseTrackingEnabledRef = useRef(false);
 	// Small delay to let chunked escape sequences complete before flushing as literal input.
 	const pendingInputFlushDelayMilliseconds = 20;
 
@@ -256,10 +268,21 @@ function App({
 
 	const emitInput = useCallback(
 		(input: string): void => {
+			const mouseInput = parseMouseInput(input);
+
+			if (mouseInput) {
+				dispatchClick(rootNode, mouseInput);
+				return;
+			}
+
+			if (isMouseInput(input)) {
+				return;
+			}
+
 			handleInput(input);
 			internal_eventEmitter.current.emit('input', input);
 		},
-		[handleInput],
+		[handleInput, rootNode],
 	);
 
 	const schedulePendingInputFlush = useCallback((): void => {
@@ -402,6 +425,34 @@ function App({
 		},
 		[stdout],
 	);
+
+	const disableMouseMode = useCallback((): void => {
+		if (!isMouseTrackingEnabledRef.current) {
+			return;
+		}
+
+		isMouseTrackingEnabledRef.current = false;
+		stdout.write(disableMouseTracking);
+		handleSetRawMode(false);
+	}, [stdout, handleSetRawMode]);
+
+	useEffect(() => {
+		const shouldEnableMouseMode =
+			interactive && stdout.isTTY && hasClickHandler(rootNode);
+
+		if (shouldEnableMouseMode && !isMouseTrackingEnabledRef.current) {
+			isMouseTrackingEnabledRef.current = true;
+			stdout.write(enableMouseTracking);
+			handleSetRawMode(true);
+			return;
+		}
+
+		if (!shouldEnableMouseMode) {
+			disableMouseMode();
+		}
+	});
+
+	useEffect(() => disableMouseMode, [disableMouseMode]);
 
 	// Focus navigation helpers
 	const findNextFocusable = useCallback(

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -53,6 +53,7 @@ type Props = {
 	readonly onWaitUntilRenderFlush: () => Promise<void>;
 	readonly setCursorPosition: (position: CursorPosition | undefined) => void;
 	readonly interactive: boolean;
+	readonly alternateScreen: boolean;
 	readonly renderThrottleMs: number;
 };
 
@@ -77,6 +78,7 @@ function App({
 	onWaitUntilRenderFlush,
 	setCursorPosition,
 	interactive,
+	alternateScreen,
 	renderThrottleMs,
 }: Props): React.ReactNode {
 	const [isFocusEnabled, setIsFocusEnabled] = useState(true);
@@ -268,6 +270,12 @@ function App({
 
 	const emitInput = useCallback(
 		(input: string): void => {
+			if (!isMouseTrackingEnabledRef.current) {
+				handleInput(input);
+				internal_eventEmitter.current.emit('input', input);
+				return;
+			}
+
 			const mouseInput = parseMouseInput(input);
 
 			if (mouseInput) {
@@ -438,7 +446,10 @@ function App({
 
 	useEffect(() => {
 		const shouldEnableMouseMode =
-			interactive && stdout.isTTY && hasClickHandler(rootNode);
+			alternateScreen &&
+			interactive &&
+			stdout.isTTY &&
+			hasClickHandler(rootNode);
 
 		if (shouldEnableMouseMode && !isMouseTrackingEnabledRef.current) {
 			isMouseTrackingEnabledRef.current = true;

--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -56,6 +56,7 @@ export type Props = Except<Styles, 'textWrap'> & {
 
 	/**
 	Function to call when the element is clicked.
+	Only supported when rendering in the alternate screen.
 	*/
 	readonly onClick?: ClickHandler;
 };

--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -1,7 +1,7 @@
 import React, {forwardRef, useContext, type PropsWithChildren} from 'react';
 import {type Except} from 'type-fest';
 import {type Styles} from '../styles.js';
-import {type DOMElement} from '../dom.js';
+import {type ClickHandler, type DOMElement} from '../dom.js';
 import {accessibilityContext} from './AccessibilityContext.js';
 import {backgroundContext} from './BackgroundContext.js';
 
@@ -53,6 +53,11 @@ export type Props = Except<Styles, 'textWrap'> & {
 		readonly required?: boolean;
 		readonly selected?: boolean;
 	};
+
+	/**
+	Function to call when the element is clicked.
+	*/
+	readonly onClick?: ClickHandler;
 };
 
 /**
@@ -67,6 +72,7 @@ const Box = forwardRef<DOMElement, PropsWithChildren<Props>>(
 			'aria-hidden': ariaHidden,
 			'aria-role': role,
 			'aria-state': ariaState,
+			onClick,
 			...style
 		},
 		ref,
@@ -94,6 +100,7 @@ const Box = forwardRef<DOMElement, PropsWithChildren<Props>>(
 					role,
 					state: ariaState,
 				}}
+				onClick={onClick}
 			>
 				{isScreenReaderEnabled && label ? label : children}
 			</ink-box>

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -2,6 +2,7 @@ import React, {useContext, type ReactNode} from 'react';
 import chalk, {type ForegroundColorName} from 'chalk';
 import {type LiteralUnion} from 'type-fest';
 import colorize from '../colorize.js';
+import {type ClickHandler} from '../dom.js';
 import {type Styles} from '../styles.js';
 import {accessibilityContext} from './AccessibilityContext.js';
 import {backgroundContext} from './BackgroundContext.js';
@@ -62,6 +63,11 @@ export type Props = {
 	*/
 	readonly wrap?: Styles['textWrap'];
 
+	/**
+	Function to call when the element is clicked.
+	*/
+	readonly onClick?: ClickHandler;
+
 	readonly children?: ReactNode;
 };
 
@@ -78,6 +84,7 @@ export default function Text({
 	strikethrough = false,
 	inverse = false,
 	wrap = 'wrap',
+	onClick,
 	children,
 	'aria-label': ariaLabel,
 	'aria-hidden': ariaHidden = false,
@@ -138,6 +145,7 @@ export default function Text({
 		<ink-text
 			style={{flexGrow: 0, flexShrink: 1, flexDirection: 'row', textWrap: wrap}}
 			internal_transform={transform}
+			onClick={onClick}
 		>
 			{childrenOrAriaLabel}
 		</ink-text>

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -65,6 +65,7 @@ export type Props = {
 
 	/**
 	Function to call when the element is clicked.
+	Only supported when rendering in the alternate screen.
 	*/
 	readonly onClick?: ClickHandler;
 

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -14,6 +14,17 @@ type InkNode = {
 
 type LayoutListener = () => void;
 
+export type ClickEvent = {
+	readonly x: number;
+	readonly y: number;
+	readonly button: 'left';
+	readonly target: DOMElement;
+	currentTarget: DOMElement;
+	stopPropagation: () => void;
+};
+
+export type ClickHandler = (event: ClickEvent) => void;
+
 export type TextName = '#text';
 export type ElementNames =
 	| 'ink-root'
@@ -90,7 +101,12 @@ export type DOMNode<T = {nodeName: NodeNames}> = T extends {
 	: never;
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export type DOMNodeAttribute = boolean | string | number;
+export type DOMNodeAttribute =
+	| boolean
+	| string
+	| number
+	| ClickHandler
+	| undefined;
 
 export const createNode = (nodeName: ElementNames): DOMElement => {
 	const node: DOMElement = {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,6 +1,6 @@
 import {type ReactNode, type Key, type Ref} from 'react';
 import {type Except} from 'type-fest';
-import {type DOMElement} from './dom.js';
+import {type ClickHandler, type DOMElement} from './dom.js';
 import {type Styles} from './styles.js';
 
 declare module 'react' {
@@ -21,6 +21,7 @@ declare namespace Ink {
 		ref?: Ref<DOMElement>;
 		style?: Except<Styles, 'textWrap'>;
 		internal_accessibility?: DOMElement['internal_accessibility'];
+		onClick?: ClickHandler;
 	};
 
 	type Text = {
@@ -31,5 +32,6 @@ declare namespace Ink {
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		internal_transform?: (children: string, index: number) => string;
 		internal_accessibility?: DOMElement['internal_accessibility'];
+		onClick?: ClickHandler;
 	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,6 @@ export type {BoxMetrics, UseBoxMetricsResult} from './hooks/use-box-metrics.js';
 export {default as useBoxMetrics} from './hooks/use-box-metrics.js';
 export type {CursorPosition} from './log-update.js';
 export {default as measureElement} from './measure-element.js';
-export type {DOMElement} from './dom.js';
+export type {ClickEvent, ClickHandler, DOMElement} from './dom.js';
 export {kittyFlags, kittyModifiers} from './kitty-keyboard.js';
 export type {KittyKeyboardOptions, KittyFlagName} from './kitty-keyboard.js';

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -641,6 +641,7 @@ export default class Ink {
 				value={{isScreenReaderEnabled: this.isScreenReaderEnabled}}
 			>
 				<App
+					rootNode={this.rootNode}
 					stdin={this.options.stdin}
 					stdout={this.options.stdout}
 					stderr={this.options.stderr}

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -647,6 +647,7 @@ export default class Ink {
 					stderr={this.options.stderr}
 					exitOnCtrlC={this.options.exitOnCtrlC}
 					interactive={this.interactive}
+					alternateScreen={this.alternateScreen}
 					renderThrottleMs={this.renderThrottleMs}
 					writeToStdout={this.writeToStdout}
 					writeToStderr={this.writeToStderr}

--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -1,0 +1,178 @@
+import Yoga from 'yoga-layout';
+import reconciler from './reconciler.js';
+import {type ClickEvent, type ClickHandler, type DOMElement} from './dom.js';
+
+type MouseInput = {
+	readonly x: number;
+	readonly y: number;
+	readonly button: 'left';
+};
+
+type NodeBounds = {
+	readonly x: number;
+	readonly y: number;
+	readonly width: number;
+	readonly height: number;
+};
+
+const sgrMousePrefix = '\u001B[<';
+
+export const enableMouseTracking = '\u001B[?1000h\u001B[?1006h';
+export const disableMouseTracking = '\u001B[?1000l\u001B[?1006l';
+
+export const isMouseInput = (input: string): boolean =>
+	input.startsWith(sgrMousePrefix) &&
+	(input.endsWith('M') || input.endsWith('m'));
+
+export const parseMouseInput = (input: string): MouseInput | undefined => {
+	if (!isMouseInput(input)) {
+		return undefined;
+	}
+
+	const parameters = input.slice(sgrMousePrefix.length, -1).split(';');
+
+	if (parameters.length !== 3 || parameters.includes('')) {
+		return undefined;
+	}
+
+	const [buttonCodeParameter, xParameter, yParameter] = parameters;
+	const buttonCode = Number(buttonCodeParameter);
+	const x = Number(xParameter);
+	const y = Number(yParameter);
+	const isPress = input.endsWith('M');
+	const button = buttonCode % 4;
+	const isMotion = Math.floor(buttonCode / 32) % 2 === 1;
+
+	if (
+		!Number.isInteger(buttonCode) ||
+		!Number.isInteger(x) ||
+		!Number.isInteger(y) ||
+		!isPress ||
+		button !== 0 ||
+		isMotion
+	) {
+		return undefined;
+	}
+
+	return {
+		x: x - 1,
+		y: y - 1,
+		button: 'left',
+	};
+};
+
+export const hasClickHandler = (node: DOMElement): boolean => {
+	if (typeof node.attributes['onClick'] === 'function') {
+		return true;
+	}
+
+	return node.childNodes.some(childNode => {
+		if (childNode.nodeName === '#text') {
+			return false;
+		}
+
+		return hasClickHandler(childNode);
+	});
+};
+
+export const dispatchClick = (
+	rootNode: DOMElement,
+	mouseInput: MouseInput,
+): boolean => {
+	const target = findDeepestClickableNode(rootNode, mouseInput);
+
+	if (!target) {
+		return false;
+	}
+
+	let isPropagationStopped = false;
+	const event: ClickEvent = {
+		...mouseInput,
+		target,
+		currentTarget: target,
+		stopPropagation() {
+			isPropagationStopped = true;
+		},
+	};
+
+	// @ts-expect-error Types require 5 arguments (fn, a, b, c, d) but only fn is needed at runtime.
+	reconciler.discreteUpdates(() => {
+		let currentNode: DOMElement | undefined = target;
+
+		while (currentNode) {
+			const handler = currentNode.attributes['onClick'] as
+				| ClickHandler
+				| undefined;
+
+			if (handler) {
+				event.currentTarget = currentNode;
+				handler(event);
+			}
+
+			if (isPropagationStopped) {
+				break;
+			}
+
+			currentNode = currentNode.parentNode;
+		}
+	});
+
+	return true;
+};
+
+const findDeepestClickableNode = (
+	node: DOMElement,
+	point: MouseInput,
+	offsetX = 0,
+	offsetY = 0,
+): DOMElement | undefined => {
+	if (node.yogaNode?.getDisplay() === Yoga.DISPLAY_NONE) {
+		return undefined;
+	}
+
+	const bounds = getBounds(node, offsetX, offsetY);
+
+	if (node.nodeName !== 'ink-root' && !isPointInsideBounds(point, bounds)) {
+		return undefined;
+	}
+
+	for (const childNode of [...node.childNodes].reverse()) {
+		if (childNode.nodeName === '#text') {
+			continue;
+		}
+
+		const match = findDeepestClickableNode(
+			childNode,
+			point,
+			bounds.x,
+			bounds.y,
+		);
+
+		if (match) {
+			return match;
+		}
+	}
+
+	if (typeof node.attributes['onClick'] === 'function') {
+		return node;
+	}
+
+	return undefined;
+};
+
+const getBounds = (
+	node: DOMElement,
+	offsetX: number,
+	offsetY: number,
+): NodeBounds => ({
+	x: offsetX + (node.yogaNode?.getComputedLeft() ?? 0),
+	y: offsetY + (node.yogaNode?.getComputedTop() ?? 0),
+	width: node.yogaNode?.getComputedWidth() ?? 0,
+	height: node.yogaNode?.getComputedHeight() ?? 0,
+});
+
+const isPointInsideBounds = (point: MouseInput, bounds: NodeBounds): boolean =>
+	point.x >= bounds.x &&
+	point.x < bounds.x + bounds.width &&
+	point.y >= bounds.y &&
+	point.y < bounds.y + bounds.height;

--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -42,14 +42,19 @@ export const parseMouseInput = (input: string): MouseInput | undefined => {
 	const isPress = input.endsWith('M');
 	const button = buttonCode % 4;
 	const isMotion = Math.floor(buttonCode / 32) % 2 === 1;
+	const isWheel = Math.floor(buttonCode / 64) % 2 === 1;
 
 	if (
 		!Number.isInteger(buttonCode) ||
 		!Number.isInteger(x) ||
 		!Number.isInteger(y) ||
+		buttonCode < 0 ||
+		x < 1 ||
+		y < 1 ||
 		!isPress ||
 		button !== 0 ||
-		isMotion
+		isMotion ||
+		isWheel
 	) {
 		return undefined;
 	}

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -1987,6 +1987,36 @@ test('stopPropagation prevents parent onClick handlers', t => {
 	t.true(onParentClick.notCalled);
 });
 
+test('dispatches onClick to topmost overlapping element only', t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	const onBottomClick = spy();
+	const onTopClick = spy();
+
+	render(
+		<Box width={10} height={2}>
+			<Box position="absolute" left={0} top={0} onClick={onBottomClick}>
+				<Text>Bottom</Text>
+			</Box>
+
+			<Box position="absolute" left={0} top={0} onClick={onTopClick}>
+				<Text>Top</Text>
+			</Box>
+		</Box>,
+		{
+			stdout,
+			stdin,
+			debug: true,
+			interactive: true,
+		},
+	);
+
+	emitReadable(stdin, '\u001B[<0;1;1M');
+
+	t.true(onBottomClick.notCalled);
+	t.is(onTopClick.callCount, 1);
+});
+
 test('disables mouse tracking when no onClick handlers remain', t => {
 	const stdout = createStdout();
 	const stdin = createStdin();

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -18,9 +18,10 @@ import {
 	useApp,
 	useInput,
 	useStdin,
+	type ClickEvent,
 } from '../src/index.js';
 import createStdout from './helpers/create-stdout.js';
-import {emitReadable} from './helpers/create-stdin.js';
+import {createStdin, emitReadable} from './helpers/create-stdin.js';
 import {
 	renderToString,
 	renderToStringAsync,
@@ -1896,6 +1897,113 @@ test('link ansi escapes are closed properly', t => {
 	);
 
 	t.is(output, ']8;;https://example.comExample]8;;');
+});
+
+test('calls onClick when element receives a mouse click', t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	const onClick = spy();
+
+	render(<Text onClick={onClick}>Click</Text>, {
+		stdout,
+		stdin,
+		debug: true,
+		interactive: true,
+	});
+
+	emitReadable(stdin, '\u001B[<0;1;1M');
+
+	t.is(onClick.callCount, 1);
+	t.like(onClick.firstCall.args[0], {
+		x: 0,
+		y: 0,
+		button: 'left',
+	});
+});
+
+test('bubbles onClick through parent elements', t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	const childCurrentTargets: unknown[] = [];
+	const parentCurrentTargets: unknown[] = [];
+	const onParentClick = spy((event: ClickEvent) => {
+		parentCurrentTargets.push(event.currentTarget);
+	});
+
+	const onChildClick = spy((event: ClickEvent) => {
+		childCurrentTargets.push(event.currentTarget);
+	});
+
+	render(
+		<Box onClick={onParentClick}>
+			<Text onClick={onChildClick}>Click</Text>
+		</Box>,
+		{
+			stdout,
+			stdin,
+			debug: true,
+			interactive: true,
+		},
+	);
+
+	emitReadable(stdin, '\u001B[<0;1;1M');
+
+	t.is(onChildClick.callCount, 1);
+	t.is(onParentClick.callCount, 1);
+	t.is(
+		onChildClick.firstCall.args[0].target,
+		onParentClick.firstCall.args[0].target,
+	);
+	t.is(childCurrentTargets[0], onChildClick.firstCall.args[0].target);
+	t.is(
+		parentCurrentTargets[0],
+		onChildClick.firstCall.args[0].target.parentNode,
+	);
+});
+
+test('stopPropagation prevents parent onClick handlers', t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	const onParentClick = spy();
+	const onChildClick = spy((event: ClickEvent) => {
+		event.stopPropagation();
+	});
+
+	render(
+		<Box onClick={onParentClick}>
+			<Text onClick={onChildClick}>Click</Text>
+		</Box>,
+		{
+			stdout,
+			stdin,
+			debug: true,
+			interactive: true,
+		},
+	);
+
+	emitReadable(stdin, '\u001B[<0;1;1M');
+
+	t.is(onChildClick.callCount, 1);
+	t.true(onParentClick.notCalled);
+});
+
+test('disables mouse tracking when no onClick handlers remain', t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+
+	const {rerender} = render(<Text onClick={() => {}}>Click</Text>, {
+		stdout,
+		stdin,
+		debug: true,
+		interactive: true,
+	});
+
+	rerender(<Text>Click</Text>);
+
+	const writes = stdout.getWrites().join('');
+
+	t.true(writes.includes('\u001B[?1000h\u001B[?1006h'));
+	t.true(writes.includes('\u001B[?1000l\u001B[?1006l'));
 });
 
 // Concurrent mode tests

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -1909,6 +1909,7 @@ test('calls onClick when element receives a mouse click', t => {
 		stdin,
 		debug: true,
 		interactive: true,
+		alternateScreen: true,
 	});
 
 	emitReadable(stdin, '\u001B[<0;1;1M');
@@ -1943,6 +1944,7 @@ test('bubbles onClick through parent elements', t => {
 			stdin,
 			debug: true,
 			interactive: true,
+			alternateScreen: true,
 		},
 	);
 
@@ -1978,6 +1980,7 @@ test('stopPropagation prevents parent onClick handlers', t => {
 			stdin,
 			debug: true,
 			interactive: true,
+			alternateScreen: true,
 		},
 	);
 
@@ -2008,6 +2011,7 @@ test('dispatches onClick to topmost overlapping element only', t => {
 			stdin,
 			debug: true,
 			interactive: true,
+			alternateScreen: true,
 		},
 	);
 
@@ -2015,6 +2019,42 @@ test('dispatches onClick to topmost overlapping element only', t => {
 
 	t.true(onBottomClick.notCalled);
 	t.is(onTopClick.callCount, 1);
+});
+
+test('does not enable onClick mouse tracking outside alternate screen', t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	const onClick = spy();
+
+	render(<Text onClick={onClick}>Click</Text>, {
+		stdout,
+		stdin,
+		debug: true,
+		interactive: true,
+	});
+
+	emitReadable(stdin, '\u001B[<0;1;1M');
+
+	t.true(onClick.notCalled);
+	t.false(stdout.getWrites().join('').includes('\u001B[?1000h\u001B[?1006h'));
+});
+
+test('does not treat SGR wheel events as onClick', t => {
+	const stdout = createStdout();
+	const stdin = createStdin();
+	const onClick = spy();
+
+	render(<Text onClick={onClick}>Click</Text>, {
+		stdout,
+		stdin,
+		debug: true,
+		interactive: true,
+		alternateScreen: true,
+	});
+
+	emitReadable(stdin, '\u001B[<64;1;1M');
+
+	t.true(onClick.notCalled);
 });
 
 test('disables mouse tracking when no onClick handlers remain', t => {
@@ -2026,6 +2066,7 @@ test('disables mouse tracking when no onClick handlers remain', t => {
 		stdin,
 		debug: true,
 		interactive: true,
+		alternateScreen: true,
 	});
 
 	rerender(<Text>Click</Text>);


### PR DESCRIPTION
## Summary

- Add terminal mouse tracking and SGR mouse parsing to support `onClick` on Ink `Box` and `Text` elements.
- Dispatch click events to the deepest matching node, then bubble through parents with `stopPropagation()` support.
- Add focused tests plus an `examples/on-click` playground for manual testing.

## Flow

```text
stdin mouse escape
  -> parse SGR mouse event
  -> find deepest rendered node containing x/y
  -> call target onClick
  -> bubble to parent onClick handlers unless stopped
```

## Design notes

- Enables xterm mouse modes 1000 + 1006 (SGR) only when the rendered tree contains an `onClick` handler.
- Parses left-button press events only; other mouse escapes are swallowed so they do not leak into `useInput`.
- Hit testing walks children in reverse DOM order so overlapping absolute boxes resolve to the topmost target.

## Test plan

- [x] `npm run lint` (passes with existing warnings)
- [x] `npm run typecheck`
- [x] `FORCE_COLOR=true npx ava test/components.tsx --match='*onClick*' --match='*mouse tracking*'`
- [x] Manual: `npm run example -- examples/on-click/index.ts`


Made with [Cursor](https://cursor.com)