### PR TITLE
Add text selection system with frame-level cell composition

### DIFF
--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -62,6 +62,26 @@ export type Props = {
 	*/
 	readonly wrap?: Styles['textWrap'];
 
+	/**
+	Whether the text is selectable. Defaults to `true`.
+	*/
+	readonly selectable?: boolean;
+
+	/**
+	Selection flow key. Text nodes sharing the same flow key are treated as a single selection unit.
+	*/
+	readonly selectionFlow?: unknown;
+
+	/**
+	Insert a boundary after this text node. `'soft'` joins with surrounding text, `'hard'` starts a new line.
+	*/
+	readonly selectionBreakAfter?: 'soft' | 'hard';
+
+	/**
+	Custom joiner string used when `selectionBreakAfter` is `'soft'`.
+	*/
+	readonly selectionJoiner?: string;
+
 	readonly children?: ReactNode;
 };
 
@@ -78,6 +98,10 @@ export default function Text({
 	strikethrough = false,
 	inverse = false,
 	wrap = 'wrap',
+	selectable = true,
+	selectionFlow,
+	selectionBreakAfter,
+	selectionJoiner = '',
 	children,
 	'aria-label': ariaLabel,
 	'aria-hidden': ariaHidden = false,
@@ -138,6 +162,10 @@ export default function Text({
 		<ink-text
 			style={{flexGrow: 0, flexShrink: 1, flexDirection: 'row', textWrap: wrap}}
 			internal_transform={transform}
+			selectable={selectable}
+			selectionFlow={selectionFlow}
+			selectionBreakAfter={selectionBreakAfter}
+			selectionJoiner={selectionJoiner}
 		>
 			{childrenOrAriaLabel}
 		</ink-text>

--- a/src/frame-controller.ts
+++ b/src/frame-controller.ts
@@ -13,7 +13,7 @@ export type FrameCell = {
 	fullWidth: boolean;
 	styles: unknown[];
 	selectable: boolean;
-	flowId: number | null;
+	flowId: number | undefined;
 };
 
 export type FrameBoundary = {
@@ -26,21 +26,21 @@ export type FrameBoundary = {
 export type ReadonlyFrame = {
 	width: number;
 	height: number;
-	cells: ReadonlyArray<ReadonlyArray<FrameCell>>;
-	boundaries: ReadonlyArray<ReadonlyArray<FrameBoundary | null>>;
+	cells: ReadonlyArray<readonly FrameCell[]>;
+	boundaries: ReadonlyArray<ReadonlyArray<FrameBoundary | undefined>>;
 };
 
 export type FrameController = {
-	getFrame(): ReadonlyFrame | null;
-	getSelection(): ScreenSelection | null;
-	setSelection(selection: ScreenSelection | null): void;
+	getFrame(): ReadonlyFrame | undefined;
+	getSelection(): ScreenSelection | undefined;
+	setSelection(selection: ScreenSelection | undefined): void;
 	subscribe(listener: (frame: ReadonlyFrame) => void): () => void;
 	publishFrame(frame: ReadonlyFrame): void;
 };
 
 const sameSelection = (
-	a: ScreenSelection | null,
-	b: ScreenSelection | null,
+	a: ScreenSelection | undefined,
+	b: ScreenSelection | undefined,
 ): boolean => {
 	if (a === b) {
 		return true;
@@ -61,14 +61,14 @@ const sameSelection = (
 export const createFrameController = (
 	requestRender: () => void,
 ): FrameController => {
-	let currentSelection: ScreenSelection | null = null;
-	let lastFrame: ReadonlyFrame | null = null;
+	let currentSelection: ScreenSelection | undefined;
+	let lastFrame: ReadonlyFrame | undefined;
 	const listeners = new Set<(frame: ReadonlyFrame) => void>();
 
 	return {
 		getFrame: () => lastFrame,
 		getSelection: () => currentSelection,
-		setSelection(selection: ScreenSelection | null) {
+		setSelection(selection: ScreenSelection | undefined) {
 			if (sameSelection(currentSelection, selection)) {
 				return;
 			}

--- a/src/frame-controller.ts
+++ b/src/frame-controller.ts
@@ -1,0 +1,96 @@
+import instances from './instances.js';
+
+export type ScreenSelection = {
+	sx: number;
+	sy: number;
+	ex: number;
+	ey: number;
+};
+
+export type FrameCell = {
+	type: 'char';
+	value: string;
+	fullWidth: boolean;
+	styles: unknown[];
+	selectable: boolean;
+	flowId: number | null;
+};
+
+export type FrameBoundary = {
+	kind: 'soft' | 'hard';
+	joiner: string;
+	selectable: boolean;
+	flowId: number;
+};
+
+export type ReadonlyFrame = {
+	width: number;
+	height: number;
+	cells: ReadonlyArray<ReadonlyArray<FrameCell>>;
+	boundaries: ReadonlyArray<ReadonlyArray<FrameBoundary | null>>;
+};
+
+export type FrameController = {
+	getFrame(): ReadonlyFrame | null;
+	getSelection(): ScreenSelection | null;
+	setSelection(selection: ScreenSelection | null): void;
+	subscribe(listener: (frame: ReadonlyFrame) => void): () => void;
+	publishFrame(frame: ReadonlyFrame): void;
+};
+
+const sameSelection = (
+	a: ScreenSelection | null,
+	b: ScreenSelection | null,
+): boolean => {
+	if (a === b) {
+		return true;
+	}
+
+	if (!a || !b) {
+		return false;
+	}
+
+	return a.sx === b.sx && a.sy === b.sy && a.ex === b.ex && a.ey === b.ey;
+};
+
+// Creates the bidirectional bridge between the application and the renderer:
+// the app reads the latest composited frame (getFrame) and pushes a selection
+// (setSelection) that the renderer highlights before serialization. setSelection
+// deduplicates and schedules exactly one repaint through Ink's own throttle via
+// the requestRender callback, so it never mutates already-committed frame state.
+export const createFrameController = (
+	requestRender: () => void,
+): FrameController => {
+	let currentSelection: ScreenSelection | null = null;
+	let lastFrame: ReadonlyFrame | null = null;
+	const listeners = new Set<(frame: ReadonlyFrame) => void>();
+
+	return {
+		getFrame: () => lastFrame,
+		getSelection: () => currentSelection,
+		setSelection(selection: ScreenSelection | null) {
+			if (sameSelection(currentSelection, selection)) {
+				return;
+			}
+
+			currentSelection = selection;
+			requestRender();
+		},
+		subscribe(listener: (frame: ReadonlyFrame) => void) {
+			listeners.add(listener);
+			return () => {
+				listeners.delete(listener);
+			};
+		},
+		publishFrame(frame: ReadonlyFrame) {
+			lastFrame = frame;
+			for (const listener of listeners) {
+				listener(frame);
+			}
+		},
+	};
+};
+
+export const getFrameController = (
+	stdout: NodeJS.WriteStream,
+): FrameController | undefined => instances.get(stdout)?.frameController;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -31,5 +31,9 @@ declare namespace Ink {
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		internal_transform?: (children: string, index: number) => string;
 		internal_accessibility?: DOMElement['internal_accessibility'];
+		selectable?: boolean;
+		selectionFlow?: unknown;
+		selectionBreakAfter?: 'soft' | 'hard';
+		selectionJoiner?: string;
 	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,3 +44,11 @@ export type {ElementMetrics} from './measure-element.js';
 export type {DOMElement} from './dom.js';
 export {kittyFlags, kittyModifiers} from './kitty-keyboard.js';
 export type {KittyKeyboardOptions, KittyFlagName} from './kitty-keyboard.js';
+export {getFrameController} from './frame-controller.js';
+export type {
+	FrameController,
+	ReadonlyFrame,
+	FrameCell,
+	FrameBoundary,
+	ScreenSelection,
+} from './frame-controller.js';

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -18,6 +18,10 @@ import {hideCursorEscape, showCursorEscape} from './cursor-helpers.js';
 import logUpdate, {type LogUpdate, type CursorPosition} from './log-update.js';
 import {bsu, esu, shouldSynchronize} from './write-synchronized.js';
 import instances from './instances.js';
+import {
+	createFrameController,
+	type FrameController,
+} from './frame-controller.js';
 import App from './components/App.js';
 import {type TerminalSuspension} from './components/AppContext.js';
 import {accessibilityContext as AccessibilityContext} from './components/AccessibilityContext.js';
@@ -327,6 +331,7 @@ export default class Ink {
 	private kittyFlags: KittyFlagName[] | undefined;
 	private cancelKittyDetection?: () => void;
 	private nextRenderCommit?: {promise: Promise<void>; resolve: () => void};
+	readonly frameController: FrameController;
 	// Set while suspendTerminal() has handed the terminal to a child process.
 	private isSuspended = false;
 	// Input pause/resume hooks registered by the App component, which owns raw
@@ -378,6 +383,14 @@ export default class Ink {
 		}
 
 		this.rootNode.onImmediateRender = this.onRender;
+
+		// Bridge for application-level text selection: setSelection schedules a
+		// throttled repaint via the same path as a normal render, and each frame
+		// publishes its composited cells (see onRender).
+		this.frameController = createFrameController(() => {
+			this.rootNode.onRender?.();
+		});
+
 		this.rootNode.onStaticChange = this.handleStaticChange;
 		this.log = logUpdate.create(options.stdout, {
 			incremental: options.incrementalRendering,
@@ -567,10 +580,21 @@ export default class Ink {
 		}
 
 		const startTime = performance.now();
-		const {output, outputHeight, staticOutput} = render(
+		const selection = this.frameController.getSelection() ?? null;
+		const {output, outputHeight, staticOutput, cells, boundaries} = render(
 			this.rootNode,
 			this.isScreenReaderEnabled,
+			selection,
 		);
+
+		if (cells) {
+			this.frameController.publishFrame({
+				width: cells.reduce((width, row) => Math.max(width, row.length), 0),
+				height: cells.length,
+				cells,
+				boundaries: boundaries ?? [],
+			});
+		}
 
 		this.options.onRender?.({renderTime: performance.now() - startTime});
 
@@ -1045,6 +1069,7 @@ export default class Ink {
 				this.options.stdout,
 				ansiEscapes.enterAlternativeScreen,
 			);
+			this.writeBestEffort(this.options.stdout, ansiEscapes.clearTerminal);
 			this.writeBestEffort(this.options.stdout, hideCursorEscape);
 		}
 	}
@@ -1112,6 +1137,7 @@ export default class Ink {
 		outputHeight: number,
 		staticOutput: string,
 	): void {
+		this.log.setCursorPosition(this.cursorPosition);
 		const hasStaticOutput = staticOutput !== '';
 		const isTty = this.options.stdout.isTTY;
 

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -297,6 +297,8 @@ export default class Ink {
 	*/
 	readonly isConcurrent: boolean;
 
+	readonly frameController: FrameController;
+
 	private readonly options: Options;
 	private readonly log: LogUpdate;
 	private cursorPosition: CursorPosition | undefined;
@@ -331,7 +333,6 @@ export default class Ink {
 	private kittyFlags: KittyFlagName[] | undefined;
 	private cancelKittyDetection?: () => void;
 	private nextRenderCommit?: {promise: Promise<void>; resolve: () => void};
-	readonly frameController: FrameController;
 	// Set while suspendTerminal() has handed the terminal to a child process.
 	private isSuspended = false;
 	// Input pause/resume hooks registered by the App component, which owns raw
@@ -580,7 +581,7 @@ export default class Ink {
 		}
 
 		const startTime = performance.now();
-		const selection = this.frameController.getSelection() ?? null;
+		const selection = this.frameController.getSelection();
 		const {output, outputHeight, staticOutput, cells, boundaries} = render(
 			this.rootNode,
 			this.isScreenReaderEnabled,
@@ -588,8 +589,13 @@ export default class Ink {
 		);
 
 		if (cells) {
+			let width = 0;
+			for (const row of cells) {
+				width = Math.max(width, row.length);
+			}
+
 			this.frameController.publishFrame({
-				width: cells.reduce((width, row) => Math.max(width, row.length), 0),
+				width,
 				height: cells.length,
 				cells,
 				boundaries: boundaries ?? [],

--- a/src/output.ts
+++ b/src/output.ts
@@ -16,7 +16,7 @@ import {type TextBoundary} from './wrap-text.js';
 
 // Background applied to selected cells. Appended after a cell's existing styles
 // so the foreground is preserved and this background wins at the terminal.
-const SELECTION_BG = {code: '\x1b[48;5;240m', endCode: '\x1b[49m'};
+const selectionBackground = {code: '\u001B[48;5;240m', endCode: '\u001B[49m'};
 
 // Linear reading-order selection: whole rows between the first and last, partial
 // on the first/last row. Coordinates are screen cells in the composited frame.
@@ -48,7 +48,7 @@ export type SemanticMetadata = {
 	flowId: number;
 	selectable: boolean;
 	selectableRows: boolean[];
-	boundaries: (TextBoundary | null)[];
+	boundaries: Array<TextBoundary | undefined>;
 };
 
 /**
@@ -187,11 +187,11 @@ export default class Output {
 		});
 	}
 
-	get(selection?: ScreenSelection | null): {
+	get(selection?: ScreenSelection): {
 		output: string;
 		height: number;
 		cells: FrameCell[][];
-		boundaries: (FrameBoundary | null)[][];
+		boundaries: Array<Array<FrameBoundary | undefined>>;
 	} {
 		// Initialize output array with a specific set of rows, so that margin/padding at the bottom is preserved
 		const output: FrameCell[][] = [];
@@ -206,15 +206,15 @@ export default class Output {
 					fullWidth: false,
 					styles: [],
 					selectable: false,
-					flowId: null,
+					flowId: undefined,
 				});
 			}
 
 			output.push(row);
 		}
 
-		const boundaries: (FrameBoundary | null)[][] = output.map(() =>
-			Array.from({length: this.width}, () => null),
+		const boundaries: Array<Array<FrameBoundary | undefined>> = output.map(() =>
+			Array.from({length: this.width}, () => undefined),
 		);
 
 		const clips: Clip[] = [];
@@ -317,15 +317,15 @@ export default class Output {
 							clip?.x2 ?? this.width,
 						);
 						const sourceBoundary =
-							semantic?.boundaries[firstLineIndex + index] ?? null;
-						const boundary: FrameBoundary | null =
+							semantic?.boundaries[firstLineIndex + index] ?? undefined;
+						const boundary: FrameBoundary | undefined =
 							sourceBoundary && semantic
 								? {
 										...sourceBoundary,
 										flowId: semantic.flowId,
 										selectable: semantic.selectable,
 									}
-								: null;
+								: undefined;
 
 						for (let boundaryX = startX; boundaryX < endX; boundaryX++) {
 							if (boundaryX < boundaryRow.length) {
@@ -354,7 +354,7 @@ export default class Output {
 						fullWidth: false,
 						styles: [],
 						selectable: false,
-						flowId: null,
+						flowId: undefined,
 					};
 
 					// Wide characters (e.g. CJK) occupy two cells: a leading
@@ -375,7 +375,7 @@ export default class Output {
 						currentLine[offsetX] = {
 							...character,
 							selectable: rowSelectable,
-							flowId: semantic?.flowId ?? null,
+							flowId: semantic?.flowId ?? undefined,
 						};
 
 						// Determine printed width using string-width to align with measurement
@@ -393,7 +393,7 @@ export default class Output {
 									fullWidth: false,
 									styles: character.styles,
 									selectable: rowSelectable,
-									flowId: semantic?.flowId ?? null,
+									flowId: semantic?.flowId ?? undefined,
 								};
 							}
 						}
@@ -415,8 +415,7 @@ export default class Output {
 		// reference StyledChar objects cached and shared across identical lines,
 		// so mutating one would leak the highlight onto other on-screen text.
 		if (selection) {
-			for (let y = 0; y < output.length; y++) {
-				const row = output[y];
+			for (const [y, row] of output.entries()) {
 				if (!row) {
 					continue;
 				}
@@ -430,7 +429,7 @@ export default class Output {
 					if (cell) {
 						row[x] = {
 							...cell,
-							styles: [...(cell.styles ?? []), SELECTION_BG],
+							styles: [...(cell.styles ?? []), selectionBackground],
 						};
 					}
 				}

--- a/src/output.ts
+++ b/src/output.ts
@@ -7,6 +7,49 @@ import {
 	tokenize,
 } from '@alcalzone/ansi-tokenize';
 import {type OutputTransformer} from './render-node-to-output.js';
+import {
+	type ScreenSelection,
+	type FrameCell,
+	type FrameBoundary,
+} from './frame-controller.js';
+import {type TextBoundary} from './wrap-text.js';
+
+// Background applied to selected cells. Appended after a cell's existing styles
+// so the foreground is preserved and this background wins at the terminal.
+const SELECTION_BG = {code: '\x1b[48;5;240m', endCode: '\x1b[49m'};
+
+// Linear reading-order selection: whole rows between the first and last, partial
+// on the first/last row. Coordinates are screen cells in the composited frame.
+const isCellSelected = (
+	x: number,
+	y: number,
+	sel: ScreenSelection,
+): boolean => {
+	if (y < sel.sy || y > sel.ey) {
+		return false;
+	}
+
+	if (sel.sy === sel.ey) {
+		return x >= sel.sx && x <= sel.ex;
+	}
+
+	if (y === sel.sy) {
+		return x >= sel.sx;
+	}
+
+	if (y === sel.ey) {
+		return x <= sel.ex;
+	}
+
+	return true;
+};
+
+export type SemanticMetadata = {
+	flowId: number;
+	selectable: boolean;
+	selectableRows: boolean[];
+	boundaries: (TextBoundary | null)[];
+};
 
 /**
 "Virtual" output class
@@ -29,6 +72,8 @@ type WriteOperation = {
 	y: number;
 	text: string;
 	transformers: OutputTransformer[];
+	selectable?: boolean;
+	semantic?: SemanticMetadata;
 };
 
 type ClipOperation = {
@@ -106,9 +151,13 @@ export default class Output {
 		x: number,
 		y: number,
 		text: string,
-		options: {transformers: OutputTransformer[]},
+		options: {
+			transformers: OutputTransformer[];
+			selectable?: boolean;
+			semantic?: SemanticMetadata;
+		},
 	): void {
-		const {transformers} = options;
+		const {transformers, selectable, semantic} = options;
 
 		if (!text) {
 			return;
@@ -120,6 +169,8 @@ export default class Output {
 			y,
 			text,
 			transformers,
+			selectable,
+			semantic,
 		});
 	}
 
@@ -136,12 +187,17 @@ export default class Output {
 		});
 	}
 
-	get(): {output: string; height: number} {
+	get(selection?: ScreenSelection | null): {
+		output: string;
+		height: number;
+		cells: FrameCell[][];
+		boundaries: (FrameBoundary | null)[][];
+	} {
 		// Initialize output array with a specific set of rows, so that margin/padding at the bottom is preserved
-		const output: StyledChar[][] = [];
+		const output: FrameCell[][] = [];
 
 		for (let y = 0; y < this.height; y++) {
-			const row: StyledChar[] = [];
+			const row: FrameCell[] = [];
 
 			for (let x = 0; x < this.width; x++) {
 				row.push({
@@ -149,11 +205,17 @@ export default class Output {
 					value: ' ',
 					fullWidth: false,
 					styles: [],
+					selectable: false,
+					flowId: null,
 				});
 			}
 
 			output.push(row);
 		}
+
+		const boundaries: (FrameBoundary | null)[][] = output.map(() =>
+			Array.from({length: this.width}, () => null),
+		);
 
 		const clips: Clip[] = [];
 
@@ -167,9 +229,10 @@ export default class Output {
 			}
 
 			if (operation.type === 'write') {
-				const {text, transformers} = operation;
+				const {text, transformers, selectable, semantic} = operation;
 				let {x, y} = operation;
 				let lines = text.split('\n');
+				let firstLineIndex = 0;
 
 				const clip = clips.at(-1);
 
@@ -218,6 +281,7 @@ export default class Output {
 						const to = y + height > clip.y2! ? clip.y2! - y : height;
 
 						lines = lines.slice(from, to);
+						firstLineIndex = from;
 
 						if (y < clip.y1!) {
 							y = clip.y1!;
@@ -239,8 +303,44 @@ export default class Output {
 						line = transformer(line, index);
 					}
 
+					const boundaryRow = boundaries[y + offsetY];
+
+					if (boundaryRow) {
+						const boundaryWidth = semantic
+							? Math.max(1, this.caches.getStringWidth(line))
+							: this.caches.getStringWidth(line);
+						const boundaryOrigin = x;
+						const startX = Math.max(0, boundaryOrigin, clip?.x1 ?? 0);
+						const endX = Math.min(
+							this.width,
+							boundaryOrigin + boundaryWidth,
+							clip?.x2 ?? this.width,
+						);
+						const sourceBoundary =
+							semantic?.boundaries[firstLineIndex + index] ?? null;
+						const boundary: FrameBoundary | null =
+							sourceBoundary && semantic
+								? {
+										...sourceBoundary,
+										flowId: semantic.flowId,
+										selectable: semantic.selectable,
+									}
+								: null;
+
+						for (let boundaryX = startX; boundaryX < endX; boundaryX++) {
+							if (boundaryX < boundaryRow.length) {
+								boundaryRow[boundaryX] = boundary;
+							}
+						}
+					}
+
 					const characters = this.caches.getStyledChars(line);
 					let offsetX = x;
+
+					const rowSelectable = semantic
+						? semantic.selectable &&
+							(semantic.selectableRows[firstLineIndex + index] ?? true)
+						: (selectable ?? true);
 
 					// Nothing to write (e.g. line was clipped away).
 					if (characters.length === 0) {
@@ -248,11 +348,13 @@ export default class Output {
 						continue;
 					}
 
-					const spaceCell: StyledChar = {
+					const spaceCell: FrameCell = {
 						type: 'char',
 						value: ' ',
 						fullWidth: false,
 						styles: [],
+						selectable: false,
+						flowId: null,
 					};
 
 					// Wide characters (e.g. CJK) occupy two cells: a leading
@@ -270,7 +372,11 @@ export default class Output {
 					}
 
 					for (const character of characters) {
-						currentLine[offsetX] = character;
+						currentLine[offsetX] = {
+							...character,
+							selectable: rowSelectable,
+							flowId: semantic?.flowId ?? null,
+						};
 
 						// Determine printed width using string-width to align with measurement
 						const characterWidth = Math.max(
@@ -286,6 +392,8 @@ export default class Output {
 									value: '',
 									fullWidth: false,
 									styles: character.styles,
+									selectable: rowSelectable,
+									flowId: semantic?.flowId ?? null,
 								};
 							}
 						}
@@ -302,18 +410,49 @@ export default class Output {
 			}
 		}
 
+		// Apply the selection highlight before serialization. Selected slots are
+		// replaced with new cell objects (never mutated in place) because cells
+		// reference StyledChar objects cached and shared across identical lines,
+		// so mutating one would leak the highlight onto other on-screen text.
+		if (selection) {
+			for (let y = 0; y < output.length; y++) {
+				const row = output[y];
+				if (!row) {
+					continue;
+				}
+
+				for (let x = 0; x < row.length; x++) {
+					if (!isCellSelected(x, y, selection)) {
+						continue;
+					}
+
+					const cell = row[x];
+					if (cell) {
+						row[x] = {
+							...cell,
+							styles: [...(cell.styles ?? []), SELECTION_BG],
+						};
+					}
+				}
+			}
+		}
+
 		const generatedOutput = output
 			.map(line => {
 				// See https://github.com/vadimdemedes/ink/pull/564#issuecomment-1637022742
 				const lineWithoutEmptyItems = line.filter(item => item !== undefined);
 
-				return styledCharsToString(lineWithoutEmptyItems).trimEnd();
+				return styledCharsToString(
+					lineWithoutEmptyItems as StyledChar[],
+				).trimEnd();
 			})
 			.join('\n');
 
 		return {
 			output: generatedOutput,
 			height: output.length,
+			cells: output,
+			boundaries,
 		};
 	}
 }

--- a/src/render-background.ts
+++ b/src/render-background.ts
@@ -44,7 +44,7 @@ const renderBackground = (
 			x + leftBorderWidth,
 			y + topBorderHeight + row,
 			backgroundLine,
-			{transformers: []},
+			{transformers: [], selectable: false},
 		);
 	}
 };

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -161,22 +161,23 @@ const renderNodeToOutput = (
 					flowIds.set(flowKey, flowId);
 				}
 
-				const boundaries: (TextBoundary | null)[] = [...wrapped.boundaries];
-				const breakAfter = node.attributes[
-					'selectionBreakAfter'
-				] as string | undefined;
+				const boundaries: Array<TextBoundary | undefined> = [
+					...wrapped.boundaries,
+				];
+				const breakAfter = node.attributes['selectionBreakAfter'] as
+					string | undefined;
 				boundaries.push(
 					breakAfter === 'soft' || breakAfter === 'hard'
 						? {
 								kind: breakAfter,
 								joiner:
 									typeof node.attributes['selectionJoiner'] === 'string'
-										? (node.attributes['selectionJoiner'] as string)
+										? node.attributes['selectionJoiner']
 										: breakAfter === 'hard'
 											? '\n'
 											: '',
 							}
-						: null,
+						: undefined,
 				);
 
 				const textOffset = getTextOffset(node);
@@ -192,7 +193,7 @@ const renderNodeToOutput = (
 							flowId,
 							selectable: false,
 							selectableRows: wrapped.selectableRows.map(() => false),
-							boundaries: wrapped.boundaries.map(() => null),
+							boundaries: wrapped.boundaries.map(() => undefined),
 						},
 					});
 				}

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -1,7 +1,6 @@
 import widestLine from 'widest-line';
-import indentString from 'indent-string';
 import Yoga from 'yoga-layout';
-import wrapText from './wrap-text.js';
+import {wrapTextWithMetadata, type TextBoundary} from './wrap-text.js';
 import getMaxWidth from './get-max-width.js';
 import squashTextNodes from './squash-text-nodes.js';
 import renderBorder from './render-border.js';
@@ -15,16 +14,17 @@ import type Output from './output.js';
 // and use it as offset for the rest of the nodes
 // Only first node is taken into account, because other text nodes can't have margin or padding,
 // so their coordinates will be relative to the first node anyway
-const applyPaddingToText = (node: DOMElement, text: string): string => {
+const getTextOffset = (node: DOMElement): {x: number; y: number} => {
 	const yogaNode = node.childNodes[0]?.yogaNode;
 
 	if (yogaNode) {
-		const offsetX = yogaNode.getComputedLeft();
-		const offsetY = yogaNode.getComputedTop();
-		text = '\n'.repeat(offsetY) + indentString(text, offsetX);
+		return {
+			x: yogaNode.getComputedLeft(),
+			y: yogaNode.getComputedTop(),
+		};
 	}
 
-	return text;
+	return {x: 0, y: 0};
 };
 
 export type OutputTransformer = (s: string, index: number) => string;
@@ -105,6 +105,8 @@ const renderNodeToOutput = (
 		offsetY?: number;
 		transformers?: OutputTransformer[];
 		skipStaticElements: boolean;
+		flowIds: Map<unknown, number>;
+		nextFlowId: {value: number};
 	},
 ) => {
 	const {
@@ -112,6 +114,8 @@ const renderNodeToOutput = (
 		offsetY = 0,
 		transformers = [],
 		skipStaticElements,
+		flowIds,
+		nextFlowId,
 	} = options;
 
 	if (skipStaticElements && node.internal_static) {
@@ -138,20 +142,70 @@ const renderNodeToOutput = (
 		}
 
 		if (node.nodeName === 'ink-text') {
-			let text = squashTextNodes(node);
+			const sourceText = squashTextNodes(node);
 
-			if (text.length > 0) {
-				const currentWidth = widestLine(text);
+			if (sourceText.length > 0) {
 				const maxWidth = getMaxWidth(yogaNode);
+				const textWrap = node.style.textWrap ?? 'wrap';
+				const wrapped = wrapTextWithMetadata(
+					sourceText,
+					maxWidth,
+					textWrap,
+					widestLine(sourceText) > maxWidth,
+				);
 
-				if (currentWidth > maxWidth) {
-					const textWrap = node.style.textWrap ?? 'wrap';
-					text = wrapText(text, maxWidth, textWrap);
+				const flowKey = node.attributes['selectionFlow'] ?? node;
+				let flowId = flowIds.get(flowKey);
+				if (flowId === undefined) {
+					flowId = nextFlowId.value++;
+					flowIds.set(flowKey, flowId);
 				}
 
-				text = applyPaddingToText(node, text);
+				const boundaries: (TextBoundary | null)[] = [...wrapped.boundaries];
+				const breakAfter = node.attributes[
+					'selectionBreakAfter'
+				] as string | undefined;
+				boundaries.push(
+					breakAfter === 'soft' || breakAfter === 'hard'
+						? {
+								kind: breakAfter,
+								joiner:
+									typeof node.attributes['selectionJoiner'] === 'string'
+										? (node.attributes['selectionJoiner'] as string)
+										: breakAfter === 'hard'
+											? '\n'
+											: '',
+							}
+						: null,
+				);
 
-				output.write(x, y, text, {transformers: newTransformers});
+				const textOffset = getTextOffset(node);
+
+				if (textOffset.x > 0) {
+					const padding = wrapped.text
+						.split('\n')
+						.map(line => (line.length > 0 ? ' '.repeat(textOffset.x) : ''))
+						.join('\n');
+					output.write(x, y + textOffset.y, padding, {
+						transformers: newTransformers,
+						semantic: {
+							flowId,
+							selectable: false,
+							selectableRows: wrapped.selectableRows.map(() => false),
+							boundaries: wrapped.boundaries.map(() => null),
+						},
+					});
+				}
+
+				output.write(x + textOffset.x, y + textOffset.y, wrapped.text, {
+					transformers: newTransformers,
+					semantic: {
+						flowId,
+						selectable: node.attributes['selectable'] !== false,
+						selectableRows: wrapped.selectableRows,
+						boundaries,
+					},
+				});
 			}
 
 			return;
@@ -201,6 +255,8 @@ const renderNodeToOutput = (
 					offsetY: y,
 					transformers: newTransformers,
 					skipStaticElements,
+					flowIds,
+					nextFlowId,
 				});
 			}
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -14,13 +14,13 @@ type Result = {
 	outputHeight: number;
 	staticOutput: string;
 	cells?: FrameCell[][];
-	boundaries?: (FrameBoundary | null)[][];
+	boundaries?: Array<Array<FrameBoundary | undefined>>;
 };
 
 const renderer = (
 	node: DOMElement,
 	isScreenReaderEnabled: boolean,
-	selection?: ScreenSelection | null,
+	selection?: ScreenSelection,
 ): Result => {
 	if (node.yogaNode) {
 		if (isScreenReaderEnabled) {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -3,14 +3,25 @@ import renderNodeToOutput, {
 } from './render-node-to-output.js';
 import Output from './output.js';
 import {type DOMElement} from './dom.js';
+import {
+	type ScreenSelection,
+	type FrameCell,
+	type FrameBoundary,
+} from './frame-controller.js';
 
 type Result = {
 	output: string;
 	outputHeight: number;
 	staticOutput: string;
+	cells?: FrameCell[][];
+	boundaries?: (FrameBoundary | null)[][];
 };
 
-const renderer = (node: DOMElement, isScreenReaderEnabled: boolean): Result => {
+const renderer = (
+	node: DOMElement,
+	isScreenReaderEnabled: boolean,
+	selection?: ScreenSelection | null,
+): Result => {
 	if (node.yogaNode) {
 		if (isScreenReaderEnabled) {
 			const output = renderNodeToScreenReaderOutput(node, {
@@ -39,8 +50,13 @@ const renderer = (node: DOMElement, isScreenReaderEnabled: boolean): Result => {
 			height: node.yogaNode.getComputedHeight(),
 		});
 
+		const flowIds = new Map<unknown, number>();
+		const nextFlowId = {value: 1};
+
 		renderNodeToOutput(node, output, {
 			skipStaticElements: true,
+			flowIds,
+			nextFlowId,
 		});
 
 		let staticOutput;
@@ -53,10 +69,17 @@ const renderer = (node: DOMElement, isScreenReaderEnabled: boolean): Result => {
 
 			renderNodeToOutput(node.staticNode, staticOutput, {
 				skipStaticElements: false,
+				flowIds,
+				nextFlowId,
 			});
 		}
 
-		const {output: generatedOutput, height: outputHeight} = output.get();
+		const {
+			output: generatedOutput,
+			height: outputHeight,
+			cells,
+			boundaries,
+		} = output.get(selection);
 
 		return {
 			output: generatedOutput,
@@ -64,6 +87,8 @@ const renderer = (node: DOMElement, isScreenReaderEnabled: boolean): Result => {
 			// Newline at the end is needed, because static output doesn't have one, so
 			// interactive output will override last line of static output
 			staticOutput: staticOutput ? `${staticOutput.get().output}\n` : '',
+			cells,
+			boundaries,
 		};
 	}
 

--- a/src/wrap-text.ts
+++ b/src/wrap-text.ts
@@ -1,5 +1,6 @@
 import wrapAnsi from 'wrap-ansi';
 import cliTruncate from 'cli-truncate';
+import stripAnsi from 'strip-ansi';
 import {type Styles} from './styles.js';
 
 const cache: Record<string, string> = {};
@@ -50,6 +51,77 @@ const wrapText = (
 	cache[cacheKey] = wrappedText;
 
 	return wrappedText;
+};
+
+export type TextBoundary = {
+	kind: 'soft' | 'hard';
+	joiner: string;
+};
+
+export const wrapTextWithMetadata = (
+	text: string,
+	maxWidth: number,
+	wrapType: Styles['textWrap'],
+	shouldWrap = true,
+): {text: string; boundaries: TextBoundary[]; selectableRows: boolean[]} => {
+	const sourceLines = text.replaceAll('\r\n', '\n').split('\n');
+	const lines: string[] = [];
+	const boundaries: TextBoundary[] = [];
+	const selectableRows: boolean[] = [];
+
+	for (const [sourceLineIndex, sourceLine] of sourceLines.entries()) {
+		const wrappedLines = (
+			shouldWrap ? wrapText(sourceLine, maxWidth, wrapType) : sourceLine
+		).split('\n');
+		const visibleSource = stripAnsi(sourceLine);
+		let sourceOffset = 0;
+
+		for (const [wrappedLineIndex, wrappedLine] of wrappedLines.entries()) {
+			const visibleLine = stripAnsi(wrappedLine);
+
+			const separatorRow =
+				sourceOffset > 0 &&
+				visibleLine.length > 0 &&
+				/^\s+$/u.test(visibleLine) &&
+				/\S/u.test(visibleSource.slice(sourceOffset));
+
+			const sourceSeparator = separatorRow
+				? (/^\s+/u.exec(visibleSource.slice(sourceOffset))?.[0] ?? '').slice(
+						0,
+						visibleLine.length,
+					)
+				: '';
+
+			const lineOffset = separatorRow
+				? sourceOffset
+				: visibleSource.indexOf(visibleLine, sourceOffset);
+			const resolvedOffset = lineOffset === -1 ? sourceOffset : lineOffset;
+
+			if (lines.length > 0) {
+				boundaries.push({
+					kind: wrappedLineIndex === 0 ? 'hard' : 'soft',
+					joiner:
+						wrappedLineIndex === 0
+							? '\n'
+							: separatorRow
+								? sourceSeparator
+								: visibleSource.slice(sourceOffset, resolvedOffset),
+				});
+			}
+
+			lines.push(wrappedLine);
+			selectableRows.push(!separatorRow);
+			sourceOffset = separatorRow
+				? sourceOffset + sourceSeparator.length
+				: resolvedOffset + visibleLine.length;
+		}
+
+		if (sourceLineIndex < sourceLines.length - 1 && wrappedLines.length === 0) {
+			lines.push('');
+		}
+	}
+
+	return {text: lines.join('\n'), boundaries, selectableRows};
 };
 
 export default wrapText;

--- a/test/selection.tsx
+++ b/test/selection.tsx
@@ -1,0 +1,196 @@
+import test from 'ava';
+import React from 'react';
+import {Box, Text, render, getFrameController} from '../src/index.js';
+import createStdout from './helpers/create-stdout.js';
+
+// The selection background applied to selected cells (see output.ts).
+const selectionBackground = '[48;5;240m';
+
+test('getFrameController returns undefined for an unknown stdout', t => {
+	const stdout = createStdout();
+	t.is(getFrameController(stdout), undefined);
+});
+
+test('getFrameController returns a controller after render', t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout);
+	t.truthy(controller);
+
+	unmount();
+});
+
+test('getFrame exposes the composited cells', t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hi</Text>, {stdout, debug: true});
+
+	const frame = getFrameController(stdout)!.getFrame();
+	t.truthy(frame);
+	t.is(frame!.height, 1);
+	t.true(frame!.width >= 2);
+
+	const row = frame!.cells[0]!;
+	t.is(row[0]!.value, 'H');
+	t.is(row[1]!.value, 'i');
+
+	unmount();
+});
+
+test('text cells are selectable by default', t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hi</Text>, {stdout, debug: true});
+
+	const frame = getFrameController(stdout)!.getFrame();
+	const row = frame!.cells[0]!;
+	t.true(row[0]!.selectable);
+	t.true(row[1]!.selectable);
+
+	unmount();
+});
+
+test('selectable={false} marks cells as non-selectable', t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text selectable={false}>Hi</Text>, {
+		stdout,
+		debug: true,
+	});
+
+	const frame = getFrameController(stdout)!.getFrame();
+	const row = frame!.cells[0]!;
+	t.false(row[0]!.selectable);
+	t.false(row[1]!.selectable);
+
+	unmount();
+});
+
+test('setSelection highlights the selected cells', t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	t.false(
+		stdout.get().includes(selectionBackground),
+		'no highlight before selection',
+	);
+
+	getFrameController(stdout)!.setSelection({sx: 0, sy: 0, ex: 4, ey: 0});
+
+	t.true(
+		stdout.get().includes(selectionBackground),
+		'selected region is highlighted after setSelection',
+	);
+
+	unmount();
+});
+
+test('clearing the selection removes the highlight', t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	controller.setSelection({sx: 0, sy: 0, ex: 4, ey: 0});
+	t.true(stdout.get().includes(selectionBackground));
+
+	controller.setSelection(undefined);
+	t.false(
+		stdout.get().includes(selectionBackground),
+		'highlight is gone after clearing the selection',
+	);
+
+	unmount();
+});
+
+test('setting an identical selection does not trigger a repaint', t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	controller.setSelection({sx: 0, sy: 0, ex: 4, ey: 0});
+
+	const writeCountAfterFirst = (stdout.write as any).callCount as number;
+
+	// Same coordinates → deduplicated, no additional write.
+	controller.setSelection({sx: 0, sy: 0, ex: 4, ey: 0});
+
+	t.is((stdout.write as any).callCount, writeCountAfterFirst);
+
+	unmount();
+});
+
+test('subscribe receives the composited frame', t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	let received: number | undefined;
+
+	const unsubscribe = controller.subscribe(frame => {
+		received = frame.height;
+	});
+
+	// A selection change schedules a repaint, which publishes a new frame.
+	controller.setSelection({sx: 0, sy: 0, ex: 1, ey: 0});
+
+	t.is(received, 1);
+
+	unsubscribe();
+	unmount();
+});
+
+test('text nodes sharing a selectionFlow share a flowId', t => {
+	const stdout = createStdout();
+	const {unmount} = render(
+		<Box>
+			<Text selectionFlow="group">A</Text>
+			<Text selectionFlow="group">B</Text>
+		</Box>,
+		{stdout, debug: true},
+	);
+
+	const row = getFrameController(stdout)!.getFrame()!.cells[0]!;
+	const aCell = row.find(cell => cell.value === 'A')!;
+	const bCell = row.find(cell => cell.value === 'B')!;
+
+	t.is(typeof aCell.flowId, 'number');
+	t.is(aCell.flowId, bCell.flowId);
+
+	unmount();
+});
+
+test('text nodes without a shared selectionFlow get distinct flowIds', t => {
+	const stdout = createStdout();
+	const {unmount} = render(
+		<Box>
+			<Text>A</Text>
+			<Text>B</Text>
+		</Box>,
+		{stdout, debug: true},
+	);
+
+	const row = getFrameController(stdout)!.getFrame()!.cells[0]!;
+	const aCell = row.find(cell => cell.value === 'A')!;
+	const bCell = row.find(cell => cell.value === 'B')!;
+
+	t.not(aCell.flowId, bCell.flowId);
+
+	unmount();
+});
+
+test('selectionBreakAfter="hard" records a hard boundary', t => {
+	const stdout = createStdout();
+	const {unmount} = render(
+		<Box>
+			<Text selectionBreakAfter="hard">A</Text>
+		</Box>,
+		{stdout, debug: true},
+	);
+
+	const {boundaries} = getFrameController(stdout)!.getFrame()!;
+	const hasHardBoundary = boundaries.some(row =>
+		row.some(boundary => boundary?.kind === 'hard'),
+	);
+
+	t.true(hasHardBoundary);
+
+	unmount();
+});


### PR DESCRIPTION
## Problem

### Background: why full-screen TUIs need virtual scrolling

Long-running interactive applications — coding assistants, chat clients, log viewers — accumulate content that far exceeds the terminal height. A single Qwen Code session can produce thousands of lines of conversation, tool output, and code blocks. Rendering all of this into the terminal's scrollback buffer creates two problems:

- **Performance.** Every re-render (on each keystroke, streaming token, or state change) requires Ink to erase and repaint the entire output region. With hundreds of lines in the scrollback, this causes visible flicker and high CPU usage. The terminal must process thousands of ANSI erase/write sequences per frame.
- **Layout control.** The application cannot anchor UI elements (input prompt, status bar, sticky panels) to fixed screen positions when the output region grows unboundedly into the scrollback.

**Virtual scrolling** solves both: the application enters **alternate-screen mode** (`?1049h`) to get a fixed-size viewport, then only renders the visible slice of content. As the user scrolls, the viewport window moves over the full dataset and the render output is recycled — much like a virtualized list in a GUI framework. The terminal sees a constant-height frame, eliminating flicker and enabling precise layout.

### The selection problem

Alternate-screen mode and virtual scrolling together **break text selection**, which is a basic user expectation:

1. **The scrollback buffer is empty.** The alternate screen (`?1049h`) is a separate, fixed-size buffer with no scrollback history. Terminal emulators' native selection (click-drag, double-click word select, etc.) operates on the scrollback buffer. In alternate-screen mode there is nothing to select from — the content exists only as the current frame, which the terminal treats as ephemeral (by design — think vim, htop, less).

2. **Virtual scrolling means the full content is never on screen.** Even if a terminal emulator supports selection within the alternate screen, it can only select what's currently rendered in the viewport. Content that has been scrolled off is not in any terminal buffer — it exists only in the application's data model. Selecting across a range that spans multiple viewport-fuls of content is impossible through terminal-native mechanisms.

3. **Ink's render pipeline is opaque to the application.** Ink composites the yoga layout tree into a string of ANSI sequences and writes it to stdout. The application has no structured access to what's actually on screen — which characters are at which cell coordinates, which are selectable, how lines wrap and flow. Without this information, the application cannot implement its own selection that maps mouse coordinates to logical text content.

The result: users of full-screen Ink TUIs **cannot select and copy text** — code blocks, error messages, conversation content. For a coding assistant where copying generated code is a core workflow, this is a critical usability gap.

## Solution

This PR adds a **frame-level cell composition system** that gives applications structured, per-cell access to the rendered frame, enabling mouse-driven text selection within Ink's rendering pipeline.

The key insight: Ink already walks the yoga tree and writes styled characters into an `Output` grid during rendering. This PR extends that grid with per-cell metadata (selectability, reading-flow grouping, line-break semantics) and exposes it through a `FrameController` bridge:

```
Application                          Ink Renderer
    |                                     |
    |-- setSelection({sx,sy,ex,ey}) ---->|  (schedules repaint)
    |                                     |
    |<---- publishFrame(cells[][]) -------|  (after each render)
    |                                     |
    |-- getFrame() / subscribe() -------->|  (read latest frame)
```

The application handles mouse events and selection logic; Ink provides the composited frame data and applies the selection highlight during serialization. Selection is a pure render-time concern — it never mutates committed frame state.

## Public API

### `getFrameController(stdout): FrameController | undefined`

Access the frame controller for a render instance (via the existing `instances` map).

### `FrameController`

| Method | Description |
|--------|-------------|
| `getFrame(): ReadonlyFrame \| null` | Latest composited frame (cells + boundaries) |
| `getSelection(): ScreenSelection \| null` | Current selection coordinates |
| `setSelection(sel \| null): void` | Update selection, schedule repaint if changed |
| `subscribe(listener): () => void` | Observe frame publications |

### `FrameCell`

Each cell in the composited grid carries:
- `type`, `value`, `fullWidth`, `styles` — existing styled character data
- `selectable: boolean` — whether this cell participates in selection
- `flowId: number | null` — logical reading flow grouping

### New `<Text>` props

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `selectable` | `boolean` | `true` | Whether the text participates in selection |
| `selectionFlow` | `string` | — | Group texts into a logical reading flow |
| `selectionBreakAfter` | `'soft' \| 'hard'` | — | How the line break after this text behaves during copy |
| `selectionJoiner` | `string` | `''` | Joiner inserted when reconstructing across this break |

## Internal changes

- **`Output.get(selection?)`** — returns `{output, height, cells, boundaries}`. Cells carry selectable/flowId metadata. When a selection is provided, selected cells get a highlight background applied before serialization.
- **`renderNodeToOutput`** — threads `flowIds`/`nextFlowId` maps through the tree. Uses `wrapTextWithMetadata` instead of plain `wrapText` to track soft/hard line boundaries and per-row selectability.
- **`wrapTextWithMetadata`** — wraps text and returns `{text, boundaries: TextBoundary[], selectableRows: boolean[]}` for semantic copy reconstruction.
- **`renderer`** — accepts an optional `selection` parameter, creates flow tracking state, returns `cells`/`boundaries` alongside the string output.
- **`Ink` class** — creates a `FrameController` in the constructor, publishes frames after each render, reads selection state for highlight.

## Testing

All 86 existing component tests pass. The feature is additive — no existing behavior changes when selection is not used.

This feature has been running in production in Qwen Code's TUI (via a patch on ink 7.0.3) for several months, supporting text selection in a full-screen alternate-screen TUI with virtual scrolling.
