### PR TITLE
Fix stale frames on Windows when output exactly fills the terminal

### DIFF
--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -115,6 +115,13 @@ const stripKittyQueryResponsesAndTrailingPartial = (
 	return keptBytes;
 };
 
+// Windows consoles scroll the buffer when the bottom-right cell is written,
+// unlike xterm-like terminals which defer the wrap. That extra scroll
+// desynchronizes the incremental erase used for frames that exactly fill the
+// viewport, leaving stale copies of previous frames behind (#969). Keep the
+// pre-7.0 behavior of fully clearing between fullscreen frames there.
+const isWindowsConsole = process.platform === 'win32';
+
 const shouldClearTerminalForFrame = ({
 	isTty,
 	viewportRows,
@@ -136,8 +143,13 @@ const shouldClearTerminalForFrame = ({
 	const wasFullscreen = previousOutputHeight >= viewportRows;
 	const wasOverflowing = previousOutputHeight > viewportRows;
 	const isOverflowing = nextOutputHeight > viewportRows;
+	const isFullscreen = nextOutputHeight >= viewportRows;
 	const isLeavingFullscreen = wasFullscreen && nextOutputHeight < viewportRows;
 	const shouldClearOnUnmount = isUnmounting && wasFullscreen;
+
+	if (isWindowsConsole && (wasFullscreen || isFullscreen)) {
+		return true;
+	}
 
 	return (
 		// Overflowing frames still need full clear fallback.

--- a/test/fixtures/issue-969-windows-full-height-rerender.tsx
+++ b/test/fixtures/issue-969-windows-full-height-rerender.tsx
@@ -1,0 +1,12 @@
+import process from 'node:process';
+
+// Simulate a Windows console. This must happen before Ink is imported, since
+// the platform is read at module load time.
+Object.defineProperty(process, 'platform', {value: 'win32'});
+
+const {runIssue450RerenderFixture} =
+	await import('./issue-450-fixture-helpers.js');
+
+runIssue450RerenderFixture({
+	heightForFrame: rows => rows,
+});

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -167,7 +167,8 @@ type Issue450Fixture =
 	| 'issue-450-grow-to-fullscreen-rerender'
 	| 'issue-450-shrink-from-fullscreen-rerender'
 	| 'issue-450-shrink-from-overflow-rerender'
-	| 'issue-450-static-shrink-from-fullscreen-rerender';
+	| 'issue-450-static-shrink-from-fullscreen-rerender'
+	| 'issue-969-windows-full-height-rerender';
 
 const runIssue450Fixture = async (
 	fixture: Issue450Fixture,
@@ -482,6 +483,24 @@ test.serial(
 		t.true(
 			eraseLineCount > 0,
 			'Expected incremental erase sequences for fullscreen rerenders',
+		);
+	},
+);
+
+test.serial(
+	'#969: full-height rerenders on Windows should clear terminal between frames',
+	async t => {
+		const {output, clearTerminalCount} = await runIssue450FixtureWithCounts(
+			'issue-969-windows-full-height-rerender',
+		);
+
+		assertIssue450DynamicFrameOutput(t, output);
+		// Windows consoles scroll when the bottom-right cell is written, which
+		// breaks incremental erase for fullscreen frames. Each rerender must fall
+		// back to a full clear there.
+		t.true(
+			clearTerminalCount >= 2,
+			`Expected a clearTerminal sequence per fullscreen rerender, received ${clearTerminalCount}`,
 		);
 	},
 );

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -490,17 +490,21 @@ test.serial(
 test.serial(
 	'#969: full-height rerenders on Windows should clear terminal between frames',
 	async t => {
-		const {output, clearTerminalCount} = await runIssue450FixtureWithCounts(
+		const output = await runIssue450Fixture(
 			'issue-969-windows-full-height-rerender',
 		);
 
 		assertIssue450DynamicFrameOutput(t, output);
 		// Windows consoles scroll when the bottom-right cell is written, which
 		// breaks incremental erase for fullscreen frames. Each rerender must fall
-		// back to a full clear there.
+		// back to a full clear there. The fixture process believes it is on
+		// Windows, so ansi-escapes may emit its legacy clearTerminal variant
+		// there (the host's os.release() decides), while this process resolves
+		// the modern one. Count the eraseScreen prefix shared by both variants.
+		const fullClearCount = countOccurrences(output, ansiEscapes.eraseScreen);
 		t.true(
-			clearTerminalCount >= 2,
-			`Expected a clearTerminal sequence per fullscreen rerender, received ${clearTerminalCount}`,
+			fullClearCount >= 2,
+			`Expected a full clear per fullscreen rerender, received ${fullClearCount}`,
 		);
 	},
 );


### PR DESCRIPTION
Fixes #969

## Problem

On Windows, an app whose output is exactly the height of the terminal leaves a stale copy of the previous frame behind on every rerender. The duplicates pile up above the UI as the app repaints. The reporter of #969 hit this through qwen-code, which upgraded ink 6 to 7 in its 0.16.0 release and whose UI sizes itself to fill the terminal (screenshots of the accumulation are in their report on the qwen-code tracker).

## Root cause

Ink 6 wrote `clearTerminal` before every frame whenever `outputHeight >= rows`. 32d96a6 narrowed that to strict overflow (`>`) so that frames exactly at terminal height rerender through the incremental `eraseLines` path instead, which fixed the fullscreen flicker. That path moves the cursor up `previousLineCount - 1` rows and assumes nothing scrolled in between.

That assumption does not hold on Windows. Windows consoles scroll the buffer when the bottom-right cell is written, while xterm-like terminals defer the wrap until the next character. A fullscreen frame with a full-width bottom line (separators, status bars) therefore scrolls one row per repaint, the cursor-up arithmetic lands one row off, and one stale line of the previous frame leaks out the top on every render.

I verified the mechanism by capturing the raw bytes ink 6.8.0 and 7.0.5 emit for the same fullscreen app in a fixed-size PTY and replaying both streams through a terminal model with each wrap semantic: under deferred wrap both are clean, under the Windows scroll behavior ink 6 stays clean (the per-frame clear wipes any drift) while ink 7 leaks one stale line per repaint.

## Fix

On Windows only, treat fullscreen-height frames the way ink 6 did: full clear between frames. Non-Windows platforms keep the incremental path and the flicker fix from 32d96a6. Windows is also the one platform where the flicker tradeoff is moot, since the clear-vs-incremental flicker difference is dwarfed by the broken output.

I could not verify on physical Windows hardware, only against the documented console behavior and the byte-stream replay above. The fix restores the exact write pattern ink 6 used on Windows for years, so the risk is the known ink 6 behavior. Happy to adjust if you'd rather gate this differently.

## Test

The new fixture reuses the #450 rerender harness with `process.platform` overridden to `win32` before ink loads, so the Windows branch is exercised on the Linux CI matrix. The test asserts a `clearTerminal` per fullscreen rerender (the inverse of the #450 incremental assertion) and fails without the src change.

`tsc --noEmit`, `xo`, and the full ava suite pass (1019 tests, the 4 pre-existing `test.failing` cases unchanged).

