### PR TITLE
Add ink-uplot to Useful Components

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2918,6 +2918,7 @@ For a practical example of building an accessible component, see the [ARIA examp
 - [ink-stepper](https://github.com/archcorsair/ink-stepper) - Step-by-step wizard.
 - [ink-virtual-list](https://github.com/archcorsair/ink-virtual-list) - Virtualized list that renders only visible items for performance.
 - [ink-color-picker](https://github.com/sina-byn/ink-color-picker) - Color picker.
+- [ink-uplot](https://github.com/planadecu/ink-uplot) - Render uPlot charts in the terminal, with truecolor Unicode and kitty/sixel/iTerm2 graphics.
 
 ## Useful Hooks
 


### PR DESCRIPTION
Adds [ink-uplot](https://github.com/planadecu/ink-uplot) to the Useful Components list.

It renders [uPlot](https://github.com/leeoniya/uPlot) charts in the terminal as an Ink component — reusing standard browser uPlot config — with truecolor Unicode block art and native kitty / sixel / iTerm2 graphics-protocol output (auto-detected per terminal). Line charts, time series, and live-updating dashboards.

MIT licensed, TypeScript, ESM.