### PR TITLE
Add `getFrameController()` for application-owned text selection

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2962,6 +2962,57 @@ const Example = () => {
 render(<Example />);
 ```
 
+#### getFrameController(stdout)
+
+Returns the `FrameController` of the Ink instance rendering to `stdout`, or `undefined` when there is none.
+
+The frame controller is a bridge for applications that own their input and implement text selection themselves, for example alternate-screen apps that handle mouse events. The app subscribes to composited frames to read what is on screen, and pushes a selection, which Ink highlights before serialization.
+
+```jsx
+import {render, Text, getFrameController} from 'ink';
+
+const {unmount} = render(<Text>Hello World</Text>);
+
+const controller = getFrameController(process.stdout);
+
+const unsubscribe = controller.subscribe(frame => {
+	// frame.cells[y][x] is the cell at column x of row y
+});
+
+controller.setSelection({sx: 0, sy: 0, ex: 4, ey: 0});
+```
+
+Frames are only generated while at least one subscriber is registered, so apps that never use the frame controller pay no overhead. Listeners are notified outside of the render pass and notifications are coalesced, so a listener can safely call `setSelection()` without re-entering rendering or observing frames out of order.
+
+##### stdout
+
+Type: `NodeJS.WriteStream`
+
+The output stream an Ink instance renders to, usually `process.stdout`.
+
+##### controller.getFrame()
+
+Returns the latest composited frame, or `undefined` when no frame has been published yet.
+
+A frame is a read-only grid of cells: `frame.cells[y][x]` is the cell at column `x` of row `y`, with `(0, 0)` at the top-left of Ink's output region and `frame.width`/`frame.height` the grid dimensions. Each cell exposes `value` (the character, or `''` for the trailing half of a wide character) and `fullWidth` (`true` for wide characters such as CJK, which occupy two cells). To extract the text of a region, concatenate cell values and skip the ones with an empty `value`.
+
+> [!NOTE]
+> Cell coordinates are positions in Ink's output region, not terminal viewport coordinates. To map a mouse event to a cell, convert the event coordinates by the viewport position of the output region, like with [`measureElement()`](#measureelementref).
+
+##### controller.getSelection()
+
+Returns the current selection in reading order, or `undefined` when there is none.
+
+##### controller.setSelection(selection)
+
+Highlights `selection` and schedules a repaint through Ink's regular render throttle. Setting an identical selection is a no-op, and passing `undefined` clears the highlight.
+
+Selections are stored in reading order: `(sx, sy)` is the first selected cell and `(ex, ey)` the last one. Reverse selections (right-to-left or bottom-to-top drags) are normalized, so they select the same region as forward drags. The region covers whole rows between the first and last row, and is partial on the first and last row.
+
+##### controller.subscribe(listener)
+
+Subscribes to composited frames. `listener` receives the frame after each render. Subscribing schedules a render, so the listener receives the current frame even when nothing else triggers one. Returns an unsubscribe function.
+
 ## Testing
 
 Ink components are simple to test with [ink-testing-library](https://github.com/vadimdemedes/ink-testing-library).

--- a/src/frame-controller.ts
+++ b/src/frame-controller.ts
@@ -1,0 +1,201 @@
+import instances from './instances.js';
+
+/**
+A selection region in the composited frame. Coordinates are zero-based cell
+positions and are always stored in reading order: `(sx, sy)` is the
+first selected cell and `(ex, ey)` the last one, so reverse (right-to-left or
+bottom-to-top) drags select the same region as forward drags.
+*/
+export type ScreenSelection = {
+	readonly sx: number;
+	readonly sy: number;
+	readonly ex: number;
+	readonly ey: number;
+};
+
+/**
+A single cell of the composited frame. Wide characters (e.g. CJK) occupy two
+cells: the leading cell has `fullWidth` set to `true` and carries the
+character, while the trailing placeholder cell has an empty `value`. Skip
+cells with an empty `value` when extracting text.
+*/
+export type FrameCell = {
+	readonly value: string;
+	readonly fullWidth: boolean;
+};
+
+/**
+A read-only snapshot of the composited frame. `cells[y][x]` is the cell at
+column `x` of row `y`, with `(0, 0)` at the top-left of Ink's output region.
+*/
+export type ReadonlyFrame = {
+	readonly width: number;
+	readonly height: number;
+	readonly cells: ReadonlyArray<readonly FrameCell[]>;
+};
+
+/**
+Bridge between an application that owns its input (for example an
+alternate-screen app handling mouse events itself) and the renderer: the app
+subscribes to composited frames and pushes a selection, which Ink highlights
+before serialization.
+
+Frames are only generated while at least one subscriber is registered, so
+apps that never subscribe pay no overhead. Listeners are notified outside of
+the render pass and notifications are coalesced, so a listener cannot
+re-enter rendering or observe frames out of order.
+*/
+export type FrameController = {
+	/**
+	Returns the latest composited frame, or `undefined` when no frame has been
+	published yet. Frames are only generated while subscribers are registered.
+	*/
+	getFrame(): ReadonlyFrame | undefined;
+
+	/**
+	Returns the current selection in reading order, or `undefined` when there
+	is none.
+	*/
+	getSelection(): ScreenSelection | undefined;
+
+	/**
+	Highlights the given selection region (or clears it with `undefined`) and
+	schedules a repaint through Ink's regular render throttle. Reverse
+	selections are normalized to reading order. Setting an identical selection
+	is a no-op.
+	*/
+	setSelection(selection: ScreenSelection | undefined): void;
+
+	/**
+	Subscribes to composited frames. Schedules a render so the listener
+	receives the current frame even when nothing else triggers one. Returns an
+	unsubscribe function.
+	*/
+	subscribe(listener: (frame: ReadonlyFrame) => void): () => void;
+};
+
+type FrameListener = (frame: ReadonlyFrame) => void;
+
+export type InternalFrameController = FrameController & {
+	/**
+	Whether frames should be generated on the next render.
+	*/
+	hasSubscribers(): boolean;
+
+	/**
+	Publishes the composited cells of the frame that was just rendered.
+	*/
+	publishFrame(cells: ReadonlyArray<readonly FrameCell[]>): void;
+};
+
+// Normalizes the selection to reading order so reverse drags select the same
+// region as forward drags.
+const normalizeSelection = (selection: ScreenSelection): ScreenSelection => {
+	let {sx, sy, ex, ey} = selection;
+
+	if (sy > ey || (sy === ey && sx > ex)) {
+		[sx, ex] = [ex, sx];
+		[sy, ey] = [ey, sy];
+	}
+
+	return {sx, sy, ex, ey};
+};
+
+const sameSelection = (
+	a: ScreenSelection | undefined,
+	b: ScreenSelection | undefined,
+): boolean => {
+	if (a === b) {
+		return true;
+	}
+
+	if (!a || !b) {
+		return false;
+	}
+
+	return a.sx === b.sx && a.sy === b.sy && a.ex === b.ex && a.ey === b.ey;
+};
+
+export const createFrameController = (
+	requestRender: () => void,
+): InternalFrameController => {
+	let currentSelection: ScreenSelection | undefined;
+	let lastFrame: ReadonlyFrame | undefined;
+	const listeners = new Set<FrameListener>();
+	let notificationScheduled = false;
+
+	// Runs in a microtask, after the render that published the frame has fully
+	// completed. A listener calling setSelection() from here schedules a new
+	// render instead of re-entering the one in flight.
+	const notifyListeners = () => {
+		notificationScheduled = false;
+
+		const frame = lastFrame;
+
+		if (!frame) {
+			return;
+		}
+
+		// Iterating the live set is safe here: listeners removed during
+		// notification are skipped, and setSelection() calls from a listener
+		// only schedule a new render.
+		for (const listener of listeners) {
+			listener(frame);
+		}
+	};
+
+	return {
+		getFrame: () => lastFrame,
+		getSelection: () => currentSelection,
+		setSelection(selection) {
+			const normalized = selection ? normalizeSelection(selection) : undefined;
+
+			if (sameSelection(currentSelection, normalized)) {
+				return;
+			}
+
+			currentSelection = normalized;
+			requestRender();
+		},
+		subscribe(listener) {
+			listeners.add(listener);
+
+			// Deliver the current frame even if nothing else triggers a render.
+			requestRender();
+
+			return () => {
+				listeners.delete(listener);
+			};
+		},
+		hasSubscribers: () => listeners.size > 0,
+		publishFrame(cells) {
+			let width = 0;
+
+			for (const row of cells) {
+				width = Math.max(width, row.length);
+			}
+
+			const frame: ReadonlyFrame = {width, height: cells.length, cells};
+
+			for (const row of cells) {
+				Object.freeze(row);
+			}
+
+			Object.freeze(frame);
+			lastFrame = frame;
+
+			if (listeners.size > 0 && !notificationScheduled) {
+				notificationScheduled = true;
+				queueMicrotask(notifyListeners);
+			}
+		},
+	};
+};
+
+/**
+Returns the frame controller of the Ink instance rendering to `stdout`, or
+`undefined` when there is none.
+*/
+export const getFrameController = (
+	stdout: NodeJS.WriteStream,
+): FrameController | undefined => instances.get(stdout)?.frameController;

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,3 +44,10 @@ export type {ElementMetrics} from './measure-element.js';
 export type {DOMElement} from './dom.js';
 export {kittyFlags, kittyModifiers} from './kitty-keyboard.js';
 export type {KittyKeyboardOptions, KittyFlagName} from './kitty-keyboard.js';
+export {getFrameController} from './frame-controller.js';
+export type {
+	FrameController,
+	ReadonlyFrame,
+	FrameCell,
+	ScreenSelection,
+} from './frame-controller.js';

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -18,6 +18,10 @@ import {hideCursorEscape, showCursorEscape} from './cursor-helpers.js';
 import logUpdate, {type LogUpdate, type CursorPosition} from './log-update.js';
 import {bsu, esu, shouldSynchronize} from './write-synchronized.js';
 import instances from './instances.js';
+import {
+	createFrameController,
+	type InternalFrameController,
+} from './frame-controller.js';
 import App from './components/App.js';
 import {type TerminalSuspension} from './components/AppContext.js';
 import {accessibilityContext as AccessibilityContext} from './components/AccessibilityContext.js';
@@ -293,6 +297,11 @@ export default class Ink {
 	*/
 	readonly isConcurrent: boolean;
 
+	/**
+	Bridge for application-owned text selection. See `getFrameController`.
+	*/
+	readonly frameController: InternalFrameController;
+
 	private readonly options: Options;
 	private readonly log: LogUpdate;
 	private cursorPosition: CursorPosition | undefined;
@@ -378,6 +387,15 @@ export default class Ink {
 		}
 
 		this.rootNode.onImmediateRender = this.onRender;
+
+		// Bridge for application-owned text selection: apps subscribe to composited
+		// frames and push a selection, which is highlighted before serialization
+		// (see onRender). Repaints scheduled by the controller go through the same
+		// (throttled) render path as regular updates.
+		this.frameController = createFrameController(() => {
+			this.rootNode.onRender?.();
+		});
+
 		this.rootNode.onStaticChange = this.handleStaticChange;
 		this.log = logUpdate.create(options.stdout, {
 			incremental: options.incrementalRendering,
@@ -567,10 +585,20 @@ export default class Ink {
 		}
 
 		const startTime = performance.now();
-		const {output, outputHeight, staticOutput} = render(
+		const {output, outputHeight, staticOutput, cells} = render(
 			this.rootNode,
 			this.isScreenReaderEnabled,
+			{
+				selection: this.frameController.getSelection(),
+				// Cells are only projected when a frame consumer subscribed, so
+				// apps that never use the frame controller pay no overhead.
+				captureCells: this.frameController.hasSubscribers(),
+			},
 		);
+
+		if (cells) {
+			this.frameController.publishFrame(cells);
+		}
 
 		this.options.onRender?.({renderTime: performance.now() - startTime});
 
@@ -1112,6 +1140,12 @@ export default class Ink {
 		outputHeight: number,
 		staticOutput: string,
 	): void {
+		// Re-assert the app's cursor intent on every interactive render: log-update
+		// only applies a cursor position set since the previous render, so without
+		// this a repaint triggered by setSelection() would leave the cursor at the
+		// end of the output instead of where useCursor() placed it.
+		this.log.setCursorPosition(this.cursorPosition);
+
 		const hasStaticOutput = staticOutput !== '';
 		const isTty = this.options.stdout.isTTY;
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,12 +1,49 @@
 import sliceAnsi from 'slice-ansi';
 import stringWidth from 'string-width';
 import {
+	type AnsiCode,
 	type StyledChar,
 	styledCharsFromTokens,
 	styledCharsToString,
 	tokenize,
 } from '@alcalzone/ansi-tokenize';
 import {type OutputTransformer} from './render-node-to-output.js';
+import {type FrameCell, type ScreenSelection} from './frame-controller.js';
+
+// Background applied to selected cells. Appended after a cell's existing styles
+// so the foreground is preserved and this background wins at the terminal.
+const selectionBackground: AnsiCode = {
+	type: 'ansi',
+	code: '\u001B[48;5;240m',
+	endCode: '\u001B[49m',
+};
+
+// Linear reading-order selection: whole rows between the first and last, partial
+// on the first/last row. Coordinates are screen cells in the composited frame;
+// the frame controller normalizes selections to reading order before they get here.
+const isCellSelected = (
+	x: number,
+	y: number,
+	selection: ScreenSelection,
+): boolean => {
+	if (y < selection.sy || y > selection.ey) {
+		return false;
+	}
+
+	if (selection.sy === selection.ey) {
+		return x >= selection.sx && x <= selection.ex;
+	}
+
+	if (y === selection.sy) {
+		return x >= selection.sx;
+	}
+
+	if (y === selection.ey) {
+		return x <= selection.ex;
+	}
+
+	return true;
+};
 
 /**
 "Virtual" output class
@@ -136,7 +173,10 @@ export default class Output {
 		});
 	}
 
-	get(): {output: string; height: number} {
+	get(
+		selection?: ScreenSelection,
+		captureCells = false,
+	): {output: string; height: number; cells?: FrameCell[][]} {
 		// Initialize output array with a specific set of rows, so that margin/padding at the bottom is preserved
 		const output: StyledChar[][] = [];
 
@@ -302,6 +342,47 @@ export default class Output {
 			}
 		}
 
+		// Apply the selection highlight before serialization. Selected slots are
+		// replaced with new cell objects (never mutated in place) because cells
+		// reference StyledChar objects cached and shared across identical lines,
+		// so mutating one would leak the highlight onto other on-screen text.
+		if (selection) {
+			for (const [y, row] of output.entries()) {
+				for (let x = 0; x < row.length; x++) {
+					if (!isCellSelected(x, y, selection)) {
+						continue;
+					}
+
+					const cell = row[x];
+
+					if (cell) {
+						row[x] = {
+							...cell,
+							styles: [...cell.styles, selectionBackground],
+						};
+					}
+				}
+			}
+		}
+
+		// Project the composited cells for frame consumers, stripping internal
+		// style data. Only runs when a consumer opted in via subscribe(), so the
+		// default render path pays no extra cost.
+		const cells = captureCells
+			? output.map(row => {
+					const frameRow: FrameCell[] = [];
+
+					for (const cell of row) {
+						frameRow.push({
+							value: cell?.value ?? ' ',
+							fullWidth: cell?.fullWidth ?? false,
+						});
+					}
+
+					return frameRow;
+				})
+			: undefined;
+
 		const generatedOutput = output
 			.map(line => {
 				// See https://github.com/vadimdemedes/ink/pull/564#issuecomment-1637022742
@@ -314,6 +395,7 @@ export default class Output {
 		return {
 			output: generatedOutput,
 			height: output.length,
+			cells,
 		};
 	}
 }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -3,14 +3,35 @@ import renderNodeToOutput, {
 } from './render-node-to-output.js';
 import Output from './output.js';
 import {type DOMElement} from './dom.js';
+import {type FrameCell, type ScreenSelection} from './frame-controller.js';
 
 type Result = {
 	output: string;
 	outputHeight: number;
 	staticOutput: string;
+	cells?: FrameCell[][];
 };
 
-const renderer = (node: DOMElement, isScreenReaderEnabled: boolean): Result => {
+type Options = {
+	/**
+	Selection region to highlight before serialization.
+	*/
+	selection?: ScreenSelection;
+
+	/**
+	Whether to expose the composited cells in the result. Only enabled when a
+	frame consumer subscribed to the frame controller.
+	*/
+	captureCells?: boolean;
+};
+
+const renderer = (
+	node: DOMElement,
+	isScreenReaderEnabled: boolean,
+	options: Options = {},
+): Result => {
+	const {selection, captureCells} = options;
+
 	if (node.yogaNode) {
 		if (isScreenReaderEnabled) {
 			const output = renderNodeToScreenReaderOutput(node, {
@@ -56,7 +77,11 @@ const renderer = (node: DOMElement, isScreenReaderEnabled: boolean): Result => {
 			});
 		}
 
-		const {output: generatedOutput, height: outputHeight} = output.get();
+		const {
+			output: generatedOutput,
+			height: outputHeight,
+			cells,
+		} = output.get(selection, captureCells);
 
 		return {
 			output: generatedOutput,
@@ -64,6 +89,7 @@ const renderer = (node: DOMElement, isScreenReaderEnabled: boolean): Result => {
 			// Newline at the end is needed, because static output doesn't have one, so
 			// interactive output will override last line of static output
 			staticOutput: staticOutput ? `${staticOutput.get().output}\n` : '',
+			cells,
 		};
 	}
 

--- a/test/selection.tsx
+++ b/test/selection.tsx
@@ -1,0 +1,293 @@
+import test from 'ava';
+import React from 'react';
+import {Box, Text, render, getFrameController} from '../src/index.js';
+import createStdout from './helpers/create-stdout.js';
+
+// Background applied to selected cells (see output.ts). Built from the escape
+// code so this test does not depend on a raw control character in the source.
+const selectionHighlight = `${String.fromCodePoint(27)}[48;5;240m`;
+
+// Frame notifications are deferred to a microtask, so tests await this to let
+// every scheduled notification (and the renders it may trigger) settle.
+const settle = async () => {
+	await new Promise<void>(resolve => {
+		setImmediate(resolve);
+	});
+};
+
+const writeCount = (stdout: ReturnType<typeof createStdout>): number =>
+	(stdout.write as any).callCount as number;
+
+test('getFrameController returns undefined for an unknown stdout', t => {
+	const stdout = createStdout();
+	t.is(getFrameController(stdout), undefined);
+});
+
+test('getFrameController returns a controller after render', t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	t.truthy(getFrameController(stdout));
+
+	unmount();
+});
+
+test('no frame is generated while there are no subscribers', t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	// Nothing subscribed during the render, so no cells were projected.
+	t.is(getFrameController(stdout)!.getFrame(), undefined);
+
+	unmount();
+});
+
+test('subscribe opts into frame generation and receives the current frame', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	const frames: number[] = [];
+	const unsubscribe = controller.subscribe(frame => {
+		frames.push(frame.height);
+	});
+
+	// Subscribing schedules a render so late subscribers still get a frame.
+	await settle();
+
+	t.deepEqual(frames, [1]);
+
+	const frame = controller.getFrame();
+	t.truthy(frame);
+	t.is(frame!.height, 1);
+	t.is(frame!.width, frame!.cells[0]!.length);
+
+	unsubscribe();
+	unmount();
+});
+
+test('listeners are notified outside of the render pass', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	let notifications = 0;
+
+	controller.subscribe(() => {
+		notifications++;
+	});
+
+	// The render triggered by subscribe() already ran synchronously (debug
+	// mode), but the notification is deferred.
+	t.is(notifications, 0);
+
+	await settle();
+	t.is(notifications, 1);
+
+	unmount();
+});
+
+test('getFrame exposes the composited cells', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hi</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	const row = controller.getFrame()!.cells[0]!;
+	t.is(row[0]!.value, 'H');
+	t.false(row[0]!.fullWidth);
+	t.is(row[1]!.value, 'i');
+
+	unmount();
+});
+
+test('frames are published on subsequent renders', async t => {
+	const stdout = createStdout();
+	const instance = render(<Text>A</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	instance.rerender(<Text>BB</Text>);
+	await settle();
+
+	const row = controller.getFrame()!.cells[0]!;
+	t.is(row[0]!.value, 'B');
+	t.is(row[1]!.value, 'B');
+
+	instance.unmount();
+});
+
+test('wide characters occupy two cells', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>你好</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	const row = controller.getFrame()!.cells[0]!;
+	t.is(row[0]!.value, '你');
+	t.true(row[0]!.fullWidth);
+	// Trailing placeholder of a wide character.
+	t.is(row[1]!.value, '');
+	t.false(row[1]!.fullWidth);
+	t.is(row[2]!.value, '好');
+	t.true(row[2]!.fullWidth);
+	t.is(row[3]!.value, '');
+
+	// Text extraction skips placeholder cells; trailing cells pad the row to
+	// the frame width with spaces.
+	const extracted = row
+		.map(cell => cell.value)
+		.join('')
+		.replace(/ +$/u, '');
+	t.is(extracted, '你好');
+
+	unmount();
+});
+
+test('setSelection highlights the selected cells', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	t.false(stdout.get().includes(selectionHighlight));
+
+	controller.setSelection({sx: 0, sy: 0, ex: 4, ey: 0});
+
+	t.true(stdout.get().includes(selectionHighlight));
+
+	unmount();
+});
+
+test('clearing the selection removes the highlight', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	controller.setSelection({sx: 0, sy: 0, ex: 4, ey: 0});
+	t.true(stdout.get().includes(selectionHighlight));
+
+	controller.setSelection(undefined);
+	t.false(stdout.get().includes(selectionHighlight));
+
+	unmount();
+});
+
+test('selections spanning multiple rows highlight whole middle rows', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(
+		<Box flexDirection="column">
+			<Text>aaaa</Text>
+			<Text>bbbb</Text>
+			<Text>cccc</Text>
+		</Box>,
+		{stdout, debug: true},
+	);
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	controller.setSelection({sx: 2, sy: 0, ex: 1, ey: 2});
+	await settle();
+
+	const highlighted = stdout.get();
+	const [first = '', middle = '', last = ''] = highlighted.split('\n');
+
+	// First row is selected from column 2, last row up to column 1, and the
+	// whole middle row is selected.
+	t.true(first.includes(selectionHighlight + 'aa'));
+	t.true(middle.startsWith(selectionHighlight));
+	t.true(last.includes(selectionHighlight + 'cc'));
+	t.false(last.includes(selectionHighlight + 'cccc'));
+
+	unmount();
+});
+
+test('reverse selections are normalized to reading order', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	// Right-to-left drag over the same region.
+	controller.setSelection({sx: 4, sy: 0, ex: 0, ey: 0});
+
+	t.deepEqual(controller.getSelection(), {sx: 0, sy: 0, ex: 4, ey: 0});
+
+	const reverseOutput = stdout.get();
+	t.true(reverseOutput.includes(selectionHighlight));
+
+	controller.setSelection(undefined);
+	controller.setSelection({sx: 0, sy: 0, ex: 4, ey: 0});
+
+	// The highlight is identical to a forward selection over the same region.
+	t.is(stdout.get(), reverseOutput);
+
+	unmount();
+});
+
+test('setting an identical selection does not trigger a repaint', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	controller.setSelection({sx: 0, sy: 0, ex: 4, ey: 0});
+	const writesAfterFirst = writeCount(stdout);
+
+	controller.setSelection({sx: 0, sy: 0, ex: 4, ey: 0});
+	t.is(writeCount(stdout), writesAfterFirst);
+
+	// The reverse spelling of the same region normalizes to it and is a no-op too.
+	controller.setSelection({sx: 4, sy: 0, ex: 0, ey: 0});
+	t.is(writeCount(stdout), writesAfterFirst);
+
+	unmount();
+});
+
+test('a subscriber calling setSelection does not re-enter rendering', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	const frames: number[] = [];
+	let reentered = false;
+
+	controller.subscribe(frame => {
+		frames.push(frame.height);
+
+		// A listener that mutates the selection schedules a new render, which
+		// publishes another frame. This must not throw or interleave frames.
+		if (!reentered) {
+			reentered = true;
+			controller.setSelection({sx: 0, sy: 0, ex: 1, ey: 0});
+		}
+	});
+
+	await settle();
+
+	// One notification per published frame: the render scheduled by
+	// subscribe() and the one triggered by setSelection(). The initial render
+	// published nothing because there were no subscribers yet.
+	t.is(frames.length, 2);
+	t.true(reentered);
+	t.true(stdout.get().includes(selectionHighlight));
+
+	unmount();
+});

--- a/test/selection.tsx
+++ b/test/selection.tsx
@@ -291,3 +291,49 @@ test('a subscriber calling setSelection does not re-enter rendering', async t =>
 
 	unmount();
 });
+
+test('getFrameController returns undefined after unmount', t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	t.truthy(getFrameController(stdout));
+
+	unmount();
+
+	t.is(getFrameController(stdout), undefined);
+});
+
+test('selection highlight reaches the terminal in interactive (non-debug) mode', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {
+		stdout,
+		interactive: true,
+	});
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	controller.setSelection({sx: 0, sy: 0, ex: 4, ey: 0});
+
+	// Renders are throttled (default maxFps), so give the repaint time to land.
+	await new Promise<void>(resolve => {
+		setTimeout(resolve, 150);
+	});
+
+	// Interactive renders write bsu/content/esu as separate writes, so look at
+	// the last render's writes rather than only the final one.
+	const lastRender = () => stdout.getWrites().slice(-3).join('');
+
+	t.true(lastRender().includes(selectionHighlight));
+
+	controller.setSelection(undefined);
+
+	await new Promise<void>(resolve => {
+		setTimeout(resolve, 150);
+	});
+
+	t.false(lastRender().includes(selectionHighlight));
+
+	unmount();
+});


### PR DESCRIPTION
This is the first part of the split suggested in #980: a small, opt-in, read-only frame controller for apps that own their alternate-screen viewport and implement selection themselves. Selection semantics for `Text` (flows, boundaries, `selectable` and friends) are left for a follow-up once the bridge is proven by a real consumer.

**What's included**

- `getFrameController(stdout)` with:
  - `getFrame()` — a read-only `cells[y][x]` grid; each cell exposes only `value` + `fullWidth`. Wide characters occupy two cells: the leading cell has `fullWidth: true`, the trailing placeholder has an empty `value`. No internal style data is exposed.
  - `getSelection()` / `setSelection()` — Ink highlights the region before serialization. Repaints go through the regular render throttle, and identical selections are deduplicated.
  - `subscribe()` — frame listener, returning an unsubscribe function.
- Selection coordinates are zero-based cell positions in Ink's output region, normalized to reading order — reverse (right-to-left or bottom-to-top) drags select the same region as forward drags.
- Readme docs covering the API and coordinate semantics.

**Concerns from #980 addressed**

1. *Per-render overhead* — cells are only projected while subscribers exist, so apps that never use the frame controller pay no overhead.
2. *Subscriber reentrancy* — listeners run in a microtask after the publishing render completes; a `setSelection()` call from a listener schedules a new render instead of re-entering the one in flight; notifications are coalesced and frames delivered in order.
3. *API surface* — frame publishing stays internal (`getFrameController` returns the read-only view); no internal style data is exposed; frames and rows are frozen and deeply readonly-typed.
4. *Reverse selections* — normalized in `setSelection()`, covered by tests.
5. *Tests* — 14 tests covering opt-in behavior, async delivery, wide characters, multi-row regions, reverse selections, dedupe, and subscriber reentrancy. The nested-text metadata concern from #980 doesn't apply here because this PR adds no semantic `Text` props.

**Also included**

`renderInteractiveFrame` re-asserts the app's current cursor intent before each interactive render: log-update only applies a cursor position set since the previous render, so without this a repaint triggered by `setSelection()` would move the cursor from its `useCursor()` position to the end of the output.

The alternate-screen `clearTerminal` from #980 is deliberately not included here: it's an unrelated behavior change and can be a separate proposal if desired.
