### PR TITLE
fix: remove useEffectEvent functions from useEffect dependency arrays

### DIFF
--- a/src/hooks/use-input.ts
+++ b/src/hooks/use-input.ts
@@ -265,7 +265,7 @@ const useInput = (inputHandler: Handler, options: Options = {}) => {
 		return () => {
 			internal_eventEmitter.removeListener('input', handleData);
 		};
-	}, [options.isActive, internal_eventEmitter, handleData]);
+	}, [options.isActive, internal_eventEmitter]);
 };
 
 export default useInput;

--- a/src/hooks/use-paste.ts
+++ b/src/hooks/use-paste.ts
@@ -77,7 +77,7 @@ const usePaste = (
 		return () => {
 			internal_eventEmitter.removeListener('paste', handlePaste);
 		};
-	}, [options.isActive, internal_eventEmitter, handlePaste]);
+	}, [options.isActive, internal_eventEmitter]);
 };
 
 export default usePaste;


### PR DESCRIPTION
## Summary

- Remove `handleData` from the `useEffect` dependency array in `useInput`
- Remove `handlePaste` from the `useEffect` dependency array in `usePaste`

These were incorrectly added in #941. `useEffectEvent` return values intentionally have an unstable identity (they change every render), so including them in deps causes the effect to tear down and re-subscribe event listeners on **every render** — completely negating the purpose of `useEffectEvent`.

Per the [React docs on `useEffectEvent`](https://react.dev/reference/react/useEffectEvent#caveats):

> Effect Event functions do not have a stable identity. Their identity intentionally changes on every render.

The original commit (cfaebbb) that introduced `useEffectEvent` in these hooks correctly excluded them from the dependency arrays.