### PR TITLE
docs: add AI DevKit to who uses ink list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,8 @@ render(<Counter />);
 - [ElevenLabs CLI](https://github.com/elevenlabs/cli) - ElevenLabs agents client.
 - [SSH AI Chat](https://github.com/miantiao-me/ssh-ai-chat) - Chat with AI over SSH.
 - [Deep Code CLI](https://github.com/lessweb/deepcode-cli) - AI coding assistant optimized for the DeepSeek model.
+- [AI DevKit](https://github.com/codeaholicguy/ai-devkit) - Orchestrates AI coding agents into a reliable software factory.
+
 
 _(PRs welcome. Append new entries at the end. Repos must have 100+ stars and showcase Ink beyond a basic list picker.)_
 


### PR DESCRIPTION
[AI DevKit](https://github.com/codeaholicguy/ai-devkit) uses Ink to build terminal-first developer experiences for orchestrating AI coding agent teams.