### PR TITLE
Add selection semantics: flows, boundaries, and semantic Text props

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -406,6 +406,52 @@ If `truncate-*` is passed, Ink will truncate text instead, resulting in one line
 //=> '…World'
 ```
 
+#### selectable
+
+Type: `boolean`\
+Default: `true`
+
+Whether the text is selectable through the [frame controller](#getframecontrollerstdout). Nested `<Text>` nodes override the value inherited from their parent, so a non-selectable region inside selectable text (and vice versa) is reported per cell. Non-selectable cells are skipped by the selection highlight and should be excluded when extracting copied text.
+
+```jsx
+<Text>
+	Copy this, <Text selectable={false}>but not this</Text>, and this.
+</Text>
+```
+
+#### selectionFlow
+
+Type: `unknown`
+
+Groups text nodes into one selection unit: cells of text nodes sharing the same flow key carry the same `flowId` in the composited frame. By default every top-level `<Text>` is its own flow.
+
+```jsx
+<Text selectionFlow="message">First part </Text>
+<Text selectionFlow="message">second part</Text>
+```
+
+#### selectionBreakAfter
+
+Type: `string`\
+Allowed values: `soft` `hard`
+
+Inserts a boundary after the text node, recorded in the frame's `boundaries` grid so consumers know how adjacent text joins when copied. `'soft'` joins with the surrounding text (with `selectionJoiner` as the joiner), `'hard'` starts a new line.
+
+#### selectionJoiner
+
+Type: `string`\
+Default: `''` for `soft`, `'\n'` for `hard`
+
+Custom joiner string used when `selectionBreakAfter` is set.
+
+```jsx
+<Box flexDirection="column">
+	<Text selectionBreakAfter="soft" selectionJoiner=" | ">Row one</Text>
+	<Text>Row two</Text>
+</Box>
+// Copying both rows yields 'Row one | Row two'
+```
+
 ### `<Box>`
 
 `<Box>` is an essential Ink component to build your layout.
@@ -2994,7 +3040,14 @@ The output stream an Ink instance renders to, usually `process.stdout`.
 
 Returns the latest composited frame, or `undefined` when no frame has been published yet.
 
-A frame is a read-only grid of cells: `frame.cells[y][x]` is the cell at column `x` of row `y`, with `(0, 0)` at the top-left of Ink's output region and `frame.width`/`frame.height` the grid dimensions. Each cell exposes `value` (the character, or `''` for the trailing half of a wide character) and `fullWidth` (`true` for wide characters such as CJK, which occupy two cells). To extract the text of a region, concatenate cell values and skip the ones with an empty `value`.
+A frame is a read-only grid of cells: `frame.cells[y][x]` is the cell at column `x` of row `y`, with `(0, 0)` at the top-left of Ink's output region and `frame.width`/`frame.height` the grid dimensions. Each cell exposes:
+
+- `value` — the character, or `''` for the trailing half of a wide character. To extract the text of a region, concatenate cell values and skip the ones with an empty `value`.
+- `fullWidth` — `true` for wide characters such as CJK, which occupy two cells.
+- `selectable` — `false` for text rendered with `selectable={false}` and for non-text content such as box backgrounds; `true` otherwise. Selections (and text extraction) should skip non-selectable cells.
+- `flowId` — identifies the selection flow the cell belongs to (see [`selectionFlow`](#selectionflow)). Cells sharing a `flowId` form one selection unit. Flow ids are stable within a frame but may change between renders.
+
+`frame.boundaries[y][x]` is the boundary immediately after that cell, if any. A boundary tells consumers how the text after it joins when copied: `'soft'` boundaries join with their `joiner` (the whitespace consumed by wrapping, or the `selectionJoiner` of a [`selectionBreakAfter="soft"`](#selectionbreakafter) node), `'hard'` boundaries start a new line.
 
 > [!NOTE]
 > Cell coordinates are positions in Ink's output region, not terminal viewport coordinates. To map a mouse event to a cell, convert the event coordinates by the viewport position of the output region, like with [`measureElement()`](#measureelementref).

--- a/readme.md
+++ b/readme.md
@@ -2962,6 +2962,57 @@ const Example = () => {
 render(<Example />);
 ```
 
