### PR TITLE
Fix dangling staticNode reference on indirect subtree removal

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -184,6 +184,32 @@ export const removeChildNode = (
 	}
 };
 
+const nullifyYogaNodes = (node: DOMNode): void => {
+	node.yogaNode = undefined;
+
+	if (node.nodeName !== '#text') {
+		for (const childNode of node.childNodes) {
+			nullifyYogaNodes(childNode);
+		}
+	}
+};
+
+/**
+Free the Yoga (WASM) memory of a removed subtree, then drop the `yogaNode`
+reference on every DOM node within it.
+
+`freeRecursive()` releases the WASM memory but leaves each JS wrapper object
+truthy, so every `?.yogaNode` guard in the codebase would still pass and then
+trap on a use-after-free when the wrapper is dereferenced (see
+QwenLM/qwen-code#6820). Nulling the references makes those guards effective and
+turns any lingering access into a safe no-op.
+*/
+export const freeYogaSubtree = (removeNode: DOMNode): void => {
+	removeNode.yogaNode?.unsetMeasureFunc();
+	removeNode.yogaNode?.freeRecursive();
+	nullifyYogaNodes(removeNode);
+};
+
 export const setAttribute = (
 	node: DOMElement,
 	key: string,

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -83,6 +83,44 @@ const cleanupYogaNode = (node?: YogaNode): void => {
 	node?.freeRecursive();
 };
 
+/**
+ * Clear `staticNode` (and its change-detection counterpart `previousStaticNode`)
+ * when the node it points at is being removed as part of a larger subtree.
+ *
+ * The existing identity check (`staticNode === removeNode`) only catches direct
+ * removal of the `<Static>` element. When an *ancestor* of `<Static>` is
+ * removed, `freeRecursive()` frees the static node's Yoga WASM memory but the
+ * stale `staticNode` reference survives, and the next render calls
+ * `getComputedWidth()` on freed memory → `RuntimeError: memory access out of
+ * bounds` (see QwenLM/qwen-code#6820).
+ *
+ * Must be called BEFORE `removeChildNode` breaks the parent chain.
+ */
+const clearStaticNodeIfContained = (
+	removeNode: DOMElement | TextNode,
+): void => {
+	const staticNode = currentRootNode?.staticNode;
+
+	if (!staticNode) {
+		return;
+	}
+
+	// Walk up from staticNode to see if removeNode is an ancestor.
+	let current: DOMElement | undefined = staticNode;
+
+	while (current) {
+		if (current === removeNode) {
+			// Only clear staticNode, not previousStaticNode. The inequality
+			// (undefined !== previousStaticNode) triggers onStaticChange in
+			// resetAfterCommit, which resets fullStaticOutput.
+			currentRootNode!.staticNode = undefined;
+			return;
+		}
+
+		current = current.parentNode;
+	}
+};
+
 type Props = Record<string, unknown>;
 
 type HostContext = {
@@ -302,16 +340,16 @@ export default createReconciler<
 	appendChildToContainer: appendChildNode,
 	insertInContainerBefore: insertBeforeNode,
 	removeChildFromContainer(node, removeNode) {
+		// Must run before removeChildNode breaks the parent chain.
+		clearStaticNodeIfContained(removeNode);
+
 		removeChildNode(node, removeNode);
 		cleanupYogaNode(removeNode.yogaNode);
 
-		// Only clear staticNode if it still points at the removed node. On key-driven remounts, `createInstance` already registered the new node before this removal fires.
-		if (
-			removeNode.internal_static &&
-			currentRootNode?.staticNode === removeNode
-		) {
-			currentRootNode.staticNode = undefined;
-		}
+		// Prevent stale references from accessing freed WASM memory. The JS
+		// wrapper stays truthy after freeRecursive(), so optional chaining
+		// (?.yogaNode) cannot detect the freed state on its own.
+		removeNode.yogaNode = undefined;
 	},
 	commitUpdate(node, _type, oldProps, newProps) {
 		if (currentRootNode && node.internal_static) {
@@ -362,16 +400,11 @@ export default createReconciler<
 		setTextNodeValue(node, newText);
 	},
 	removeChild(node, removeNode) {
+		clearStaticNodeIfContained(removeNode);
+
 		removeChildNode(node, removeNode);
 		cleanupYogaNode(removeNode.yogaNode);
-
-		// Same guard as removeChildFromContainer: only clear if this is still the active static node.
-		if (
-			removeNode.internal_static &&
-			currentRootNode?.staticNode === removeNode
-		) {
-			currentRootNode.staticNode = undefined;
-		}
+		removeNode.yogaNode = undefined;
 	},
 	setCurrentUpdatePriority(newPriority: number) {
 		currentUpdatePriority = newPriority;

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -139,8 +139,6 @@ type HostContext = {
 
 let currentUpdatePriority = NoEventPriority;
 
-let currentRootNode: DOMElement | undefined;
-
 async function loadPackageJson() {
 	const fs = await import('node:fs');
 	const content = fs.readFileSync(
@@ -282,7 +280,6 @@ export default createReconciler<
 			}
 
 			if (key === 'internal_static') {
-				currentRootNode = rootNode;
 				node.internal_static = true;
 				rootNode.isStaticDirty = true;
 
@@ -358,8 +355,12 @@ export default createReconciler<
 		freeYogaSubtree(removeNode);
 	},
 	commitUpdate(node, _type, oldProps, newProps) {
-		if (currentRootNode && node.internal_static) {
-			currentRootNode.isStaticDirty = true;
+		if (node.internal_static) {
+			const rootNode = findRootNode(node);
+
+			if (rootNode) {
+				rootNode.isStaticDirty = true;
+			}
 		}
 
 		const props = diff(oldProps, newProps);

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -5,13 +5,14 @@ import {
 	NoEventPriority,
 } from 'react-reconciler/constants.js';
 import * as Scheduler from 'scheduler';
-import Yoga, {type Node as YogaNode} from 'yoga-layout';
+import Yoga from 'yoga-layout';
 import {createContext, version as reactVersion} from 'react';
 import {
 	createTextNode,
 	appendChildNode,
 	insertBeforeNode,
 	removeChildNode,
+	freeYogaSubtree,
 	emitLayoutListeners,
 	setStyle,
 	setTextNodeValue,
@@ -78,42 +79,51 @@ const diff = (before: AnyObject, after: AnyObject): AnyObject | undefined => {
 	return isChanged ? changed : undefined;
 };
 
-const cleanupYogaNode = (node?: YogaNode): void => {
-	node?.unsetMeasureFunc();
-	node?.freeRecursive();
+const findRootNode = (node: DOMElement): DOMElement | undefined => {
+	let current: DOMElement | undefined = node;
+
+	while (current) {
+		if (current.nodeName === 'ink-root') {
+			return current;
+		}
+
+		current = current.parentNode;
+	}
+
+	return undefined;
 };
 
 /**
- * Clear `staticNode` (and its change-detection counterpart `previousStaticNode`)
- * when the node it points at is being removed as part of a larger subtree.
+ * Clear the root's cached `staticNode` when the node it points at is being
+ * removed as part of a larger subtree.
  *
- * The existing identity check (`staticNode === removeNode`) only catches direct
+ * The previous identity check (`staticNode === removeNode`) only caught direct
  * removal of the `<Static>` element. When an *ancestor* of `<Static>` is
- * removed, `freeRecursive()` frees the static node's Yoga WASM memory but the
- * stale `staticNode` reference survives, and the next render calls
- * `getComputedWidth()` on freed memory → `RuntimeError: memory access out of
- * bounds` (see QwenLM/qwen-code#6820).
+ * removed, the stale `staticNode` reference survives and the next render would
+ * replay stale static output (and, before `freeYogaSubtree`, trap on freed
+ * WASM memory — see QwenLM/qwen-code#6820).
  *
- * Must be called BEFORE `removeChildNode` breaks the parent chain.
+ * The owning root is derived from the host parent passed to the removal hook,
+ * not a module-level global, so instances with separate stdout streams don't
+ * clobber each other's pointers.
  */
 const clearStaticNodeIfContained = (
+	rootNode: DOMElement | undefined,
 	removeNode: DOMElement | TextNode,
 ): void => {
-	const staticNode = currentRootNode?.staticNode;
-
-	if (!staticNode) {
+	if (!rootNode?.staticNode) {
 		return;
 	}
 
 	// Walk up from staticNode to see if removeNode is an ancestor.
-	let current: DOMElement | undefined = staticNode;
+	let current: DOMElement | undefined = rootNode.staticNode;
 
 	while (current) {
 		if (current === removeNode) {
 			// Only clear staticNode, not previousStaticNode. The inequality
 			// (undefined !== previousStaticNode) triggers onStaticChange in
 			// resetAfterCommit, which resets fullStaticOutput.
-			currentRootNode!.staticNode = undefined;
+			rootNode.staticNode = undefined;
 			return;
 		}
 
@@ -340,16 +350,12 @@ export default createReconciler<
 	appendChildToContainer: appendChildNode,
 	insertInContainerBefore: insertBeforeNode,
 	removeChildFromContainer(node, removeNode) {
-		// Must run before removeChildNode breaks the parent chain.
-		clearStaticNodeIfContained(removeNode);
+		// `node` is the container, i.e. the root itself. Clear before
+		// removeChildNode breaks the parent chain.
+		clearStaticNodeIfContained(findRootNode(node), removeNode);
 
 		removeChildNode(node, removeNode);
-		cleanupYogaNode(removeNode.yogaNode);
-
-		// Prevent stale references from accessing freed WASM memory. The JS
-		// wrapper stays truthy after freeRecursive(), so optional chaining
-		// (?.yogaNode) cannot detect the freed state on its own.
-		removeNode.yogaNode = undefined;
+		freeYogaSubtree(removeNode);
 	},
 	commitUpdate(node, _type, oldProps, newProps) {
 		if (currentRootNode && node.internal_static) {
@@ -400,11 +406,12 @@ export default createReconciler<
 		setTextNodeValue(node, newText);
 	},
 	removeChild(node, removeNode) {
-		clearStaticNodeIfContained(removeNode);
+		// `node` is the host parent; its chain up to the root is still intact
+		// here, so derive the owning root from it rather than a global.
+		clearStaticNodeIfContained(findRootNode(node), removeNode);
 
 		removeChildNode(node, removeNode);
-		cleanupYogaNode(removeNode.yogaNode);
-		removeNode.yogaNode = undefined;
+		freeYogaSubtree(removeNode);
 	},
 	setCurrentUpdatePriority(newPriority: number) {
 		currentUpdatePriority = newPriority;

--- a/src/render-to-string.ts
+++ b/src/render-to-string.ts
@@ -112,7 +112,7 @@ const renderToString = (
 
 		// Tear down: unmount the tree so the reconciler cleans up child nodes
 		// and runs effect cleanup functions. Child Yoga nodes are freed by the
-		// reconciler's removeChildFromContainer → cleanupYogaNode → freeRecursive.
+		// reconciler's removeChildFromContainer → freeYogaSubtree → freeRecursive.
 		reconciler.updateContainerSync(null, container, null, () => {});
 		reconciler.flushSyncWork();
 		teardownSucceeded = true;

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -603,6 +603,68 @@ test('fullStaticOutput is reset when <Static> unmounts so stale items are not re
 	t.true(afterUnmount.includes('d2'), 'new dynamic output must still render');
 });
 
+test('unmounting an ancestor of <Static> clears staticNode and does not crash the renderer', t => {
+	// When a component that *contains* <Static> is unmounted, the reconciler
+	// removes the ancestor and freeRecursive() frees the static node's Yoga
+	// WASM memory. If staticNode is not cleared, the next render calls
+	// getComputedWidth() on freed memory → RuntimeError: memory access out
+	// of bounds (QwenLM/qwen-code#6820).
+	const stdout = createStdout();
+
+	function Wrapper({children}: {readonly children: React.ReactNode}) {
+		return <Box>{children}</Box>;
+	}
+
+	function App({
+		showWrapper,
+		label,
+	}: {
+		readonly showWrapper: boolean;
+		readonly label: string;
+	}) {
+		return (
+			<Box>
+				{showWrapper ? (
+					<Wrapper>
+						<Static items={['HISTORY-X']}>
+							{item => <Text key={item}>{item}</Text>}
+						</Static>
+					</Wrapper>
+				) : null}
+				<Text>{label}</Text>
+			</Box>
+		);
+	}
+
+	const {rerender} = render(<App showWrapper label="live-1" />, {
+		stdout,
+		debug: true,
+	});
+
+	const afterMount = (stdout.write as any).lastCall.args[0] as string;
+	t.true(afterMount.includes('HISTORY-X'), 'Static item emitted on mount');
+
+	// Unmount the Wrapper (ancestor of <Static>), not <Static> directly.
+	// Before the fix this left a dangling staticNode pointing at freed WASM
+	// memory, and the rerender below would crash.
+	rerender(<App showWrapper={false} label="live-2" />);
+
+	const afterUnmount = (stdout.write as any).lastCall.args[0] as string;
+	t.true(afterUnmount.includes('live-2'), 'dynamic content renders after unmount');
+	t.false(
+		afterUnmount.includes('HISTORY-X'),
+		'stale static output must not replay',
+	);
+
+	// A second rerender confirms the renderer is still functional.
+	rerender(<App showWrapper={false} label="live-3" />);
+	t.is(
+		(stdout.write as any).lastCall.args[0],
+		'live-3',
+		'renderer remains functional after indirect Static removal',
+	);
+});
+
 test('remounting <Static> via key change emits the new items (nested under <Box>)', t => {
 	/*
 	Exercises the `removeChild` path (Static nested in a <Box>). On key-driven remount, `createInstance` registers the new node before the old one is removed; the removal must not clobber the fresh pointer.

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -2,6 +2,7 @@ import EventEmitter from 'node:events';
 import process from 'node:process';
 import test from 'ava';
 import FakeTimers from '@sinonjs/fake-timers';
+import delay from 'delay';
 import chalk from 'chalk';
 import stripAnsi from 'strip-ansi';
 import React, {Component, useEffect, useState} from 'react';
@@ -650,7 +651,10 @@ test('unmounting an ancestor of <Static> clears staticNode and does not crash th
 	rerender(<App showWrapper={false} label="live-2" />);
 
 	const afterUnmount = (stdout.write as any).lastCall.args[0] as string;
-	t.true(afterUnmount.includes('live-2'), 'dynamic content renders after unmount');
+	t.true(
+		afterUnmount.includes('live-2'),
+		'dynamic content renders after unmount',
+	);
 	t.false(
 		afterUnmount.includes('HISTORY-X'),
 		'stale static output must not replay',
@@ -663,6 +667,216 @@ test('unmounting an ancestor of <Static> clears staticNode and does not crash th
 		'live-3',
 		'renderer remains functional after indirect Static removal',
 	);
+});
+
+test('removing a <Static> ancestor that is a direct child of the root does not crash', t => {
+	// Exercises the removeChildFromContainer path: the wrapper holding <Static>
+	// is a direct child of the root container (via a top-level fragment), so its
+	// removal fires removeChildFromContainer rather than removeChild.
+	const stdout = createStdout();
+
+	function App({
+		showWrapper,
+		label,
+	}: {
+		readonly showWrapper: boolean;
+		readonly label: string;
+	}) {
+		return (
+			<>
+				{showWrapper ? (
+					<Box>
+						<Static items={['ROOT-HISTORY']}>
+							{item => <Text key={item}>{item}</Text>}
+						</Static>
+					</Box>
+				) : null}
+				<Text>{label}</Text>
+			</>
+		);
+	}
+
+	const {rerender} = render(<App showWrapper label="root-1" />, {
+		stdout,
+		debug: true,
+	});
+
+	const afterMount = (stdout.write as any).lastCall.args[0] as string;
+	t.true(afterMount.includes('ROOT-HISTORY'), 'Static item emitted on mount');
+
+	rerender(<App showWrapper={false} label="root-2" />);
+
+	const afterUnmount = (stdout.write as any).lastCall.args[0] as string;
+	t.true(
+		afterUnmount.includes('root-2'),
+		'dynamic content renders after unmount',
+	);
+	t.false(
+		afterUnmount.includes('ROOT-HISTORY'),
+		'stale static output must not replay',
+	);
+});
+
+test('separate Ink instances do not clobber each other’s staticNode', t => {
+	// The owning root must be derived from the removal hook’s host parent, not a
+	// module-level global. Rendering <Static> in the second instance moves the
+	// global pointer to the second root; removing <Static>’s ancestor from the
+	// first instance must still clear the FIRST root’s staticNode.
+	const stdout1 = createStdout();
+	const stdout2 = createStdout();
+
+	function App({
+		show,
+		label,
+	}: {
+		readonly show: boolean;
+		readonly label: string;
+	}) {
+		return (
+			<Box>
+				{show ? (
+					<Box>
+						<Static items={[`${label}-history`]}>
+							{item => <Text key={item}>{item}</Text>}
+						</Static>
+					</Box>
+				) : null}
+				<Text>{label}</Text>
+			</Box>
+		);
+	}
+
+	const first = render(<App show label="first" />, {
+		stdout: stdout1,
+		debug: true,
+	});
+
+	// Rendering <Static> here points the module-global root at the second root.
+	const second = render(<App show label="second" />, {
+		stdout: stdout2,
+		debug: true,
+	});
+
+	// Remove <Static>’s ancestor from the FIRST instance. With a global-based
+	// lookup this consulted the second root and left the first root’s pointer
+	// dangling, replaying stale static output.
+	first.rerender(<App show={false} label="first-2" />);
+
+	const firstOut = (stdout1.write as any).lastCall.args[0] as string;
+	t.true(firstOut.includes('first-2'), 'first instance renders new output');
+	t.false(
+		firstOut.includes('first-history'),
+		'first instance must not replay stale static output',
+	);
+
+	// The second instance stays functional and independent.
+	second.rerender(<App show={false} label="second-2" />);
+	const secondOut = (stdout2.write as any).lastCall.args[0] as string;
+	t.true(secondOut.includes('second-2'), 'second instance renders new output');
+
+	first.unmount();
+	second.unmount();
+});
+
+test('unmounting a <Static> ancestor in screen-reader mode does not replay stale output', t => {
+	// The screen-reader render path reads node.staticNode without a yogaNode
+	// guard, so a dangling staticNode would replay the stale static subtree.
+	const stdout = createStdout();
+
+	function App({
+		showWrapper,
+		label,
+	}: {
+		readonly showWrapper: boolean;
+		readonly label: string;
+	}) {
+		return (
+			<Box>
+				{showWrapper ? (
+					<Box>
+						<Static items={['SR-HISTORY']}>
+							{item => <Text key={item}>{item}</Text>}
+						</Static>
+					</Box>
+				) : null}
+				<Text>{label}</Text>
+			</Box>
+		);
+	}
+
+	const {rerender} = render(<App showWrapper label="sr-1" />, {
+		stdout,
+		debug: true,
+		isScreenReaderEnabled: true,
+	});
+
+	rerender(<App showWrapper={false} label="sr-2" />);
+
+	const afterUnmount = (stdout.write as any).lastCall.args[0] as string;
+	t.true(
+		afterUnmount.includes('sr-2'),
+		'dynamic content renders after unmount',
+	);
+	t.false(
+		afterUnmount.includes('SR-HISTORY'),
+		'stale static output must not replay in screen-reader mode',
+	);
+});
+
+test('unmounting a <Static> ancestor in concurrent mode does not crash', async t => {
+	const stdout = createStdout();
+	const {act} = await import('react');
+
+	function App({
+		showWrapper,
+		label,
+	}: {
+		readonly showWrapper: boolean;
+		readonly label: string;
+	}) {
+		return (
+			<Box>
+				{showWrapper ? (
+					<Box>
+						<Static items={['CC-HISTORY']}>
+							{item => <Text key={item}>{item}</Text>}
+						</Static>
+					</Box>
+				) : null}
+				<Text>{label}</Text>
+			</Box>
+		);
+	}
+
+	let instance!: ReturnType<typeof render>;
+
+	await act(async () => {
+		instance = render(<App showWrapper label="cc-1" />, {
+			stdout,
+			debug: true,
+			concurrent: true,
+		});
+	});
+
+	await delay(50);
+
+	await act(async () => {
+		instance.rerender(<App showWrapper={false} label="cc-2" />);
+	});
+
+	await delay(50);
+
+	const afterUnmount = (stdout.write as any).lastCall.args[0] as string;
+	t.true(
+		afterUnmount.includes('cc-2'),
+		'dynamic content renders after unmount',
+	);
+	t.false(
+		afterUnmount.includes('CC-HISTORY'),
+		'stale static output must not replay',
+	);
+
+	instance.unmount();
 });
 
 test('remounting <Static> via key change emits the new items (nested under <Box>)', t => {

--- a/test/components.tsx
+++ b/test/components.tsx
@@ -778,6 +778,59 @@ test('separate Ink instances do not clobber each other’s staticNode', t => {
 	second.unmount();
 });
 
+test('updating <Static> in one instance after another instance mounted <Static> sets the dirty flag on the correct root', t => {
+	// CommitUpdate must derive the owning root from the updated node, not a
+	// module-level global. Rendering <Static> in the second instance used to
+	// move the global pointer; appending to the first instance's <Static> then
+	// set isStaticDirty on the second root, so the first root missed its
+	// immediate render and the new item was lost.
+	const stdout1 = createStdout();
+	const stdout2 = createStdout();
+
+	function App({
+		items,
+		label,
+	}: {
+		readonly items: string[];
+		readonly label: string;
+	}) {
+		return (
+			<Box>
+				<Static items={items}>{item => <Text key={item}>{item}</Text>}</Static>
+				<Text>{label}</Text>
+			</Box>
+		);
+	}
+
+	const first = render(<App items={['A']} label="first" />, {
+		stdout: stdout1,
+		debug: true,
+	});
+
+	// Mounting <Static> in the second instance used to overwrite the global
+	// root pointer.
+	const second = render(<App items={['X']} label="second" />, {
+		stdout: stdout2,
+		debug: true,
+	});
+
+	// Append to the FIRST instance's <Static>. This triggers commitUpdate on
+	// the first root's static node. The dirty flag must land on the first root
+	// so the immediate render fires before useLayoutEffect clears the children.
+	first.rerender(<App items={['A', 'B']} label="first" />);
+
+	const firstOut = (stdout1.write as any).lastCall.args[0] as string;
+	t.true(firstOut.includes('B'), 'appended static item must reach stdout');
+
+	// The second instance stays functional and independent.
+	second.rerender(<App items={['X', 'Y']} label="second" />);
+	const secondOut = (stdout2.write as any).lastCall.args[0] as string;
+	t.true(secondOut.includes('Y'), 'second instance static update works');
+
+	first.unmount();
+	second.unmount();
+});
+
 test('unmounting a <Static> ancestor in screen-reader mode does not replay stale output', t => {
 	// The screen-reader render path reads node.staticNode without a yogaNode
 	// guard, so a dangling staticNode would replay the stale static subtree.


### PR DESCRIPTION
Follow-up to #904 / #905.

## Problem

PR #905 fixed the case where `<Static>` is **directly** removed — the `removeNode.internal_static` identity check clears `staticNode`. But when an **ancestor** of `<Static>` is removed (e.g. a parent `<Box>` is conditionally unmounted), `removeChild` receives the ancestor, whose `internal_static` is `false`. The check skips, `freeRecursive()` frees the entire subtree including the static node's Yoga WASM memory, and `staticNode` survives as a dangling reference.

The next render then calls `node.staticNode.yogaNode.getComputedWidth()` in `renderer.ts`. The JS wrapper object is still truthy after `free()` (yoga-layout does not invalidate it), so the `?.yogaNode` optional chain passes — and the WASM call traps with `RuntimeError: memory access out of bounds`.

This was reported in production by QwenLM/qwen-code#6820 (Qwen Code CLI), where `transcriptFreeze` toggles between `<App/>` (which contains `<Static>`) and `<TranscriptView/>`, unmounting the entire `<App/>` subtree.

## Fix

Two changes in `reconciler.ts`:

1. **`clearStaticNodeIfContained()`** — called before `removeChildNode` (while the parent chain is still intact), walks up from `staticNode` to check whether `removeNode` is an ancestor. If so, clears `staticNode` so the renderer skips the static output path. This subsumes the previous direct-removal identity check.

2. **`removeNode.yogaNode = undefined`** — after `freeRecursive()`, nulls out the freed WASM pointer on the removed DOM node. This is defense-in-depth: any stale JS reference to the removed node will short-circuit on `?.yogaNode` instead of trapping into invalid WASM memory.

## Test

Added a regression test in `test/components.tsx` that:
1. Renders `<Static>` nested inside a `<Box>` wrapper
2. Unmounts the wrapper (not `<Static>` directly)
3. Confirms the renderer does not crash and produces correct output on subsequent rerenders

All existing Static-related tests continue to pass (direct unmount, key-driven remount via both `removeChild` and `removeChildFromContainer` paths, `fullStaticOutput` reset).
