### PR TITLE
fix: the ink rendering engine writes all react compo... in ink.tsx

### DIFF
--- a/src/sanitize-ansi.ts
+++ b/src/sanitize-ansi.ts
@@ -14,7 +14,17 @@ const sanitizeAnsi = (text: string): string => {
 	let output = '';
 
 	for (const token of tokenizeAnsi(text)) {
-		if (token.type === 'text' || token.type === 'osc') {
+		if (token.type === 'text') {
+			output += token.value;
+			continue;
+		}
+
+		// Allow only OSC 8 (hyperlinks); strip all other OSC sequences
+		// to prevent title-hijacking (OSC 0/2) and other terminal attacks
+		if (
+			token.type === 'osc' &&
+			(token.value.startsWith('\x1b]8') || token.value.startsWith('\x9d8'))
+		) {
 			output += token.value;
 			continue;
 		}


### PR DESCRIPTION
## Summary
Fix high severity security issue in `src/ink.tsx`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `src/ink.tsx:18` |

**Description**: The Ink rendering engine writes all React component output directly to stdout via log-update (src/ink.tsx:18). There is no centralized sanitization layer that strips ANSI escape sequences from externally sourced strings before they reach the renderer. If the application renders data from environment variables, file system paths, command-line arguments, or remote API responses, an attacker who controls any such string can embed ANSI escape sequences (e.g., \x1b[2J to clear the screen, \x1b]0;HACKED\x07 to hijack the terminal title, or \x1b[?1049h to switch to the alternate screen) that execute when the string is rendered. The @alcalzone/ansi-tokenize library is present in the dependency tree but there is no evidence it is applied as a sanitization gate on external input.

## Changes
- `src/sanitize-ansi.ts`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