+#### getFrameController(stdout)
+
+Returns the `FrameController` of the Ink instance rendering to `stdout`, or `undefined` when there is none.
+
+The frame controller is a bridge for applications that own their input and implement text selection themselves, for example alternate-screen apps that handle mouse events. The app subscribes to composited frames to read what is on screen, and pushes a selection, which Ink highlights before serialization.
+
+```jsx
+import {render, Text, getFrameController} from 'ink';
+
+const {unmount} = render(<Text>Hello World</Text>);
+
+const controller = getFrameController(process.stdout);
+
+const unsubscribe = controller.subscribe(frame => {
+	// frame.cells[y][x] is the cell at column x of row y
+});
+
+controller.setSelection({sx: 0, sy: 0, ex: 4, ey: 0});
+```
+
+Frames are only generated while at least one subscriber is registered, so apps that never use the frame controller pay no overhead. Listeners are notified outside of the render pass and notifications are coalesced, so a listener can safely call `setSelection()` without re-entering rendering or observing frames out of order.
+
+##### stdout
+
+Type: `NodeJS.WriteStream`
+
+The output stream an Ink instance renders to, usually `process.stdout`.
+
+##### controller.getFrame()
+
+Returns the latest composited frame, or `undefined` when no frame has been published yet.
+
+A frame is a read-only grid of cells: `frame.cells[y][x]` is the cell at column `x` of row `y`, with `(0, 0)` at the top-left of Ink's output region and `frame.width`/`frame.height` the grid dimensions. Each cell exposes `value` (the character, or `''` for the trailing half of a wide character) and `fullWidth` (`true` for wide characters such as CJK, which occupy two cells). To extract the text of a region, concatenate cell values and skip the ones with an empty `value`.
+
+> [!NOTE]
+> Cell coordinates are positions in Ink's output region, not terminal viewport coordinates. To map a mouse event to a cell, convert the event coordinates by the viewport position of the output region, like with [`measureElement()`](#measureelementref).
+
+##### controller.getSelection()
+
+Returns the current selection in reading order, or `undefined` when there is none.
+
+##### controller.setSelection(selection)
+
+Highlights `selection` and schedules a repaint through Ink's regular render throttle. Setting an identical selection is a no-op, and passing `undefined` clears the highlight.
+
+Selections are stored in reading order: `(sx, sy)` is the first selected cell and `(ex, ey)` the last one. Reverse selections (right-to-left or bottom-to-top drags) are normalized, so they select the same region as forward drags. The region covers whole rows between the first and last row, and is partial on the first and last row.
+
+##### controller.subscribe(listener)
+
+Subscribes to composited frames. `listener` receives the frame after each render. Subscribing schedules a render, so the listener receives the current frame even when nothing else triggers one. Returns an unsubscribe function.
+
 ## Testing
 
 Ink components are simple to test with [ink-testing-library](https://github.com/vadimdemedes/ink-testing-library).

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -62,6 +62,26 @@ export type Props = {
 	*/
 	readonly wrap?: Styles['textWrap'];
 
+	/**
+	Whether the text is selectable through the [frame controller](#getframecontrollerstdout). Defaults to `true`. Nested `<Text>` nodes override the value inherited from their parent.
+	*/
+	readonly selectable?: boolean;
+
+	/**
+	Selection flow key. Text nodes sharing the same flow key are reported as one selection unit: cells of a flow share the same `flowId` in the composited frame. Defaults to each top-level `<Text>` being its own flow.
+	*/
+	readonly selectionFlow?: unknown;
+
+	/**
+	Insert a boundary after this text node, telling consumers how the following text joins when copied. `'soft'` joins with the surrounding text, `'hard'` starts a new line.
+	*/
+	readonly selectionBreakAfter?: 'soft' | 'hard';
+
+	/**
+	Custom joiner string used when `selectionBreakAfter` is `'soft'`.
+	*/
+	readonly selectionJoiner?: string;
+
 	readonly children?: ReactNode;
 };
 
@@ -78,6 +98,10 @@ export default function Text({
 	strikethrough = false,
 	inverse = false,
 	wrap = 'wrap',
+	selectable = true,
+	selectionFlow,
+	selectionBreakAfter,
+	selectionJoiner,
 	children,
 	'aria-label': ariaLabel,
 	'aria-hidden': ariaHidden = false,
@@ -138,6 +162,10 @@ export default function Text({
 		<ink-text
 			style={{flexGrow: 0, flexShrink: 1, flexDirection: 'row', textWrap: wrap}}
 			internal_transform={transform}
+			selectable={selectable}
+			selectionFlow={selectionFlow}
+			selectionBreakAfter={selectionBreakAfter}
+			selectionJoiner={selectionJoiner}
 		>
 			{childrenOrAriaLabel}
 		</ink-text>

--- a/src/frame-controller.ts
+++ b/src/frame-controller.ts
@@ -1,0 +1,201 @@
+import instances from './instances.js';
+
+/**
+A selection region in the composited frame. Coordinates are zero-based cell
+positions and are always stored in reading order: `(sx, sy)` is the
+first selected cell and `(ex, ey)` the last one, so reverse (right-to-left or
+bottom-to-top) drags select the same region as forward drags.
+*/
+export type ScreenSelection = {
+	readonly sx: number;
+	readonly sy: number;
+	readonly ex: number;
+	readonly ey: number;
+};
+
+/**
+A single cell of the composited frame. Wide characters (e.g. CJK) occupy two
+cells: the leading cell has `fullWidth` set to `true` and carries the
+character, while the trailing placeholder cell has an empty `value`. Skip
+cells with an empty `value` when extracting text.
+*/
+export type FrameCell = {
+	readonly value: string;
+	readonly fullWidth: boolean;
+};
+
+/**
+A read-only snapshot of the composited frame. `cells[y][x]` is the cell at
+column `x` of row `y`, with `(0, 0)` at the top-left of Ink's output region.
+*/
+export type ReadonlyFrame = {
+	readonly width: number;
+	readonly height: number;
+	readonly cells: ReadonlyArray<readonly FrameCell[]>;
+};
+
+/**
+Bridge between an application that owns its input (for example an
+alternate-screen app handling mouse events itself) and the renderer: the app
+subscribes to composited frames and pushes a selection, which Ink highlights
+before serialization.
+
+Frames are only generated while at least one subscriber is registered, so
+apps that never subscribe pay no overhead. Listeners are notified outside of
+the render pass and notifications are coalesced, so a listener cannot
+re-enter rendering or observe frames out of order.
+*/
+export type FrameController = {
+	/**
+	Returns the latest composited frame, or `undefined` when no frame has been
+	published yet. Frames are only generated while subscribers are registered.
+	*/
+	getFrame(): ReadonlyFrame | undefined;
+
+	/**
+	Returns the current selection in reading order, or `undefined` when there
+	is none.
+	*/
+	getSelection(): ScreenSelection | undefined;
+
+	/**
+	Highlights the given selection region (or clears it with `undefined`) and
+	schedules a repaint through Ink's regular render throttle. Reverse
+	selections are normalized to reading order. Setting an identical selection
+	is a no-op.
+	*/
+	setSelection(selection: ScreenSelection | undefined): void;
+
+	/**
+	Subscribes to composited frames. Schedules a render so the listener
+	receives the current frame even when nothing else triggers one. Returns an
+	unsubscribe function.
+	*/
+	subscribe(listener: (frame: ReadonlyFrame) => void): () => void;
+};
+
+type FrameListener = (frame: ReadonlyFrame) => void;
+
+export type InternalFrameController = FrameController & {
+	/**
+	Whether frames should be generated on the next render.
+	*/
+	hasSubscribers(): boolean;
+
+	/**
+	Publishes the composited cells of the frame that was just rendered.
+	*/
+	publishFrame(cells: ReadonlyArray<readonly FrameCell[]>): void;
+};
+
+// Normalizes the selection to reading order so reverse drags select the same
+// region as forward drags.
+const normalizeSelection = (selection: ScreenSelection): ScreenSelection => {
+	let {sx, sy, ex, ey} = selection;
+
+	if (sy > ey || (sy === ey && sx > ex)) {
+		[sx, ex] = [ex, sx];
+		[sy, ey] = [ey, sy];
+	}
+
+	return {sx, sy, ex, ey};
+};
+
+const sameSelection = (
+	a: ScreenSelection | undefined,
+	b: ScreenSelection | undefined,
+): boolean => {
+	if (a === b) {
+		return true;
+	}
+
+	if (!a || !b) {
+		return false;
+	}
+
+	return a.sx === b.sx && a.sy === b.sy && a.ex === b.ex && a.ey === b.ey;
+};
+
+export const createFrameController = (
+	requestRender: () => void,
+): InternalFrameController => {
+	let currentSelection: ScreenSelection | undefined;
+	let lastFrame: ReadonlyFrame | undefined;
+	const listeners = new Set<FrameListener>();
+	let notificationScheduled = false;
+
+	// Runs in a microtask, after the render that published the frame has fully
+	// completed. A listener calling setSelection() from here schedules a new
+	// render instead of re-entering the one in flight.
+	const notifyListeners = () => {
+		notificationScheduled = false;
+
+		const frame = lastFrame;
+
+		if (!frame) {
+			return;
+		}
+
+		// Iterating the live set is safe here: listeners removed during
+		// notification are skipped, and setSelection() calls from a listener
+		// only schedule a new render.
+		for (const listener of listeners) {
+			listener(frame);
+		}
+	};
+
+	return {
+		getFrame: () => lastFrame,
+		getSelection: () => currentSelection,
+		setSelection(selection) {
+			const normalized = selection ? normalizeSelection(selection) : undefined;
+
+			if (sameSelection(currentSelection, normalized)) {
+				return;
+			}
+
+			currentSelection = normalized;
+			requestRender();
+		},
+		subscribe(listener) {
+			listeners.add(listener);
+
+			// Deliver the current frame even if nothing else triggers a render.
+			requestRender();
+
+			return () => {
+				listeners.delete(listener);
+			};
+		},
+		hasSubscribers: () => listeners.size > 0,
+		publishFrame(cells) {
+			let width = 0;
+
+			for (const row of cells) {
+				width = Math.max(width, row.length);
+			}
+
+			const frame: ReadonlyFrame = {width, height: cells.length, cells};
+
+			for (const row of cells) {
+				Object.freeze(row);
+			}
+
+			Object.freeze(frame);
+			lastFrame = frame;
+
+			if (listeners.size > 0 && !notificationScheduled) {
+				notificationScheduled = true;
+				queueMicrotask(notifyListeners);
+			}
+		},
+	};
+};
+
+/**
+Returns the frame controller of the Ink instance rendering to `stdout`, or
+`undefined` when there is none.
+*/
+export const getFrameController = (
+	stdout: NodeJS.WriteStream,
+): FrameController | undefined => instances.get(stdout)?.frameController;

--- a/src/frame-controller.ts
+++ b/src/frame-controller.ts
@@ -18,20 +18,41 @@ A single cell of the composited frame. Wide characters (e.g. CJK) occupy two
 cells: the leading cell has `fullWidth` set to `true` and carries the
 character, while the trailing placeholder cell has an empty `value`. Skip
 cells with an empty `value` when extracting text.
+
+`selectable` reflects the selection semantics of the `<Text>` the cell
+originated from (and is `false` for non-text content such as box
+backgrounds). Cells of one selection flow share the same numeric `flowId`,
+which is stable for the duration of a single render.
 */
 export type FrameCell = {
 	readonly value: string;
 	readonly fullWidth: boolean;
+	readonly selectable: boolean;
+	readonly flowId: number | undefined;
+};
+
+/**
+How two adjacent regions of text join when copied. `'soft'` boundaries come
+from wrapping (the `joiner` is the whitespace the wrap consumed, possibly
+empty) or an explicit `selectionBreakAfter="soft"`; `'hard'` boundaries come
+from source newlines or `selectionBreakAfter="hard"` and join with `\n`
+unless a custom `joiner` was given.
+*/
+export type FrameBoundary = {
+	readonly kind: 'soft' | 'hard';
+	readonly joiner: string;
 };
 
 /**
 A read-only snapshot of the composited frame. `cells[y][x]` is the cell at
 column `x` of row `y`, with `(0, 0)` at the top-left of Ink's output region.
+`boundaries[y][x]` is the boundary immediately after that cell, if any.
 */
 export type ReadonlyFrame = {
 	readonly width: number;
 	readonly height: number;
 	readonly cells: ReadonlyArray<readonly FrameCell[]>;
+	readonly boundaries: ReadonlyArray<ReadonlyArray<FrameBoundary | undefined>>;
 };
 
 /**
@@ -62,7 +83,8 @@ export type FrameController = {
 	Highlights the given selection region (or clears it with `undefined`) and
 	schedules a repaint through Ink's regular render throttle. Reverse
 	selections are normalized to reading order. Setting an identical selection
-	is a no-op.
+	is a no-op. Non-selectable cells inside the region are not highlighted,
+	matching what a copy would include.
 	*/
 	setSelection(selection: ScreenSelection | undefined): void;
 
@@ -83,9 +105,13 @@ export type InternalFrameController = FrameController & {
 	hasSubscribers(): boolean;
 
 	/**
-	Publishes the composited cells of the frame that was just rendered.
+	Publishes the composited cells and boundaries of the frame that was just
+	rendered.
 	*/
-	publishFrame(cells: ReadonlyArray<readonly FrameCell[]>): void;
+	publishFrame(
+		cells: ReadonlyArray<readonly FrameCell[]>,
+		boundaries: ReadonlyArray<ReadonlyArray<FrameBoundary | undefined>>,
+	): void;
 };
 
 // Normalizes the selection to reading order so reverse drags select the same
@@ -168,16 +194,25 @@ export const createFrameController = (
 			};
 		},
 		hasSubscribers: () => listeners.size > 0,
-		publishFrame(cells) {
+		publishFrame(cells, boundaries) {
 			let width = 0;
 
 			for (const row of cells) {
 				width = Math.max(width, row.length);
 			}
 
-			const frame: ReadonlyFrame = {width, height: cells.length, cells};
+			const frame: ReadonlyFrame = {
+				width,
+				height: cells.length,
+				cells,
+				boundaries,
+			};
 
 			for (const row of cells) {
+				Object.freeze(row);
+			}
+
+			for (const row of boundaries) {
 				Object.freeze(row);
 			}
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -31,5 +31,9 @@ declare namespace Ink {
 		// eslint-disable-next-line @typescript-eslint/naming-convention
 		internal_transform?: (children: string, index: number) => string;
 		internal_accessibility?: DOMElement['internal_accessibility'];
+		selectable?: boolean;
+		selectionFlow?: unknown;
+		selectionBreakAfter?: 'soft' | 'hard';
+		selectionJoiner?: string;
 	};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,5 +49,6 @@ export type {
 	FrameController,
 	ReadonlyFrame,
 	FrameCell,
+	FrameBoundary,
 	ScreenSelection,
 } from './frame-controller.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,3 +44,10 @@ export type {ElementMetrics} from './measure-element.js';
 export type {DOMElement} from './dom.js';
 export {kittyFlags, kittyModifiers} from './kitty-keyboard.js';
 export type {KittyKeyboardOptions, KittyFlagName} from './kitty-keyboard.js';
+export {getFrameController} from './frame-controller.js';
+export type {
+	FrameController,
+	ReadonlyFrame,
+	FrameCell,
+	ScreenSelection,
+} from './frame-controller.js';

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -585,7 +585,7 @@ export default class Ink {
 		}
 
 		const startTime = performance.now();
-		const {output, outputHeight, staticOutput, cells} = render(
+		const {output, outputHeight, staticOutput, cells, boundaries} = render(
 			this.rootNode,
 			this.isScreenReaderEnabled,
 			{
@@ -597,7 +597,7 @@ export default class Ink {
 		);
 
 		if (cells) {
-			this.frameController.publishFrame(cells);
+			this.frameController.publishFrame(cells, boundaries ?? []);
 		}
 
 		this.options.onRender?.({renderTime: performance.now() - startTime});

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -18,6 +18,10 @@ import {hideCursorEscape, showCursorEscape} from './cursor-helpers.js';
 import logUpdate, {type LogUpdate, type CursorPosition} from './log-update.js';
 import {bsu, esu, shouldSynchronize} from './write-synchronized.js';
 import instances from './instances.js';
+import {
+	createFrameController,
+	type InternalFrameController,
+} from './frame-controller.js';
 import App from './components/App.js';
 import {type TerminalSuspension} from './components/AppContext.js';
 import {accessibilityContext as AccessibilityContext} from './components/AccessibilityContext.js';
@@ -293,6 +297,11 @@ export default class Ink {
 	*/
 	readonly isConcurrent: boolean;
 
+	/**
+	Bridge for application-owned text selection. See `getFrameController`.
+	*/
+	readonly frameController: InternalFrameController;
+
 	private readonly options: Options;
 	private readonly log: LogUpdate;
 	private cursorPosition: CursorPosition | undefined;
@@ -378,6 +387,15 @@ export default class Ink {
 		}
 
 		this.rootNode.onImmediateRender = this.onRender;
+
+		// Bridge for application-owned text selection: apps subscribe to composited
+		// frames and push a selection, which is highlighted before serialization
+		// (see onRender). Repaints scheduled by the controller go through the same
+		// (throttled) render path as regular updates.
+		this.frameController = createFrameController(() => {
+			this.rootNode.onRender?.();
+		});
+
 		this.rootNode.onStaticChange = this.handleStaticChange;
 		this.log = logUpdate.create(options.stdout, {
 			incremental: options.incrementalRendering,
@@ -567,10 +585,20 @@ export default class Ink {
 		}
 
 		const startTime = performance.now();
-		const {output, outputHeight, staticOutput} = render(
+		const {output, outputHeight, staticOutput, cells} = render(
 			this.rootNode,
 			this.isScreenReaderEnabled,
+			{
+				selection: this.frameController.getSelection(),
+				// Cells are only projected when a frame consumer subscribed, so
+				// apps that never use the frame controller pay no overhead.
+				captureCells: this.frameController.hasSubscribers(),
+			},
 		);
+
+		if (cells) {
+			this.frameController.publishFrame(cells);
+		}
 
 		this.options.onRender?.({renderTime: performance.now() - startTime});
 
@@ -1112,6 +1140,12 @@ export default class Ink {
 		outputHeight: number,
 		staticOutput: string,
 	): void {
+		// Re-assert the app's cursor intent on every interactive render: log-update
+		// only applies a cursor position set since the previous render, so without
+		// this a repaint triggered by setSelection() would leave the cursor at the
+		// end of the output instead of where useCursor() placed it.
+		this.log.setCursorPosition(this.cursorPosition);
+
 		const hasStaticOutput = staticOutput !== '';
 		const isTty = this.options.stdout.isTTY;
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,5 +1,6 @@
 import sliceAnsi from 'slice-ansi';
 import stringWidth from 'string-width';
+import stripAnsi from 'strip-ansi';
 import {
 	type AnsiCode,
 	type StyledChar,
@@ -7,8 +8,15 @@ import {
 	styledCharsToString,
 	tokenize,
 } from '@alcalzone/ansi-tokenize';
-import {type OutputTransformer} from './render-node-to-output.js';
-import {type FrameCell, type ScreenSelection} from './frame-controller.js';
+import {
+	type LineSemantics,
+	type OutputTransformer,
+} from './render-node-to-output.js';
+import {
+	type FrameBoundary,
+	type FrameCell,
+	type ScreenSelection,
+} from './frame-controller.js';
 
 // Background applied to selected cells. Appended after a cell's existing styles
 // so the foreground is preserved and this background wins at the terminal.
@@ -66,6 +74,8 @@ type WriteOperation = {
 	y: number;
 	text: string;
 	transformers: OutputTransformer[];
+	selectable?: boolean;
+	semantics?: LineSemantics[];
 };
 
 type ClipOperation = {
@@ -143,9 +153,13 @@ export default class Output {
 		x: number,
 		y: number,
 		text: string,
-		options: {transformers: OutputTransformer[]},
+		options: {
+			transformers: OutputTransformer[];
+			selectable?: boolean;
+			semantics?: LineSemantics[];
+		},
 	): void {
-		const {transformers} = options;
+		const {transformers, selectable, semantics} = options;
 
 		if (!text) {
 			return;
@@ -157,6 +171,8 @@ export default class Output {
 			y,
 			text,
 			transformers,
+			selectable,
+			semantics,
 		});
 	}
 
@@ -176,7 +192,24 @@ export default class Output {
 	get(
 		selection?: ScreenSelection,
 		captureCells = false,
-	): {output: string; height: number; cells?: FrameCell[][]} {
+	): {
+		output: string;
+		height: number;
+		cells?: FrameCell[][];
+		boundaries?: Array<Array<FrameBoundary | undefined>>;
+	} {
+		// Cells are selectable unless a write marked them otherwise (e.g.
+		// `selectable={false}` text or box backgrounds). Tracked only when a
+		// selection is applied or cells are captured.
+		const trackSemantics = captureCells || selection !== undefined;
+		const nonSelectable = trackSemantics ? new Set<string>() : undefined;
+		const flowGrid: Array<Array<number | undefined>> | undefined = captureCells
+			? []
+			: undefined;
+		const boundaryStamps = captureCells
+			? new Map<string, FrameBoundary>()
+			: undefined;
+
 		// Initialize output array with a specific set of rows, so that margin/padding at the bottom is preserved
 		const output: StyledChar[][] = [];
 
@@ -207,9 +240,13 @@ export default class Output {
 			}
 
 			if (operation.type === 'write') {
-				const {text, transformers} = operation;
+				const {text, transformers, selectable, semantics} = operation;
 				let {x, y} = operation;
 				let lines = text.split('\n');
+				let firstLineIndex = 0;
+				// Visible columns removed from the front by horizontal clipping,
+				// expressed in source code units for semantics lookups.
+				let codeUnitsShift = 0;
 
 				const clip = clips.at(-1);
 
@@ -239,8 +276,15 @@ export default class Output {
 					}
 
 					if (clipHorizontally) {
+						const from = x < clip.x1! ? clip.x1! - x : 0;
+
+						if (from > 0 && semantics) {
+							codeUnitsShift = stripAnsi(
+								sliceAnsi(lines[0] ?? '', 0, from),
+							).length;
+						}
+
 						lines = lines.map(line => {
-							const from = x < clip.x1! ? clip.x1! - x : 0;
 							const width = this.caches.getStringWidth(line);
 							const to = x + width > clip.x2! ? clip.x2! - x : width;
 
@@ -258,6 +302,7 @@ export default class Output {
 						const to = y + height > clip.y2! ? clip.y2! - y : height;
 
 						lines = lines.slice(from, to);
+						firstLineIndex = from;
 
 						if (y < clip.y1!) {
 							y = clip.y1!;
@@ -287,6 +332,10 @@ export default class Output {
 						offsetY++;
 						continue;
 					}
+
+					const lineSemantics = semantics?.[firstLineIndex + index];
+					const rowIndex = y + offsetY;
+					let codeIndex = codeUnitsShift;
 
 					const spaceCell: StyledChar = {
 						type: 'char',
@@ -330,6 +379,48 @@ export default class Output {
 							}
 						}
 
+						if (trackSemantics) {
+							// Semantic lookups are indexed by source code units, while
+							// grid positions are terminal columns (wide characters
+							// occupy several columns for one code unit).
+							let cellSelectable = selectable ?? true;
+							let flowId: number | undefined;
+							let boundary: FrameBoundary | undefined;
+
+							if (lineSemantics) {
+								cellSelectable = lineSemantics.selectable[codeIndex] ?? true;
+								flowId = lineSemantics.flowIds[codeIndex];
+								boundary = lineSemantics.boundariesAfter[codeIndex];
+							}
+
+							for (
+								let cellColumn = offsetX;
+								cellColumn < offsetX + characterWidth;
+								cellColumn++
+							) {
+								if (!cellSelectable) {
+									nonSelectable?.add(`${rowIndex},${cellColumn}`);
+								}
+
+								if (flowGrid && flowId !== undefined) {
+									const existingRow = flowGrid[rowIndex];
+									const gridRow = existingRow ?? [];
+
+									if (!existingRow) {
+										flowGrid[rowIndex] = gridRow;
+									}
+
+									gridRow[cellColumn] = flowId;
+								}
+
+								if (boundaryStamps && boundary) {
+									boundaryStamps.set(`${rowIndex},${cellColumn}`, boundary);
+								}
+							}
+
+							codeIndex += character.value.length;
+						}
+
 						offsetX += characterWidth;
 					}
 
@@ -353,6 +444,13 @@ export default class Output {
 						continue;
 					}
 
+					// Non-selectable cells (e.g. `selectable={false}` text or box
+					// backgrounds) are excluded from what a selection copies, so
+					// they are not highlighted either.
+					if (nonSelectable?.has(`${y},${x}`)) {
+						continue;
+					}
+
 					const cell = row[x];
 
 					if (cell) {
@@ -369,17 +467,31 @@ export default class Output {
 		// style data. Only runs when a consumer opted in via subscribe(), so the
 		// default render path pays no extra cost.
 		const cells = captureCells
-			? output.map(row => {
+			? output.map((row, rowIndex) => {
 					const frameRow: FrameCell[] = [];
 
-					for (const cell of row) {
+					for (const [column, cell] of row.entries()) {
 						frameRow.push({
 							value: cell?.value ?? ' ',
 							fullWidth: cell?.fullWidth ?? false,
+							selectable: !nonSelectable!.has(`${rowIndex},${column}`),
+							flowId: flowGrid?.[rowIndex]?.[column],
 						});
 					}
 
 					return frameRow;
+				})
+			: undefined;
+
+		const boundaries = captureCells
+			? output.map((row, rowIndex) => {
+					const boundaryRow: Array<FrameBoundary | undefined> = [];
+
+					for (let column = 0; column < row.length; column++) {
+						boundaryRow.push(boundaryStamps!.get(`${rowIndex},${column}`));
+					}
+
+					return boundaryRow;
 				})
 			: undefined;
 
@@ -396,6 +508,7 @@ export default class Output {
 			output: generatedOutput,
 			height: output.length,
 			cells,
+			boundaries,
 		};
 	}
 }

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,12 +1,49 @@
 import sliceAnsi from 'slice-ansi';
 import stringWidth from 'string-width';
 import {
+	type AnsiCode,
 	type StyledChar,
 	styledCharsFromTokens,
 	styledCharsToString,
 	tokenize,
 } from '@alcalzone/ansi-tokenize';
 import {type OutputTransformer} from './render-node-to-output.js';
+import {type FrameCell, type ScreenSelection} from './frame-controller.js';
+
+// Background applied to selected cells. Appended after a cell's existing styles
+// so the foreground is preserved and this background wins at the terminal.
+const selectionBackground: AnsiCode = {
+	type: 'ansi',
+	code: '\u001B[48;5;240m',
+	endCode: '\u001B[49m',
+};
+
+// Linear reading-order selection: whole rows between the first and last, partial
+// on the first/last row. Coordinates are screen cells in the composited frame;
+// the frame controller normalizes selections to reading order before they get here.
+const isCellSelected = (
+	x: number,
+	y: number,
+	selection: ScreenSelection,
+): boolean => {
+	if (y < selection.sy || y > selection.ey) {
+		return false;
+	}
+
+	if (selection.sy === selection.ey) {
+		return x >= selection.sx && x <= selection.ex;
+	}
+
+	if (y === selection.sy) {
+		return x >= selection.sx;
+	}
+
+	if (y === selection.ey) {
+		return x <= selection.ex;
+	}
+
+	return true;
+};
 
 /**
 "Virtual" output class
@@ -136,7 +173,10 @@ export default class Output {
 		});
 	}
 
-	get(): {output: string; height: number} {
+	get(
+		selection?: ScreenSelection,
+		captureCells = false,
+	): {output: string; height: number; cells?: FrameCell[][]} {
 		// Initialize output array with a specific set of rows, so that margin/padding at the bottom is preserved
 		const output: StyledChar[][] = [];
 
@@ -302,6 +342,47 @@ export default class Output {
 			}
 		}
 
+		// Apply the selection highlight before serialization. Selected slots are
+		// replaced with new cell objects (never mutated in place) because cells
+		// reference StyledChar objects cached and shared across identical lines,
+		// so mutating one would leak the highlight onto other on-screen text.
+		if (selection) {
+			for (const [y, row] of output.entries()) {
+				for (let x = 0; x < row.length; x++) {
+					if (!isCellSelected(x, y, selection)) {
+						continue;
+					}
+
+					const cell = row[x];
+
+					if (cell) {
+						row[x] = {
+							...cell,
+							styles: [...cell.styles, selectionBackground],
+						};
+					}
+				}
+			}
+		}
+
+		// Project the composited cells for frame consumers, stripping internal
+		// style data. Only runs when a consumer opted in via subscribe(), so the
+		// default render path pays no extra cost.
+		const cells = captureCells
+			? output.map(row => {
+					const frameRow: FrameCell[] = [];
+
+					for (const cell of row) {
+						frameRow.push({
+							value: cell?.value ?? ' ',
+							fullWidth: cell?.fullWidth ?? false,
+						});
+					}
+
+					return frameRow;
+				})
+			: undefined;
+
 		const generatedOutput = output
 			.map(line => {
 				// See https://github.com/vadimdemedes/ink/pull/564#issuecomment-1637022742
@@ -314,6 +395,7 @@ export default class Output {
 		return {
 			output: generatedOutput,
 			height: output.length,
+			cells,
 		};
 	}
 }

--- a/src/render-background.ts
+++ b/src/render-background.ts
@@ -44,7 +44,7 @@ const renderBackground = (
 			x + leftBorderWidth,
 			y + topBorderHeight + row,
 			backgroundLine,
-			{transformers: []},
+			{transformers: [], selectable: false},
 		);
 	}
 };

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -1,9 +1,16 @@
 import widestLine from 'widest-line';
 import indentString from 'indent-string';
 import Yoga from 'yoga-layout';
-import wrapText from './wrap-text.js';
+import wrapText, {
+	wrapTextWithMetadata,
+	type TextBoundary,
+	type WrappedLineMetadata,
+} from './wrap-text.js';
 import getMaxWidth from './get-max-width.js';
-import squashTextNodes from './squash-text-nodes.js';
+import squashTextNodes, {
+	squashTextNodesWithMetadata,
+	type TextSegment,
+} from './squash-text-nodes.js';
 import renderBorder from './render-border.js';
 import renderBackground from './render-background.js';
 import {type DOMElement} from './dom.js';
@@ -25,6 +32,170 @@ const applyPaddingToText = (node: DOMElement, text: string): string => {
 	}
 
 	return text;
+};
+
+// Same offset as `applyPaddingToText`, but exposed so the semantic path can
+// write the padding separately (as non-selectable cells) from the text itself.
+const getTextOffset = (node: DOMElement): {x: number; y: number} => {
+	const yogaNode = node.childNodes[0]?.yogaNode;
+
+	if (yogaNode) {
+		return {
+			x: yogaNode.getComputedLeft(),
+			y: yogaNode.getComputedTop(),
+		};
+	}
+
+	return {x: 0, y: 0};
+};
+
+/**
+Assigns stable numeric ids to selection flows during a single render.
+*/
+export type FlowState = {
+	ids: Map<unknown, number>;
+	next: number;
+};
+
+/**
+Per-column selection metadata of one line of written text. `boundariesAfter`
+holds the boundary immediately after each column, if any.
+*/
+export type LineSemantics = {
+	selectable: boolean[];
+	flowIds: Array<number | undefined>;
+	boundariesAfter: Array<TextBoundary | undefined>;
+};
+
+const resolveFlowId = (flowKey: unknown, flows: FlowState): number => {
+	let flowId = flows.ids.get(flowKey);
+
+	if (flowId === undefined) {
+		flowId = flows.next++;
+		flows.ids.set(flowKey, flowId);
+	}
+
+	return flowId;
+};
+
+// Maps each output line's columns back to the source segments so every cell
+// keeps the selection attributes of the node it originated from, then places
+// boundaries: wrap/source-newline boundaries after each line's last column
+// and explicit `selectionBreakAfter` boundaries after the segment that
+// requested them.
+const buildLineSemantics = (
+	segments: TextSegment[],
+	lines: WrappedLineMetadata[],
+	flows: FlowState,
+): LineSemantics[] => {
+	const semantics: LineSemantics[] = lines.map(() => ({
+		selectable: [],
+		flowIds: [],
+		boundariesAfter: [],
+	}));
+
+	let segmentIndex = 0;
+
+	const segmentAt = (offset: number): TextSegment | undefined => {
+		while (
+			segmentIndex < segments.length &&
+			segments[segmentIndex]!.visibleEnd <= offset
+		) {
+			segmentIndex++;
+		}
+
+		const segment = segments[segmentIndex];
+
+		return segment && segment.visibleStart <= offset ? segment : undefined;
+	};
+
+	for (const [lineIndex, line] of lines.entries()) {
+		const lineSemantics = semantics[lineIndex]!;
+
+		for (let column = 0; column < line.visibleLength; column++) {
+			const segment = segmentAt(line.visibleStart + column);
+
+			lineSemantics.selectable.push(
+				line.selectable && (segment?.attributes.selectable ?? true),
+			);
+			lineSemantics.flowIds.push(
+				segment ? resolveFlowId(segment.attributes.flowKey, flows) : undefined,
+			);
+			lineSemantics.boundariesAfter.push(undefined);
+		}
+	}
+
+	// A line's incoming boundary belongs after the previous line's last
+	// column. Empty lines (e.g. from source newlines) have no column to hold
+	// it, so walk back to the nearest line that does.
+	for (let lineIndex = 1; lineIndex < lines.length; lineIndex++) {
+		const {boundary} = lines[lineIndex]!;
+
+		if (!boundary) {
+			continue;
+		}
+
+		let target = lineIndex - 1;
+
+		while (target >= 0 && semantics[target]!.selectable.length === 0) {
+			target--;
+		}
+
+		if (target >= 0) {
+			const targetSemantics = semantics[target]!;
+
+			targetSemantics.boundariesAfter[
+				targetSemantics.boundariesAfter.length - 1
+			] = boundary;
+		}
+	}
+
+	for (const segment of segments) {
+		const {breakAfter, joiner} = segment.attributes;
+
+		if (!breakAfter) {
+			continue;
+		}
+
+		const boundary: TextBoundary = {kind: breakAfter, joiner};
+		const position = segment.visibleEnd - 1;
+		let placed = false;
+
+		for (const [lineIndex, line] of lines.entries()) {
+			if (
+				position >= line.visibleStart &&
+				position < line.visibleStart + line.visibleLength
+			) {
+				// Explicit boundaries win over wrap boundaries at the same spot.
+				semantics[lineIndex]!.boundariesAfter[position - line.visibleStart] =
+					boundary;
+				placed = true;
+				break;
+			}
+		}
+
+		if (!placed) {
+			// The segment ends in whitespace consumed by wrapping; attach the
+			// boundary to the last line that starts before it.
+			let target = -1;
+
+			for (const [lineIndex, line] of lines.entries()) {
+				if (line.visibleStart <= position && line.visibleLength > 0) {
+					target = lineIndex;
+				}
+			}
+
+			if (target >= 0) {
+				const targetSemantics = semantics[target]!;
+
+				targetSemantics.boundariesAfter[
+					targetSemantics.boundariesAfter.length - 1
+				] = boundary;
+			}
+		}
+	}
+
+	return semantics;
 };
 
 export type OutputTransformer = (s: string, index: number) => string;
@@ -105,6 +276,7 @@ const renderNodeToOutput = (
 		offsetY?: number;
 		transformers?: OutputTransformer[];
 		skipStaticElements: boolean;
+		flows?: FlowState;
 	},
 ) => {
 	const {
@@ -112,6 +284,7 @@ const renderNodeToOutput = (
 		offsetY = 0,
 		transformers = [],
 		skipStaticElements,
+		flows,
 	} = options;
 
 	if (skipStaticElements && node.internal_static) {
@@ -138,6 +311,45 @@ const renderNodeToOutput = (
 		}
 
 		if (node.nodeName === 'ink-text') {
+			if (flows) {
+				// Semantic path: squash with per-node selection attributes and
+				// carry them through wrapping, so nested `<Text>` props are not
+				// lost when nodes are squashed into a single string.
+				const {text: sourceText, segments} = squashTextNodesWithMetadata(node);
+
+				if (sourceText.length > 0) {
+					const maxWidth = getMaxWidth(yogaNode);
+					const textWrap = node.style.textWrap ?? 'wrap';
+					const wrapped = wrapTextWithMetadata(
+						sourceText,
+						maxWidth,
+						textWrap,
+						widestLine(sourceText) > maxWidth,
+					);
+					const semantics = buildLineSemantics(segments, wrapped.lines, flows);
+					const textOffset = getTextOffset(node);
+
+					if (textOffset.x > 0) {
+						const padding = wrapped.text
+							.split('\n')
+							.map(line => (line.length > 0 ? ' '.repeat(textOffset.x) : ''))
+							.join('\n');
+
+						output.write(x, y + textOffset.y, padding, {
+							transformers: newTransformers,
+							selectable: false,
+						});
+					}
+
+					output.write(x + textOffset.x, y + textOffset.y, wrapped.text, {
+						transformers: newTransformers,
+						semantics,
+					});
+				}
+
+				return;
+			}
+
 			let text = squashTextNodes(node);
 
 			if (text.length > 0) {
@@ -201,6 +413,7 @@ const renderNodeToOutput = (
 					offsetY: y,
 					transformers: newTransformers,
 					skipStaticElements,
+					flows,
 				});
 			}
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,15 +1,21 @@
 import renderNodeToOutput, {
 	renderNodeToScreenReaderOutput,
+	type FlowState,
 } from './render-node-to-output.js';
 import Output from './output.js';
 import {type DOMElement} from './dom.js';
-import {type FrameCell, type ScreenSelection} from './frame-controller.js';
+import {
+	type FrameBoundary,
+	type FrameCell,
+	type ScreenSelection,
+} from './frame-controller.js';
 
 type Result = {
 	output: string;
 	outputHeight: number;
 	staticOutput: string;
 	cells?: FrameCell[][];
+	boundaries?: Array<Array<FrameBoundary | undefined>>;
 };
 
 type Options = {
@@ -33,6 +39,14 @@ const renderer = (
 	const {selection, captureCells} = options;
 
 	if (node.yogaNode) {
+		// Selection metadata (per-cell `selectable`, flows, boundaries) is
+		// resolved whenever it can be observed: when cells are captured or a
+		// selection highlight is applied.
+		const flows: FlowState | undefined =
+			captureCells === true || selection !== undefined
+				? {ids: new Map<unknown, number>(), next: 1}
+				: undefined;
+
 		if (isScreenReaderEnabled) {
 			const output = renderNodeToScreenReaderOutput(node, {
 				skipStaticElements: true,
@@ -62,6 +76,7 @@ const renderer = (
 
 		renderNodeToOutput(node, output, {
 			skipStaticElements: true,
+			flows,
 		});
 
 		let staticOutput;
@@ -81,6 +96,7 @@ const renderer = (
 			output: generatedOutput,
 			height: outputHeight,
 			cells,
+			boundaries,
 		} = output.get(selection, captureCells);
 
 		return {
@@ -90,6 +106,7 @@ const renderer = (
 			// interactive output will override last line of static output
 			staticOutput: staticOutput ? `${staticOutput.get().output}\n` : '',
 			cells,
+			boundaries,
 		};
 	}
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -3,14 +3,35 @@ import renderNodeToOutput, {
 } from './render-node-to-output.js';
 import Output from './output.js';
 import {type DOMElement} from './dom.js';
+import {type FrameCell, type ScreenSelection} from './frame-controller.js';
 
 type Result = {
 	output: string;
 	outputHeight: number;
 	staticOutput: string;
+	cells?: FrameCell[][];
 };
 
-const renderer = (node: DOMElement, isScreenReaderEnabled: boolean): Result => {
+type Options = {
+	/**
+	Selection region to highlight before serialization.
+	*/
+	selection?: ScreenSelection;
+
+	/**
+	Whether to expose the composited cells in the result. Only enabled when a
+	frame consumer subscribed to the frame controller.
+	*/
+	captureCells?: boolean;
+};
+
+const renderer = (
+	node: DOMElement,
+	isScreenReaderEnabled: boolean,
+	options: Options = {},
+): Result => {
+	const {selection, captureCells} = options;
+
 	if (node.yogaNode) {
 		if (isScreenReaderEnabled) {
 			const output = renderNodeToScreenReaderOutput(node, {
@@ -56,7 +77,11 @@ const renderer = (node: DOMElement, isScreenReaderEnabled: boolean): Result => {
 			});
 		}
 
-		const {output: generatedOutput, height: outputHeight} = output.get();
+		const {
+			output: generatedOutput,
+			height: outputHeight,
+			cells,
+		} = output.get(selection, captureCells);
 
 		return {
 			output: generatedOutput,
@@ -64,6 +89,7 @@ const renderer = (node: DOMElement, isScreenReaderEnabled: boolean): Result => {
 			// Newline at the end is needed, because static output doesn't have one, so
 			// interactive output will override last line of static output
 			staticOutput: staticOutput ? `${staticOutput.get().output}\n` : '',
+			cells,
 		};
 	}
 

--- a/src/squash-text-nodes.ts
+++ b/src/squash-text-nodes.ts
@@ -1,3 +1,4 @@
+import stripAnsi from 'strip-ansi';
 import {type DOMElement} from './dom.js';
 import sanitizeAnsi from './sanitize-ansi.js';
 
@@ -46,3 +47,223 @@ const squashTextNodes = (node: DOMElement): string => {
 };
 
 export default squashTextNodes;
+
+/**
+Selection attributes resolved for a segment of squashed text.
+*/
+export type TextSegmentAttributes = {
+	selectable: boolean;
+	flowKey: unknown;
+	breakAfter?: 'soft' | 'hard';
+	joiner: string;
+};
+
+/**
+A run of squashed text originating from a single source node, carrying the
+selection attributes effective at that node. `visibleStart`/`visibleEnd` are
+offsets in the visible (ANSI-stripped) squashed text.
+*/
+export type TextSegment = {
+	text: string;
+	visibleStart: number;
+	visibleEnd: number;
+	attributes: TextSegmentAttributes;
+};
+
+export type SquashedText = {
+	text: string;
+	segments: TextSegment[];
+};
+
+type InheritedAttributes = {
+	selectable: boolean;
+	flowKey: unknown;
+};
+
+type CollectorState = {
+	text: string;
+	visibleLength: number;
+	segments: TextSegment[];
+};
+
+const createState = (): CollectorState => ({
+	text: '',
+	visibleLength: 0,
+	segments: [],
+});
+
+const appendSegment = (
+	state: CollectorState,
+	text: string,
+	attributes: TextSegmentAttributes,
+): void => {
+	if (!text) {
+		return;
+	}
+
+	const visibleLength = stripAnsi(text).length;
+
+	state.text += text;
+
+	if (visibleLength === 0) {
+		return;
+	}
+
+	state.segments.push({
+		text,
+		visibleStart: state.visibleLength,
+		visibleEnd: state.visibleLength + visibleLength,
+		attributes: {...attributes},
+	});
+	state.visibleLength += visibleLength;
+};
+
+// Returns the attributes effective for `node`'s subtree, applying explicit
+// `selectable`/`selectionFlow` overrides on top of the inherited ones.
+const resolveAttributes = (
+	node: DOMElement,
+	inherited: InheritedAttributes,
+): InheritedAttributes => {
+	const {selectable, selectionFlow} = node.attributes;
+
+	return {
+		selectable:
+			typeof selectable === 'boolean' ? selectable : inherited.selectable,
+		flowKey: selectionFlow ?? inherited.flowKey,
+	};
+};
+
+const collectChildren = (
+	node: DOMElement,
+	inherited: InheritedAttributes,
+	state: CollectorState,
+): void => {
+	for (const [index, childNode] of node.childNodes.entries()) {
+		if (childNode === undefined) {
+			continue;
+		}
+
+		if (childNode.nodeName === '#text') {
+			appendSegment(state, sanitizeAnsi(childNode.nodeValue), {
+				...inherited,
+				joiner: '',
+			});
+			continue;
+		}
+
+		if (
+			childNode.nodeName !== 'ink-text' &&
+			childNode.nodeName !== 'ink-virtual-text'
+		) {
+			continue;
+		}
+
+		collectTextSubtree(childNode, inherited, state, index);
+
+		// A boundary requested after this node lands after the last visible
+		// character emitted for its subtree (or after the preceding content
+		// when the subtree emitted none).
+		const breakAfter = childNode.attributes['selectionBreakAfter'];
+
+		if (breakAfter === 'soft' || breakAfter === 'hard') {
+			const lastSegment = state.segments.at(-1);
+
+			if (lastSegment) {
+				const joiner = childNode.attributes['selectionJoiner'];
+
+				lastSegment.attributes.breakAfter = breakAfter;
+				lastSegment.attributes.joiner =
+					typeof joiner === 'string'
+						? joiner
+						: breakAfter === 'hard'
+							? '\n'
+							: '';
+			}
+		}
+	}
+};
+
+const collectTextSubtree = (
+	node: DOMElement,
+	inherited: InheritedAttributes,
+	state: CollectorState,
+	index: number,
+): void => {
+	const attributes = resolveAttributes(node, inherited);
+	const transform = node.internal_transform;
+
+	if (typeof transform === 'function') {
+		// Transforms may rewrite visible text arbitrarily (e.g. <Transform>),
+		// in which case per-segment provenance cannot be preserved. Apply the
+		// transform per segment and verify the visible result still matches a
+		// whole-subtree application (as color transforms do); otherwise fall
+		// back to one uniform segment to stay byte-identical with the plain
+		// squashing path.
+		const subState = createState();
+		collectChildren(node, attributes, subState);
+
+		if (subState.segments.length === 0) {
+			if (subState.text.length > 0) {
+				state.text += sanitizeAnsi(transform(subState.text, index));
+			}
+
+			return;
+		}
+
+		const wholeText = transform(subState.text, index);
+		const transformedSegments = subState.segments.map(segment =>
+			transform(segment.text, index),
+		);
+
+		const segmentVisible = transformedSegments
+			.map(segment => stripAnsi(segment))
+			.join('');
+
+		if (segmentVisible === stripAnsi(wholeText)) {
+			for (const [segmentIndex, segment] of subState.segments.entries()) {
+				const transformed = transformedSegments[segmentIndex];
+
+				appendSegment(
+					state,
+					sanitizeAnsi(transformed ?? segment.text),
+					segment.attributes,
+				);
+			}
+
+			return;
+		}
+
+		appendSegment(state, sanitizeAnsi(wholeText), {...attributes, joiner: ''});
+		return;
+	}
+
+	collectChildren(node, attributes, state);
+};
+
+/**
+Like `squashTextNodes`, but additionally tracks which selection attributes
+(`selectable`, `selectionFlow`, `selectionBreakAfter`) are effective for each
+run of the squashed text, so nested `<Text>` nodes keep their metadata.
+*/
+export const squashTextNodesWithMetadata = (node: DOMElement): SquashedText => {
+	const state = createState();
+	const attributes = resolveAttributes(node, {selectable: true, flowKey: node});
+
+	collectChildren(node, attributes, state);
+
+	const breakAfter = node.attributes['selectionBreakAfter'];
+
+	if (breakAfter === 'soft' || breakAfter === 'hard') {
+		const lastSegment = state.segments.at(-1);
+
+		if (lastSegment) {
+			const joiner = node.attributes['selectionJoiner'];
+
+			lastSegment.attributes.breakAfter = breakAfter;
+			lastSegment.attributes.joiner =
+				typeof joiner === 'string' ? joiner : breakAfter === 'hard' ? '\n' : '';
+		}
+	}
+
+	return {text: state.text, segments: state.segments};
+};

--- a/src/wrap-text.ts
+++ b/src/wrap-text.ts
@@ -1,5 +1,6 @@
 import wrapAnsi from 'wrap-ansi';
 import cliTruncate from 'cli-truncate';
+import stripAnsi from 'strip-ansi';
 import {type Styles} from './styles.js';
 
 const cache: Record<string, string> = {};
@@ -53,3 +54,114 @@ const wrapText = (
 };
 
 export default wrapText;
+
+export type TextBoundary = {
+	kind: 'soft' | 'hard';
+	joiner: string;
+};
+
+/**
+Wrapping metadata of a single output line, relative to the source text.
+*/
+export type WrappedLineMetadata = {
+	/**
+	Visible offset in the source text where this line's content starts.
+	*/
+	visibleStart: number;
+
+	/**
+	Visible length of this line's content.
+	*/
+	visibleLength: number;
+
+	/**
+	False for whitespace-only lines that merely continue a whitespace run from
+	the source (e.g. indent continuation after a wrap), which should not
+	contribute to copied text.
+	*/
+	selectable: boolean;
+
+	/**
+	Boundary between the previous line and this one. Undefined for the first
+	line. `'hard'` boundaries come from explicit newlines in the source;
+	`'soft'` ones from wrapping, with the consumed whitespace as the joiner.
+	*/
+	boundary?: TextBoundary;
+};
+
+/**
+Like `wrapText`, but additionally reports how each output line maps back to
+the source text so callers can preserve per-character metadata across
+wrapping.
+*/
+export const wrapTextWithMetadata = (
+	text: string,
+	maxWidth: number,
+	wrapType: Styles['textWrap'],
+	shouldWrap = true,
+): {text: string; lines: WrappedLineMetadata[]} => {
+	const sourceLines = text.replaceAll('\r\n', '\n').split('\n');
+	const lines: string[] = [];
+	const metadata: WrappedLineMetadata[] = [];
+	let sourceBase = 0;
+
+	for (const sourceLine of sourceLines) {
+		const wrappedLines = (
+			shouldWrap ? wrapText(sourceLine, maxWidth, wrapType) : sourceLine
+		).split('\n');
+		const visibleSource = stripAnsi(sourceLine);
+		let sourceOffset = 0;
+
+		for (const [wrappedLineIndex, wrappedLine] of wrappedLines.entries()) {
+			const visibleLine = stripAnsi(wrappedLine);
+
+			const separatorRow =
+				sourceOffset > 0 &&
+				visibleLine.length > 0 &&
+				/^\s+$/u.test(visibleLine) &&
+				/\S/u.test(visibleSource.slice(sourceOffset));
+
+			const sourceSeparator = separatorRow
+				? (/^\s+/u.exec(visibleSource.slice(sourceOffset))?.[0] ?? '').slice(
+						0,
+						visibleLine.length,
+					)
+				: '';
+
+			const lineOffset = separatorRow
+				? sourceOffset
+				: visibleSource.indexOf(visibleLine, sourceOffset);
+			const resolvedOffset = lineOffset === -1 ? sourceOffset : lineOffset;
+
+			let boundary: TextBoundary | undefined;
+
+			if (lines.length > 0) {
+				boundary =
+					wrappedLineIndex === 0
+						? {kind: 'hard', joiner: '\n'}
+						: {
+								kind: 'soft',
+								joiner: separatorRow
+									? sourceSeparator
+									: visibleSource.slice(sourceOffset, resolvedOffset),
+							};
+			}
+
+			lines.push(wrappedLine);
+			metadata.push({
+				visibleStart: sourceBase + resolvedOffset,
+				visibleLength: visibleLine.length,
+				selectable: !separatorRow,
+				boundary,
+			});
+
+			sourceOffset = separatorRow
+				? sourceOffset + sourceSeparator.length
+				: resolvedOffset + visibleLine.length;
+		}
+
+		sourceBase += visibleSource.length + 1;
+	}
+
+	return {text: lines.join('\n'), lines: metadata};
+};

--- a/test/selection-semantics.tsx
+++ b/test/selection-semantics.tsx
@@ -1,0 +1,317 @@
+import test from 'ava';
+import React from 'react';
+import {
+	Box,
+	Text,
+	render,
+	getFrameController,
+	type ReadonlyFrame,
+} from '../src/index.js';
+import createStdout from './helpers/create-stdout.js';
+
+// Background applied to selected cells (see output.ts). Built from the escape
+// code so this test does not depend on a raw control character in the source.
+const selectionHighlight = `${String.fromCodePoint(27)}[48;5;240m`;
+
+const settle = async () => {
+	await new Promise<void>(resolve => {
+		setImmediate(resolve);
+	});
+};
+
+// Renders `element`, subscribes so cells are captured, and returns the frame.
+const captureFrame = async (
+	element: React.ReactElement,
+): Promise<{
+	frame: ReadonlyFrame;
+	stdout: ReturnType<typeof createStdout>;
+	unmount: () => void;
+}> => {
+	const stdout = createStdout();
+	const {unmount} = render(element, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	return {frame: controller.getFrame()!, stdout, unmount};
+};
+
+test('selectable={false} on a nested Text node is preserved through squashing', async t => {
+	const {frame, unmount} = await captureFrame(
+		<Text>
+			AB
+			<Text selectable={false}>CD</Text>
+			EF
+		</Text>,
+	);
+
+	const row = frame.cells[0]!;
+	t.is(
+		row
+			.map(cell => cell.value)
+			.join('')
+			.trimEnd(),
+		'ABCDEF',
+	);
+
+	t.true(row[0]!.selectable);
+	t.true(row[1]!.selectable);
+	t.false(row[2]!.selectable);
+	t.false(row[3]!.selectable);
+	t.true(row[4]!.selectable);
+	t.true(row[5]!.selectable);
+
+	unmount();
+});
+
+test('explicit selectable={true} on a nested Text re-enables selection', async t => {
+	const {frame, unmount} = await captureFrame(
+		<Text selectable={false}>
+			AB<Text selectable>CD</Text>EF
+		</Text>,
+	);
+
+	const row = frame.cells[0]!;
+	t.false(row[0]!.selectable);
+	t.false(row[1]!.selectable);
+	t.true(row[2]!.selectable);
+	t.true(row[3]!.selectable);
+	t.false(row[4]!.selectable);
+	t.false(row[5]!.selectable);
+
+	unmount();
+});
+
+test('nested selectable metadata survives color transforms', async t => {
+	const {frame, unmount} = await captureFrame(
+		<Text color="red">
+			A<Text selectable={false}>B</Text>C
+		</Text>,
+	);
+
+	const row = frame.cells[0]!;
+	t.is(
+		row
+			.map(cell => cell.value)
+			.join('')
+			.trimEnd(),
+		'ABC',
+	);
+	t.true(row[0]!.selectable);
+	t.false(row[1]!.selectable);
+	t.true(row[2]!.selectable);
+
+	unmount();
+});
+
+test('selection skips non-selectable cells when highlighting', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(
+		<Text>
+			AB
+			<Text selectable={false}>CD</Text>
+			EF
+		</Text>,
+		{stdout, debug: true},
+	);
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	controller.setSelection({sx: 0, sy: 0, ex: 5, ey: 0});
+
+	const output = stdout.get();
+	t.true(
+		output.includes(selectionHighlight + 'AB'),
+		'selectable prefix is highlighted',
+	);
+	t.true(
+		output.includes(selectionHighlight + 'EF'),
+		'selectable suffix is highlighted',
+	);
+	t.false(
+		output.includes(selectionHighlight + 'C'),
+		'non-selectable cells are skipped',
+	);
+
+	unmount();
+});
+
+test('non-selectable wide characters are skipped by the highlight', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text selectable={false}>你好</Text>, {
+		stdout,
+		debug: true,
+	});
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	controller.setSelection({sx: 0, sy: 0, ex: 3, ey: 0});
+
+	t.false(stdout.get().includes(selectionHighlight));
+
+	unmount();
+});
+
+test('box background cells are not selectable', async t => {
+	const {frame, unmount} = await captureFrame(
+		<Box backgroundColor="red" width={3} height={1} />,
+	);
+
+	const row = frame.cells[0]!;
+	t.false(row[0]!.selectable);
+	t.false(row[1]!.selectable);
+	t.false(row[2]!.selectable);
+
+	unmount();
+});
+
+test('text nodes sharing a selectionFlow share a flowId', async t => {
+	const {frame, unmount} = await captureFrame(
+		<Box>
+			<Text selectionFlow="group">A</Text>
+			<Text selectionFlow="group">B</Text>
+		</Box>,
+	);
+
+	const row = frame.cells[0]!;
+	const aCell = row.find(cell => cell.value === 'A')!;
+	const bCell = row.find(cell => cell.value === 'B')!;
+
+	t.is(typeof aCell.flowId, 'number');
+	t.is(aCell.flowId, bCell.flowId);
+
+	unmount();
+});
+
+test('text nodes without a shared selectionFlow get distinct flowIds', async t => {
+	const {frame, unmount} = await captureFrame(
+		<Box>
+			<Text>A</Text>
+			<Text>B</Text>
+		</Box>,
+	);
+
+	const row = frame.cells[0]!;
+	const aCell = row.find(cell => cell.value === 'A')!;
+	const bCell = row.find(cell => cell.value === 'B')!;
+
+	t.not(aCell.flowId, bCell.flowId);
+
+	unmount();
+});
+
+test('a nested selectionFlow overrides the surrounding flow', async t => {
+	const {frame, unmount} = await captureFrame(
+		<Text selectionFlow="outer">
+			A<Text selectionFlow="inner">B</Text>C
+		</Text>,
+	);
+
+	const row = frame.cells[0]!;
+	t.is(row[0]!.value, 'A');
+	t.is(row[1]!.value, 'B');
+	t.is(row[2]!.value, 'C');
+
+	t.is(row[0]!.flowId, row[2]!.flowId);
+	t.not(row[1]!.flowId, row[0]!.flowId);
+
+	unmount();
+});
+
+test('selectionBreakAfter="hard" records a boundary after the text', async t => {
+	const {frame, unmount} = await captureFrame(
+		<Box>
+			<Text selectionBreakAfter="hard">AB</Text>
+		</Box>,
+	);
+
+	const boundary = frame.boundaries[0]![1];
+	t.truthy(boundary);
+	t.is(boundary!.kind, 'hard');
+	t.is(boundary!.joiner, '\n');
+	t.is(frame.boundaries[0]![0], undefined);
+
+	unmount();
+});
+
+test('selectionBreakAfter="soft" uses the custom joiner', async t => {
+	const {frame, unmount} = await captureFrame(
+		<Box>
+			<Text selectionBreakAfter="soft" selectionJoiner=" | ">
+				AB
+			</Text>
+		</Box>,
+	);
+
+	const boundary = frame.boundaries[0]![1];
+	t.truthy(boundary);
+	t.is(boundary!.kind, 'soft');
+	t.is(boundary!.joiner, ' | ');
+
+	unmount();
+});
+
+test('explicit newlines produce hard boundaries', async t => {
+	const {frame, unmount} = await captureFrame(<Text>{'aaa\nbbb'}</Text>);
+
+	const boundary = frame.boundaries[0]![2];
+	t.truthy(boundary);
+	t.is(boundary!.kind, 'hard');
+	t.is(boundary!.joiner, '\n');
+
+	unmount();
+});
+
+test('wrapping produces soft boundaries with the consumed whitespace', async t => {
+	const {frame, unmount} = await captureFrame(
+		<Box width={5}>
+			<Text>aaa bbb</Text>
+		</Box>,
+	);
+
+	t.is(
+		frame.cells[0]!.slice(0, 3)
+			.map(cell => cell.value)
+			.join(''),
+		'aaa',
+	);
+	t.is(
+		frame.cells[1]!.slice(0, 3)
+			.map(cell => cell.value)
+			.join(''),
+		'bbb',
+	);
+
+	// With `trim: false` wrapping the space at the wrap point stays on the
+	// first line, so the boundary sits after it with an empty joiner: copying
+	// the cells up to the boundary and joining the next line reproduces the
+	// original text.
+	const boundary = frame.boundaries[0]![3];
+	t.truthy(boundary);
+	t.is(boundary!.kind, 'soft');
+	t.is(boundary!.joiner, '');
+
+	unmount();
+});
+
+test('wide characters carry semantics on leading and placeholder cells', async t => {
+	const {frame, unmount} = await captureFrame(
+		<Text selectable={false}>你好</Text>,
+	);
+
+	const row = frame.cells[0]!;
+	t.is(row[0]!.value, '你');
+	t.true(row[0]!.fullWidth);
+	t.false(row[0]!.selectable);
+	t.is(row[1]!.value, '');
+	t.false(row[1]!.selectable);
+	t.is(typeof row[0]!.flowId, 'number');
+	t.is(row[1]!.flowId, row[0]!.flowId);
+
+	unmount();
+});

--- a/test/selection.tsx
+++ b/test/selection.tsx
@@ -1,0 +1,293 @@
+import test from 'ava';
+import React from 'react';
+import {Box, Text, render, getFrameController} from '../src/index.js';
+import createStdout from './helpers/create-stdout.js';
+
+// Background applied to selected cells (see output.ts). Built from the escape
+// code so this test does not depend on a raw control character in the source.
+const selectionHighlight = `${String.fromCodePoint(27)}[48;5;240m`;
+
+// Frame notifications are deferred to a microtask, so tests await this to let
+// every scheduled notification (and the renders it may trigger) settle.
+const settle = async () => {
+	await new Promise<void>(resolve => {
+		setImmediate(resolve);
+	});
+};
+
+const writeCount = (stdout: ReturnType<typeof createStdout>): number =>
+	(stdout.write as any).callCount as number;
+
+test('getFrameController returns undefined for an unknown stdout', t => {
+	const stdout = createStdout();
+	t.is(getFrameController(stdout), undefined);
+});
+
+test('getFrameController returns a controller after render', t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	t.truthy(getFrameController(stdout));
+
+	unmount();
+});
+
+test('no frame is generated while there are no subscribers', t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	// Nothing subscribed during the render, so no cells were projected.
+	t.is(getFrameController(stdout)!.getFrame(), undefined);
+
+	unmount();
+});
+
+test('subscribe opts into frame generation and receives the current frame', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	const frames: number[] = [];
+	const unsubscribe = controller.subscribe(frame => {
+		frames.push(frame.height);
+	});
+
+	// Subscribing schedules a render so late subscribers still get a frame.
+	await settle();
+
+	t.deepEqual(frames, [1]);
+
+	const frame = controller.getFrame();
+	t.truthy(frame);
+	t.is(frame!.height, 1);
+	t.is(frame!.width, frame!.cells[0]!.length);
+
+	unsubscribe();
+	unmount();
+});
+
+test('listeners are notified outside of the render pass', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	let notifications = 0;
+
+	controller.subscribe(() => {
+		notifications++;
+	});
+
+	// The render triggered by subscribe() already ran synchronously (debug
+	// mode), but the notification is deferred.
+	t.is(notifications, 0);
+
+	await settle();
+	t.is(notifications, 1);
+
+	unmount();
+});
+
+test('getFrame exposes the composited cells', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hi</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	const row = controller.getFrame()!.cells[0]!;
+	t.is(row[0]!.value, 'H');
+	t.false(row[0]!.fullWidth);
+	t.is(row[1]!.value, 'i');
+
+	unmount();
+});
+
+test('frames are published on subsequent renders', async t => {
+	const stdout = createStdout();
+	const instance = render(<Text>A</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	instance.rerender(<Text>BB</Text>);
+	await settle();
+
+	const row = controller.getFrame()!.cells[0]!;
+	t.is(row[0]!.value, 'B');
+	t.is(row[1]!.value, 'B');
+
+	instance.unmount();
+});
+
+test('wide characters occupy two cells', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>你好</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	const row = controller.getFrame()!.cells[0]!;
+	t.is(row[0]!.value, '你');
+	t.true(row[0]!.fullWidth);
+	// Trailing placeholder of a wide character.
+	t.is(row[1]!.value, '');
+	t.false(row[1]!.fullWidth);
+	t.is(row[2]!.value, '好');
+	t.true(row[2]!.fullWidth);
+	t.is(row[3]!.value, '');
+
+	// Text extraction skips placeholder cells; trailing cells pad the row to
+	// the frame width with spaces.
+	const extracted = row
+		.map(cell => cell.value)
+		.join('')
+		.replace(/ +$/u, '');
+	t.is(extracted, '你好');
+
+	unmount();
+});
+
+test('setSelection highlights the selected cells', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	t.false(stdout.get().includes(selectionHighlight));
+
+	controller.setSelection({sx: 0, sy: 0, ex: 4, ey: 0});
+
+	t.true(stdout.get().includes(selectionHighlight));
+
+	unmount();
+});
+
+test('clearing the selection removes the highlight', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	controller.setSelection({sx: 0, sy: 0, ex: 4, ey: 0});
+	t.true(stdout.get().includes(selectionHighlight));
+
+	controller.setSelection(undefined);
+	t.false(stdout.get().includes(selectionHighlight));
+
+	unmount();
+});
+
+test('selections spanning multiple rows highlight whole middle rows', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(
+		<Box flexDirection="column">
+			<Text>aaaa</Text>
+			<Text>bbbb</Text>
+			<Text>cccc</Text>
+		</Box>,
+		{stdout, debug: true},
+	);
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	controller.setSelection({sx: 2, sy: 0, ex: 1, ey: 2});
+	await settle();
+
+	const highlighted = stdout.get();
+	const [first = '', middle = '', last = ''] = highlighted.split('\n');
+
+	// First row is selected from column 2, last row up to column 1, and the
+	// whole middle row is selected.
+	t.true(first.includes(selectionHighlight + 'aa'));
+	t.true(middle.startsWith(selectionHighlight));
+	t.true(last.includes(selectionHighlight + 'cc'));
+	t.false(last.includes(selectionHighlight + 'cccc'));
+
+	unmount();
+});
+
+test('reverse selections are normalized to reading order', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	// Right-to-left drag over the same region.
+	controller.setSelection({sx: 4, sy: 0, ex: 0, ey: 0});
+
+	t.deepEqual(controller.getSelection(), {sx: 0, sy: 0, ex: 4, ey: 0});
+
+	const reverseOutput = stdout.get();
+	t.true(reverseOutput.includes(selectionHighlight));
+
+	controller.setSelection(undefined);
+	controller.setSelection({sx: 0, sy: 0, ex: 4, ey: 0});
+
+	// The highlight is identical to a forward selection over the same region.
+	t.is(stdout.get(), reverseOutput);
+
+	unmount();
+});
+
+test('setting an identical selection does not trigger a repaint', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	controller.subscribe(() => {});
+	await settle();
+
+	controller.setSelection({sx: 0, sy: 0, ex: 4, ey: 0});
+	const writesAfterFirst = writeCount(stdout);
+
+	controller.setSelection({sx: 0, sy: 0, ex: 4, ey: 0});
+	t.is(writeCount(stdout), writesAfterFirst);
+
+	// The reverse spelling of the same region normalizes to it and is a no-op too.
+	controller.setSelection({sx: 4, sy: 0, ex: 0, ey: 0});
+	t.is(writeCount(stdout), writesAfterFirst);
+
+	unmount();
+});
+
+test('a subscriber calling setSelection does not re-enter rendering', async t => {
+	const stdout = createStdout();
+	const {unmount} = render(<Text>Hello</Text>, {stdout, debug: true});
+
+	const controller = getFrameController(stdout)!;
+	const frames: number[] = [];
+	let reentered = false;
+
+	controller.subscribe(frame => {
+		frames.push(frame.height);
+
+		// A listener that mutates the selection schedules a new render, which
+		// publishes another frame. This must not throw or interleave frames.
+		if (!reentered) {
+			reentered = true;
+			controller.setSelection({sx: 0, sy: 0, ex: 1, ey: 0});
+		}
+	});
+
+	await settle();
+
+	// One notification per published frame: the render scheduled by
+	// subscribe() and the one triggered by setSelection(). The initial render
+	// published nothing because there were no subscribers yet.
+	t.is(frames.length, 2);
+	t.true(reentered);
+	t.true(stdout.get().includes(selectionHighlight));
+
+	unmount();
+});


### PR DESCRIPTION
Second part of the split suggested in #980, stacked on #984 (the diff against `master` includes #984 until it merges — review that one first). Adds the selection semantics needed to extract copied text: flows, boundaries, and semantic `<Text>` props.

**What's included**

- `<Text>` gains `selectable`, `selectionFlow`, `selectionBreakAfter`, and `selectionJoiner` props (documented in the readme).
- Frame cells expose `selectable` and `flowId`; frames carry a `boundaries` grid describing how adjacent text joins when copied (wrap points with the consumed whitespace, source newlines, explicit `selectionBreakAfter` boundaries).
- The selection highlight skips non-selectable cells, matching what a copy would include.

**Concerns from the #980 review addressed here**

1. *Metadata lost when nested `Text` nodes are squashed* — squashing now tracks per-node selection attributes (`squashTextNodesWithMetadata`), so an inner `selectable={false}` (or `selectionFlow` override) is preserved per cell instead of being overwritten by the outer node. Arbitrary `<Transform>` functions may rewrite visible text, so subtrees transformed by them fall back to one uniform segment (verified byte-identical output); color/style transforms keep full granularity.
2. *Missing test coverage* — 14 new tests: nested `selectable` (both directions), nesting through color transforms, highlight skipping non-selectable cells (ASCII, wide characters, box backgrounds), shared/distinct/nested flows, and boundary placement (`hard`, `soft` with custom joiner, source newlines, wrapping).

**Performance**

Semantics are only resolved when they can be observed (cells captured or a selection applied), extending the opt-in from #984. With neither, the render path is unchanged. The semantic path produces byte-identical output to the plain path (verified for nested/colored text, wrapping, padding, wide characters, multi-line text).

Kept as a draft until #984 lands.
