### PR TITLE
fix: handle incomplete stack frames in error overview

### DIFF
--- a/src/components/ErrorOverview.tsx
+++ b/src/components/ErrorOverview.tsx
@@ -27,6 +27,7 @@ export default function ErrorOverview({error}: Props) {
 	const filePath = cleanupPath(origin?.file);
 	let excerpt: CodeExcerpt[] | undefined;
 	let lineWidth = 0;
+	const stackLineCounts = new Map<string, number>();
 
 	if (filePath && origin?.line && fs.existsSync(filePath)) {
 		const sourceCode = fs.readFileSync(filePath, 'utf8');
@@ -96,11 +97,15 @@ export default function ErrorOverview({error}: Props) {
 						.slice(1)
 						.map(line => {
 							const parsedLine = stackUtils.parseLine(line);
+							const lineCount = stackLineCounts.get(line) ?? 0;
+							stackLineCounts.set(line, lineCount + 1);
+							const key = `${line}-${lineCount}`;
 
-							// If the line from the stack cannot be parsed, we print out the unparsed line.
-							if (!parsedLine) {
+							// If the line from the stack cannot be parsed, or parsed into an incomplete
+							// frame (for example, "at native"), we print out the unparsed line.
+							if (!parsedLine || (!parsedLine.file && !parsedLine.function)) {
 								return (
-									<Box key={line}>
+									<Box key={key}>
 										<Text dimColor>- </Text>
 										<Text dimColor bold>
 											{line}
@@ -111,7 +116,7 @@ export default function ErrorOverview({error}: Props) {
 							}
 
 							return (
-								<Box key={line}>
+								<Box key={key}>
 									<Text dimColor>- </Text>
 									<Text dimColor bold>
 										{parsedLine.function}

--- a/src/components/ErrorOverview.tsx
+++ b/src/components/ErrorOverview.tsx
@@ -102,8 +102,9 @@ export default function ErrorOverview({error}: Props) {
 							const key = `${line}-${lineCount}`;
 
 							// If the line from the stack cannot be parsed, or parsed into an incomplete
-							// frame (for example, "at native"), we print out the unparsed line.
-							if (!parsedLine || (!parsedLine.file && !parsedLine.function)) {
+							// frame without source location data (for example, "at native"), we print
+							// out the unparsed line.
+							if (!parsedLine?.file || !parsedLine.line || !parsedLine.column) {
 								return (
 									<Box key={key}>
 										<Text dimColor>- </Text>

--- a/test/error-overview.tsx
+++ b/test/error-overview.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import test from 'ava';
+import stripAnsi from 'strip-ansi';
+import {renderToString} from '../src/index.js';
+import ErrorOverview from '../src/components/ErrorOverview.js';
+
+const createErrorWithStack = (stack: string) => {
+	const error = new Error('Oh no');
+	error.stack = stack;
+
+	return error;
+};
+
+test('renders native stack frames as raw lines', t => {
+	const output = stripAnsi(
+		renderToString(
+			<ErrorOverview
+				error={createErrorWithStack('Error: Oh no\n    at native')}
+			/>,
+		),
+	);
+
+	t.true(output.includes(' -     at native'));
+	t.false(output.includes('undefined'));
+});
+
+test('does not emit duplicate key warnings for repeated stack lines', t => {
+	const consoleErrors: string[] = [];
+	const originalConsoleError = console.error;
+
+	console.error = (...arguments_: unknown[]) => {
+		consoleErrors.push(arguments_.join(' '));
+	};
+
+	try {
+		renderToString(
+			<ErrorOverview error={createErrorWithStack('Error: Oh no\n\n\n')} />,
+		);
+	} finally {
+		console.error = originalConsoleError;
+	}
+
+	t.false(
+		consoleErrors.some(error =>
+			error.includes('Encountered two children with the same key'),
+		),
+	);
+});

--- a/test/error-overview.tsx
+++ b/test/error-overview.tsx
@@ -24,6 +24,20 @@ test('renders native stack frames as raw lines', t => {
 	t.false(output.includes('undefined'));
 });
 
+test('renders named native stack frames as raw lines', t => {
+	const output = stripAnsi(
+		renderToString(
+			<ErrorOverview
+				error={createErrorWithStack('Error: Oh no\n    at foo (native)')}
+			/>,
+		),
+	);
+
+	t.true(output.includes(' -     at foo (native)'));
+	t.false(output.includes('foo (::)'));
+	t.false(output.includes('undefined'));
+});
+
 test('does not emit duplicate key warnings for repeated stack lines', t => {
 	const consoleErrors: string[] = [];
 	const originalConsoleError = console.error;


### PR DESCRIPTION
## Summary
- Render `stack-utils` incomplete stack frames (for example `at native`) as raw stack lines instead of structured frames with `undefined` fields.
- Give repeated stack lines unique, stable keys so trailing/empty stack lines do not trigger React duplicate-key warnings.
- Add focused `ErrorOverview` regression coverage for native frames and repeated blank stack lines.

Closes #963

## Test Plan
- `FORCE_COLOR=true npx ava test/error-overview.tsx --serial`
- `FORCE_COLOR=true npx ava test/errors.tsx test/error-overview.tsx --serial`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings in unrelated files)
- `npm run build`
- `git diff --check`

Note: I also ran `npm test`; it reached the broad AVA suite but failed in unrelated existing tests (`alternate-screen-example`, `cursor`, and `measure-element`) outside the touched ErrorOverview surface.