### PR TITLE
Add scrolling primitives: `contentOffsetX`/`contentOffsetY` props and client/scroll size metrics

### DIFF
--- a/examples/scroll/index.ts
+++ b/examples/scroll/index.ts
@@ -1,0 +1,1 @@
+import './scroll.js';

--- a/examples/scroll/scroll.tsx
+++ b/examples/scroll/scroll.tsx
@@ -19,30 +19,32 @@ function ScrollView({
 	const contentRef = useRef(null);
 	const {clientWidth, clientHeight} = useBoxMetrics(ref);
 	const content = useBoxMetrics(contentRef);
-	const [scrollTop, setScrollTop] = useState(0);
-	const [scrollLeft, setScrollLeft] = useState(0);
+	const [requestedScrollTop, setRequestedScrollTop] = useState(0);
+	const [requestedScrollLeft, setRequestedScrollLeft] = useState(0);
 	const maxScrollTop = Math.max(0, content.height - clientHeight);
 	const maxScrollLeft = Math.max(0, content.width - clientWidth);
 
+	// Clamp on every render, not just in the key handlers: the maximum shrinks
+	// when the content gets shorter or the terminal gets wider, and an offset
+	// left over from before would scroll the viewport past its content.
+	const scrollTop = Math.min(requestedScrollTop, maxScrollTop);
+	const scrollLeft = Math.min(requestedScrollLeft, maxScrollLeft);
+
 	useInput((_input, key) => {
 		if (key.upArrow) {
-			setScrollTop(previousScrollTop => Math.max(0, previousScrollTop - 1));
+			setRequestedScrollTop(Math.max(0, scrollTop - 1));
 		}
 
 		if (key.downArrow) {
-			setScrollTop(previousScrollTop =>
-				Math.min(maxScrollTop, previousScrollTop + 1),
-			);
+			setRequestedScrollTop(Math.min(maxScrollTop, scrollTop + 1));
 		}
 
 		if (key.leftArrow) {
-			setScrollLeft(previousScrollLeft => Math.max(0, previousScrollLeft - 2));
+			setRequestedScrollLeft(Math.max(0, scrollLeft - 2));
 		}
 
 		if (key.rightArrow) {
-			setScrollLeft(previousScrollLeft =>
-				Math.min(maxScrollLeft, previousScrollLeft + 2),
-			);
+			setRequestedScrollLeft(Math.min(maxScrollLeft, scrollLeft + 2));
 		}
 	});
 

--- a/examples/scroll/scroll.tsx
+++ b/examples/scroll/scroll.tsx
@@ -16,9 +16,12 @@ function ScrollView({
 	readonly children: React.ReactNode;
 }) {
 	const ref = useRef(null);
-	const {clientHeight, scrollHeight} = useBoxMetrics(ref);
+	const {clientWidth, clientHeight, scrollWidth, scrollHeight} =
+		useBoxMetrics(ref);
 	const [scrollTop, setScrollTop] = useState(0);
+	const [scrollLeft, setScrollLeft] = useState(0);
 	const maxScrollTop = Math.max(0, scrollHeight - clientHeight);
+	const maxScrollLeft = Math.max(0, scrollWidth - clientWidth);
 
 	useInput((_input, key) => {
 		if (key.upArrow) {
@@ -30,6 +33,16 @@ function ScrollView({
 				Math.min(maxScrollTop, previousScrollTop + 1),
 			);
 		}
+
+		if (key.leftArrow) {
+			setScrollLeft(previousScrollLeft => Math.max(0, previousScrollLeft - 2));
+		}
+
+		if (key.rightArrow) {
+			setScrollLeft(previousScrollLeft =>
+				Math.min(maxScrollLeft, previousScrollLeft + 2),
+			);
+		}
 	});
 
 	return (
@@ -39,17 +52,19 @@ function ScrollView({
 				height={height}
 				overflow="hidden"
 				contentOffsetY={scrollTop}
+				contentOffsetX={scrollLeft}
 				flexDirection="column"
 				borderStyle="round"
 			>
-				{/* flexShrink=0 keeps the content at its natural height, so it can overflow (and scroll) instead of being squeezed into the viewport. */}
-				<Box flexDirection="column" flexShrink={0}>
+				{/* flexShrink=0 keeps the content at its natural height, so it can overflow (and scroll) instead of being squeezed into the viewport. The explicit width gives the content a horizontal extent wider than the viewport; without it, text wraps or truncates at the viewport edge and there is nothing to scroll horizontally. */}
+				<Box flexDirection="column" flexShrink={0} width={140}>
 					{children}
 				</Box>
 			</Box>
 			<Text dimColor>
-				scrollTop={scrollTop}/{maxScrollTop} client={clientHeight} scroll=
-				{scrollHeight} (↑/↓ to scroll, q to quit)
+				scrollTop={scrollTop}/{maxScrollTop} scrollLeft={scrollLeft}/
+				{maxScrollLeft} client={clientWidth}x{clientHeight} scroll=
+				{scrollWidth}x{scrollHeight} (arrows to scroll, q to quit)
 			</Text>
 		</Box>
 	);
@@ -67,9 +82,11 @@ function Demo() {
 	return (
 		<ScrollView height={10}>
 			{Array.from({length: 40}, (_, index) => (
-				<Text key={index}>
+				<Text key={index} wrap="truncate">
 					Line {String(index + 1).padStart(2, '0')}{' '}
-					{index % 5 === 0 ? '◀ marker' : ''}
+					{index % 5 === 0
+						? `◀ marker ${'·'.repeat(100)} end-of-line-${index + 1} ▶`
+						: ''}
 				</Text>
 			))}
 		</ScrollView>

--- a/examples/scroll/scroll.tsx
+++ b/examples/scroll/scroll.tsx
@@ -1,0 +1,76 @@
+import React, {useRef, useState} from 'react';
+import {
+	render,
+	Box,
+	Text,
+	useInput,
+	useApp,
+	useBoxMetrics,
+} from '../../src/index.js';
+
+function ScrollView({
+	height,
+	children,
+}: {
+	readonly height: number;
+	readonly children: React.ReactNode;
+}) {
+	const ref = useRef(null);
+	const {clientHeight, scrollHeight} = useBoxMetrics(ref);
+	const [scrollTop, setScrollTop] = useState(0);
+	const maxScrollTop = Math.max(0, scrollHeight - clientHeight);
+
+	useInput((_input, key) => {
+		if (key.upArrow) {
+			setScrollTop(previousScrollTop => Math.max(0, previousScrollTop - 1));
+		}
+
+		if (key.downArrow) {
+			setScrollTop(previousScrollTop =>
+				Math.min(maxScrollTop, previousScrollTop + 1),
+			);
+		}
+	});
+
+	return (
+		<Box flexDirection="column">
+			<Box
+				ref={ref}
+				height={height}
+				overflow="hidden"
+				contentOffsetY={scrollTop}
+				flexDirection="column"
+				borderStyle="round"
+			>
+				{children}
+			</Box>
+			<Text dimColor>
+				scrollTop={scrollTop}/{maxScrollTop} client={clientHeight} scroll=
+				{scrollHeight} (↑/↓ to scroll, q to quit)
+			</Text>
+		</Box>
+	);
+}
+
+function Demo() {
+	const {exit} = useApp();
+
+	useInput(input => {
+		if (input === 'q') {
+			exit();
+		}
+	});
+
+	return (
+		<ScrollView height={10}>
+			{Array.from({length: 40}, (_, index) => (
+				<Text key={index}>
+					Line {String(index + 1).padStart(2, '0')}{' '}
+					{index % 5 === 0 ? '◀ marker' : ''}
+				</Text>
+			))}
+		</ScrollView>
+	);
+}
+
+render(<Demo />);

--- a/examples/scroll/scroll.tsx
+++ b/examples/scroll/scroll.tsx
@@ -42,7 +42,10 @@ function ScrollView({
 				flexDirection="column"
 				borderStyle="round"
 			>
-				{children}
+				{/* flexShrink=0 keeps the content at its natural height, so it can overflow (and scroll) instead of being squeezed into the viewport. */}
+				<Box flexDirection="column" flexShrink={0}>
+					{children}
+				</Box>
 			</Box>
 			<Text dimColor>
 				scrollTop={scrollTop}/{maxScrollTop} client={clientHeight} scroll=

--- a/examples/scroll/scroll.tsx
+++ b/examples/scroll/scroll.tsx
@@ -16,12 +16,13 @@ function ScrollView({
 	readonly children: React.ReactNode;
 }) {
 	const ref = useRef(null);
-	const {clientWidth, clientHeight, scrollWidth, scrollHeight} =
-		useBoxMetrics(ref);
+	const contentRef = useRef(null);
+	const {clientWidth, clientHeight} = useBoxMetrics(ref);
+	const content = useBoxMetrics(contentRef);
 	const [scrollTop, setScrollTop] = useState(0);
 	const [scrollLeft, setScrollLeft] = useState(0);
-	const maxScrollTop = Math.max(0, scrollHeight - clientHeight);
-	const maxScrollLeft = Math.max(0, scrollWidth - clientWidth);
+	const maxScrollTop = Math.max(0, content.height - clientHeight);
+	const maxScrollLeft = Math.max(0, content.width - clientWidth);
 
 	useInput((_input, key) => {
 		if (key.upArrow) {
@@ -57,14 +58,14 @@ function ScrollView({
 				borderStyle="round"
 			>
 				{/* flexShrink=0 keeps the content at its natural height, so it can overflow (and scroll) instead of being squeezed into the viewport. The explicit width gives the content a horizontal extent wider than the viewport; without it, text wraps or truncates at the viewport edge and there is nothing to scroll horizontally. */}
-				<Box flexDirection="column" flexShrink={0} width={140}>
+				<Box ref={contentRef} flexDirection="column" flexShrink={0} width={140}>
 					{children}
 				</Box>
 			</Box>
 			<Text dimColor>
 				scrollTop={scrollTop}/{maxScrollTop} scrollLeft={scrollLeft}/
-				{maxScrollLeft} client={clientWidth}x{clientHeight} scroll=
-				{scrollWidth}x{scrollHeight} (arrows to scroll, q to quit)
+				{maxScrollLeft} client={clientWidth}x{clientHeight} content=
+				{content.width}x{content.height} (arrows to scroll, q to quit)
 			</Text>
 		</Box>
 	);

--- a/readme.md
+++ b/readme.md
@@ -1057,18 +1057,19 @@ const ScrollView = ({height, children}) => {
 	const contentRef = useRef(null);
 	const {clientHeight} = useBoxMetrics(ref);
 	const content = useBoxMetrics(contentRef);
-	const [scrollTop, setScrollTop] = useState(0);
+	const [requestedScrollTop, setRequestedScrollTop] = useState(0);
 	const maxScrollTop = Math.max(0, content.height - clientHeight);
+	// Clamp on every render, since the maximum shrinks when the content gets
+	// shorter or the terminal gets taller.
+	const scrollTop = Math.min(requestedScrollTop, maxScrollTop);
 
 	useInput((input, key) => {
 		if (key.upArrow) {
-			setScrollTop(previousScrollTop => Math.max(0, previousScrollTop - 1));
+			setRequestedScrollTop(Math.max(0, scrollTop - 1));
 		}
 
 		if (key.downArrow) {
-			setScrollTop(previousScrollTop =>
-				Math.min(maxScrollTop, previousScrollTop + 1),
-			);
+			setRequestedScrollTop(Math.min(maxScrollTop, scrollTop + 1));
 		}
 	});
 
@@ -1087,6 +1088,8 @@ const ScrollView = ({height, children}) => {
 	);
 };
 ```
+
+Note: put any padding on the content wrapper rather than the viewport. `clientHeight` excludes borders but not padding, so a padded viewport reports more room than its content actually gets and `content.height - clientHeight` comes out one row short per padded edge, leaving the last row unreachable.
 
 Note: wrap the content in a `flexShrink={0}` container so it keeps its natural height. Without it, Yoga squeezes the children into the fixed-height viewport and the content is never taller than the viewport, leaving nothing to scroll. Measuring that wrapper with its own `useBoxMetrics` ref is what gives you the scroll bounds, since the viewport only knows its own size.
 
@@ -3001,7 +3004,7 @@ Returns an object with `x`, `y`, `width`, `height`, `clientWidth` and `clientHei
 
 `x` and `y` are the element's position within the live layout region, computed by walking up the layout tree. These are layout-tree coordinates, not terminal viewport coordinates. To compare them with mouse events, convert the event coordinates using the live region's viewport position. This is necessary even in alternate-screen mode when output, such as `<Static>` content, appears above the live region.
 
-`clientWidth` and `clientHeight` are the element's dimensions excluding borders, which is the amount of space its content can occupy. To build a scrollable view, measure the content wrapper separately and clamp the offset with `content.height - viewport.clientHeight`, together with the `contentOffsetX`/`contentOffsetY` props.
+`clientWidth` and `clientHeight` are the element's dimensions excluding borders, which is the amount of space its content can occupy. To build a scrollable view, measure the content wrapper separately and clamp the offset with `content.height - viewport.clientHeight`, together with the `contentOffsetX`/`contentOffsetY` props. That bound assumes an unpadded viewport, since `clientWidth`/`clientHeight` exclude borders but not padding; put padding on the content wrapper instead.
 
 > [!NOTE]
 > `measureElement()` returns zeros for all properties when called during render (before layout is calculated). Call it from post-render code, such as `useEffect`, `useLayoutEffect`, input handlers, or timer callbacks. When content changes, pass the relevant dependency to your effect so it re-measures after each update.

--- a/readme.md
+++ b/readme.md
@@ -1048,6 +1048,8 @@ Vertical offset applied to the element's children, in rows. Children are shifted
 
 Offsets are terminal cell coordinates, so fractional values are truncated toward zero and non-finite values are treated as `0`.
 
+When an offset splits a wide character, such as CJK, the hidden half still owns a terminal cell and is rendered as a blank so the columns after it stay aligned. Styling of that blank is best-effort: the split character's inline background or color is not carried over to it.
+
 ```jsx
 import {useState, useRef} from 'react';
 import {Box, useInput, useBoxMetrics} from 'ink';
@@ -2231,13 +2233,13 @@ Element height.
 
 Type: `number`
 
-Distance from the left edge of the parent.
+Distance from the left edge of the parent. These are layout coordinates and do not include any `contentOffsetX`/`contentOffsetY` applied by an ancestor, so hit-testing inside a scrolled container has to subtract those offsets too.
 
 #### top
 
 Type: `number`
 
-Distance from the top edge of the parent.
+Distance from the top edge of the parent. These are layout coordinates and do not include any `contentOffsetX`/`contentOffsetY` applied by an ancestor, so hit-testing inside a scrolled container has to subtract those offsets too.
 
 #### clientWidth
 
@@ -3002,7 +3004,7 @@ clear();
 Measure the layout metrics of a particular `<Box>` element.
 Returns an object with `x`, `y`, `width`, `height`, `clientWidth` and `clientHeight` properties.
 
-`x` and `y` are the element's position within the live layout region, computed by walking up the layout tree. These are layout-tree coordinates, not terminal viewport coordinates. To compare them with mouse events, convert the event coordinates using the live region's viewport position. This is necessary even in alternate-screen mode when output, such as `<Static>` content, appears above the live region.
+`x` and `y` are the element's position within the live layout region, computed by walking up the layout tree. These are layout-tree coordinates, not terminal viewport coordinates. To compare them with mouse events, convert the event coordinates using the live region's viewport position. This is necessary even in alternate-screen mode when output, such as `<Static>` content, appears above the live region. These are layout coordinates and do not include any `contentOffsetX`/`contentOffsetY` applied by an ancestor, so hit-testing inside a scrolled container has to subtract those offsets too.
 
 `clientWidth` and `clientHeight` are the element's dimensions excluding borders, which is the amount of space its content can occupy. To build a scrollable view, measure the content wrapper separately and clamp the offset with `content.height - viewport.clientHeight`, together with the `contentOffsetX`/`contentOffsetY` props. That bound assumes an unpadded viewport, since `clientWidth`/`clientHeight` exclude borders but not padding; put padding on the content wrapper instead.
 

--- a/readme.md
+++ b/readme.md
@@ -1030,6 +1030,56 @@ Default: `visible`
 
 A shortcut for setting `overflowX` and `overflowY` at the same time.
 
+##### contentOffsetX
+
+Type: `number`\
+Default: `0`
+
+Horizontal offset applied to the element's children, in columns. Children are shifted left by this amount. Combine with `overflow="hidden"` to build scrollable views.
+
+##### contentOffsetY
+
+Type: `number`\
+Default: `0`
+
+Vertical offset applied to the element's children, in rows. Children are shifted up by this amount. Combine with `overflow="hidden"` to build scrollable views.
+
+```jsx
+import {useState, useRef} from 'react';
+import {Box, useInput, useBoxMetrics} from 'ink';
+
+const ScrollView = ({height, children}) => {
+	const ref = useRef(null);
+	const {clientHeight, scrollHeight} = useBoxMetrics(ref);
+	const [scrollTop, setScrollTop] = useState(0);
+	const maxScrollTop = Math.max(0, scrollHeight - clientHeight);
+
+	useInput((input, key) => {
+		if (key.upArrow) {
+			setScrollTop(previousScrollTop => Math.max(0, previousScrollTop - 1));
+		}
+
+		if (key.downArrow) {
+			setScrollTop(previousScrollTop =>
+				Math.min(maxScrollTop, previousScrollTop + 1),
+			);
+		}
+	});
+
+	return (
+		<Box
+			ref={ref}
+			height={height}
+			overflow="hidden"
+			contentOffsetY={scrollTop}
+			flexDirection="column"
+		>
+			{children}
+		</Box>
+	);
+};
+```
+
 #### Borders
 
 ##### borderStyle
@@ -2176,6 +2226,30 @@ Type: `number`
 
 Distance from the top edge of the parent.
 
+#### clientWidth
+
+Type: `number`
+
+Element width excluding borders.
+
+#### clientHeight
+
+Type: `number`
+
+Element height excluding borders.
+
+#### scrollWidth
+
+Type: `number`
+
+Total width of the element's content, including content not visible due to overflow. Always at least `clientWidth`.
+
+#### scrollHeight
+
+Type: `number`
+
+Total height of the element's content, including content not visible due to overflow. Always at least `clientHeight`.
+
 #### hasMeasured
 
 Type: `boolean`
@@ -2183,7 +2257,7 @@ Type: `boolean`
 Whether the currently tracked element has been measured.
 
 > [!NOTE]
-> The hook returns `{width: 0, height: 0, left: 0, top: 0}` until the first layout pass completes. It also returns zeros when the tracked ref is detached.
+> The hook returns zeros for all metrics until the first layout pass completes. It also returns zeros when the tracked ref is detached.
 
 ### useStderr()
 
@@ -2925,12 +2999,14 @@ clear();
 #### measureElement(ref)
 
 Measure the layout metrics of a particular `<Box>` element.
-Returns an object with `x`, `y`, `width`, and `height` properties.
+Returns an object with `x`, `y`, `width`, `height`, `clientWidth`, `clientHeight`, `scrollWidth` and `scrollHeight` properties.
 
 `x` and `y` are the element's position within the live layout region, computed by walking up the layout tree. These are layout-tree coordinates, not terminal viewport coordinates. To compare them with mouse events, convert the event coordinates using the live region's viewport position. This is necessary even in alternate-screen mode when output, such as `<Static>` content, appears above the live region.
 
+`clientWidth` and `clientHeight` are the element's dimensions excluding borders. `scrollWidth` and `scrollHeight` are the total dimensions of the element's content, including content not visible due to overflow, and are always at least `clientWidth`/`clientHeight`. These are useful when your component needs to know the amount of available space it has, or how far its content overflows, for example to build scrollable views together with the `contentOffsetX`/`contentOffsetY` props.
+
 > [!NOTE]
-> `measureElement()` returns `{x: 0, y: 0, width: 0, height: 0}` when called during render (before layout is calculated). Call it from post-render code, such as `useEffect`, `useLayoutEffect`, input handlers, or timer callbacks. When content changes, pass the relevant dependency to your effect so it re-measures after each update.
+> `measureElement()` returns zeros for all properties when called during render (before layout is calculated). Call it from post-render code, such as `useEffect`, `useLayoutEffect`, input handlers, or timer callbacks. When content changes, pass the relevant dependency to your effect so it re-measures after each update.
 
 ##### ref
 

--- a/readme.md
+++ b/readme.md
@@ -1037,6 +1037,8 @@ Default: `0`
 
 Horizontal offset applied to the element's children, in columns. Children are shifted left by this amount. Combine with `overflow="hidden"` to build scrollable views.
 
+Offsets are terminal cell coordinates, so fractional values are truncated toward zero and non-finite values are treated as `0`.
+
 ##### contentOffsetY
 
 Type: `number`\
@@ -1044,15 +1046,19 @@ Default: `0`
 
 Vertical offset applied to the element's children, in rows. Children are shifted up by this amount. Combine with `overflow="hidden"` to build scrollable views.
 
+Offsets are terminal cell coordinates, so fractional values are truncated toward zero and non-finite values are treated as `0`.
+
 ```jsx
 import {useState, useRef} from 'react';
 import {Box, useInput, useBoxMetrics} from 'ink';
 
 const ScrollView = ({height, children}) => {
 	const ref = useRef(null);
-	const {clientHeight, scrollHeight} = useBoxMetrics(ref);
+	const contentRef = useRef(null);
+	const {clientHeight} = useBoxMetrics(ref);
+	const content = useBoxMetrics(contentRef);
 	const [scrollTop, setScrollTop] = useState(0);
-	const maxScrollTop = Math.max(0, scrollHeight - clientHeight);
+	const maxScrollTop = Math.max(0, content.height - clientHeight);
 
 	useInput((input, key) => {
 		if (key.upArrow) {
@@ -1074,7 +1080,7 @@ const ScrollView = ({height, children}) => {
 			contentOffsetY={scrollTop}
 			flexDirection="column"
 		>
-			<Box flexDirection="column" flexShrink={0}>
+			<Box ref={contentRef} flexDirection="column" flexShrink={0}>
 				{children}
 			</Box>
 		</Box>
@@ -1082,7 +1088,7 @@ const ScrollView = ({height, children}) => {
 };
 ```
 
-Note: wrap the content in a `flexShrink={0}` container so it keeps its natural height. Without it, Yoga squeezes the children into the fixed-height viewport and `scrollHeight` never exceeds `clientHeight`, leaving nothing to scroll.
+Note: wrap the content in a `flexShrink={0}` container so it keeps its natural height. Without it, Yoga squeezes the children into the fixed-height viewport and the content is never taller than the viewport, leaving nothing to scroll. Measuring that wrapper with its own `useBoxMetrics` ref is what gives you the scroll bounds, since the viewport only knows its own size.
 
 #### Borders
 
@@ -2242,18 +2248,6 @@ Type: `number`
 
 Element height excluding borders.
 
-#### scrollWidth
-
-Type: `number`
-
-Total width of the element's content, including content not visible due to overflow. Always at least `clientWidth`.
-
-#### scrollHeight
-
-Type: `number`
-
-Total height of the element's content, including content not visible due to overflow. Always at least `clientHeight`.
-
 #### hasMeasured
 
 Type: `boolean`
@@ -3003,11 +2997,11 @@ clear();
 #### measureElement(ref)
 
 Measure the layout metrics of a particular `<Box>` element.
-Returns an object with `x`, `y`, `width`, `height`, `clientWidth`, `clientHeight`, `scrollWidth` and `scrollHeight` properties.
+Returns an object with `x`, `y`, `width`, `height`, `clientWidth` and `clientHeight` properties.
 
 `x` and `y` are the element's position within the live layout region, computed by walking up the layout tree. These are layout-tree coordinates, not terminal viewport coordinates. To compare them with mouse events, convert the event coordinates using the live region's viewport position. This is necessary even in alternate-screen mode when output, such as `<Static>` content, appears above the live region.
 
-`clientWidth` and `clientHeight` are the element's dimensions excluding borders. `scrollWidth` and `scrollHeight` are the total dimensions of the element's content, including content not visible due to overflow, and are always at least `clientWidth`/`clientHeight`. These are useful when your component needs to know the amount of available space it has, or how far its content overflows, for example to build scrollable views together with the `contentOffsetX`/`contentOffsetY` props.
+`clientWidth` and `clientHeight` are the element's dimensions excluding borders, which is the amount of space its content can occupy. To build a scrollable view, measure the content wrapper separately and clamp the offset with `content.height - viewport.clientHeight`, together with the `contentOffsetX`/`contentOffsetY` props.
 
 > [!NOTE]
 > `measureElement()` returns zeros for all properties when called during render (before layout is calculated). Call it from post-render code, such as `useEffect`, `useLayoutEffect`, input handlers, or timer callbacks. When content changes, pass the relevant dependency to your effect so it re-measures after each update.

--- a/readme.md
+++ b/readme.md
@@ -1074,11 +1074,15 @@ const ScrollView = ({height, children}) => {
 			contentOffsetY={scrollTop}
 			flexDirection="column"
 		>
-			{children}
+			<Box flexDirection="column" flexShrink={0}>
+				{children}
+			</Box>
 		</Box>
 	);
 };
 ```
+
+Note: wrap the content in a `flexShrink={0}` container so it keeps its natural height. Without it, Yoga squeezes the children into the fixed-height viewport and `scrollHeight` never exceeds `clientHeight`, leaving nothing to scroll.
 
 #### Borders
 

--- a/src/hooks/use-box-metrics.ts
+++ b/src/hooks/use-box-metrics.ts
@@ -20,12 +20,12 @@ export type BoxMetrics = {
 	readonly height: number;
 
 	/**
-	Distance from the left edge of the parent.
+	Distance from the left edge of the parent. These are layout coordinates and do not include any `contentOffsetX`/`contentOffsetY` applied by an ancestor, so hit-testing inside a scrolled container has to subtract those offsets too.
 	*/
 	readonly left: number;
 
 	/**
-	Distance from the top edge of the parent.
+	Distance from the top edge of the parent. These are layout coordinates and do not include any `contentOffsetX`/`contentOffsetY` applied by an ancestor, so hit-testing inside a scrolled container has to subtract those offsets too.
 	*/
 	readonly top: number;
 

--- a/src/hooks/use-box-metrics.ts
+++ b/src/hooks/use-box-metrics.ts
@@ -38,16 +38,6 @@ export type BoxMetrics = {
 	Element height excluding borders.
 	*/
 	readonly clientHeight: number;
-
-	/**
-	Total width of the element's content, including content not visible due to overflow. Always at least `clientWidth`.
-	*/
-	readonly scrollWidth: number;
-
-	/**
-	Total height of the element's content, including content not visible due to overflow. Always at least `clientHeight`.
-	*/
-	readonly scrollHeight: number;
 };
 
 export type UseBoxMetricsResult = BoxMetrics & {
@@ -64,8 +54,6 @@ const emptyMetrics: BoxMetrics = {
 	top: 0,
 	clientWidth: 0,
 	clientHeight: 0,
-	scrollWidth: 0,
-	scrollHeight: 0,
 };
 
 // eslint-disable-next-line @typescript-eslint/no-restricted-types
@@ -120,14 +108,21 @@ const useBoxMetrics = (
 		const node = ref.current;
 		const layout = node?.yogaNode?.getComputedLayout();
 
-		const nextMetrics: BoxMetrics =
-			node && layout
-				? {
-						left: layout.left,
-						top: layout.top,
-						...measureElement(node),
-					}
-				: emptyMetrics;
+		// `measureElement()` also returns `x`/`y`, which aren't part of `BoxMetrics` and must not enter the change detection below.
+		let nextMetrics: BoxMetrics = emptyMetrics;
+
+		if (node && layout) {
+			const {width, height, clientWidth, clientHeight} = measureElement(node);
+
+			nextMetrics = {
+				width,
+				height,
+				left: layout.left,
+				top: layout.top,
+				clientWidth,
+				clientHeight,
+			};
+		}
 
 		setMetrics(previousMetrics => {
 			const hasChanged = (

--- a/src/hooks/use-box-metrics.ts
+++ b/src/hooks/use-box-metrics.ts
@@ -1,5 +1,6 @@
 import {type RefObject, useState, useEffect, useCallback, useMemo} from 'react';
 import {type DOMElement, addLayoutListener} from '../dom.js';
+import measureElement from '../measure-element.js';
 
 // Yoga's `right`/`bottom` are omitted: always `0` for flow layout and unintuitive for absolute positioning.
 /**
@@ -27,6 +28,26 @@ export type BoxMetrics = {
 	Distance from the top edge of the parent.
 	*/
 	readonly top: number;
+
+	/**
+	Element width excluding borders.
+	*/
+	readonly clientWidth: number;
+
+	/**
+	Element height excluding borders.
+	*/
+	readonly clientHeight: number;
+
+	/**
+	Total width of the element's content, including content not visible due to overflow. Always at least `clientWidth`.
+	*/
+	readonly scrollWidth: number;
+
+	/**
+	Total height of the element's content, including content not visible due to overflow. Always at least `clientHeight`.
+	*/
+	readonly scrollHeight: number;
 };
 
 export type UseBoxMetricsResult = BoxMetrics & {
@@ -41,6 +62,10 @@ const emptyMetrics: BoxMetrics = {
 	height: 0,
 	left: 0,
 	top: 0,
+	clientWidth: 0,
+	clientHeight: 0,
+	scrollWidth: 0,
+	scrollHeight: 0,
 };
 
 // eslint-disable-next-line @typescript-eslint/no-restricted-types
@@ -60,7 +85,7 @@ const findRootNode = (node: DOMElement | null): DOMElement | undefined => {
 A React hook that returns the current layout metrics for a tracked box element.
 It updates when layout changes (for example terminal resize, sibling/content changes, or position changes).
 
-The hook returns `{width: 0, height: 0, left: 0, top: 0}` until the first layout pass completes. It also returns zeros when the tracked ref is detached.
+The hook returns zeros for all metrics until the first layout pass completes. It also returns zeros when the tracked ref is detached.
 
 Use `hasMeasured` to detect when the currently tracked element has been measured.
 
@@ -92,19 +117,27 @@ const useBoxMetrics = (
 	const [hasMeasured, setHasMeasured] = useState(false);
 
 	const updateMetrics = useCallback(() => {
-		const layout = ref.current?.yogaNode?.getComputedLayout() ?? emptyMetrics;
+		const node = ref.current;
+		const layout = node?.yogaNode?.getComputedLayout();
+
+		const nextMetrics: BoxMetrics =
+			node && layout
+				? {
+						left: layout.left,
+						top: layout.top,
+						...measureElement(node),
+					}
+				: emptyMetrics;
 
 		setMetrics(previousMetrics => {
-			const hasChanged =
-				previousMetrics.width !== layout.width ||
-				previousMetrics.height !== layout.height ||
-				previousMetrics.left !== layout.left ||
-				previousMetrics.top !== layout.top;
+			const hasChanged = (
+				Object.keys(nextMetrics) as Array<keyof BoxMetrics>
+			).some(key => previousMetrics[key] !== nextMetrics[key]);
 
-			return hasChanged ? layout : previousMetrics;
+			return hasChanged ? nextMetrics : previousMetrics;
 		});
 
-		setHasMeasured(Boolean(ref.current));
+		setHasMeasured(Boolean(node));
 	}, [ref]);
 
 	// Runs after every render of this component.

--- a/src/measure-element.ts
+++ b/src/measure-element.ts
@@ -48,7 +48,7 @@ Returns an object with `x`, `y`, `width`, `height`, `clientWidth` and `clientHei
 
 `x` and `y` are the element's position within the live layout region, computed by walking up the layout tree and accumulating each ancestor's offset. These are layout-tree coordinates, not terminal viewport coordinates. To compare them with mouse events, convert the event coordinates using the live region's viewport position. This is necessary even in alternate-screen mode when output, such as `<Static>` content, appears above the live region.
 
-`clientWidth` and `clientHeight` are the element's dimensions excluding borders, which is the amount of space its content can occupy. To build a scrollable view, measure the content wrapper separately and clamp the offset with `content.height - viewport.clientHeight`, together with the `contentOffsetX`/`contentOffsetY` props.
+`clientWidth` and `clientHeight` are the element's dimensions excluding borders, which is the amount of space its content can occupy. To build a scrollable view, measure the content wrapper separately and clamp the offset with `content.height - viewport.clientHeight`, together with the `contentOffsetX`/`contentOffsetY` props. That bound assumes an unpadded viewport, since `clientWidth`/`clientHeight` exclude borders but not padding; put padding on the content wrapper instead.
 
 Note: `measureElement()` returns zeros for all properties when called during render (before layout is calculated). Call it from post-render code, such as `useEffect`, `useLayoutEffect`, input handlers, or timer callbacks. When content changes, pass the relevant dependency to your effect so it re-measures after each update.
 */

--- a/src/measure-element.ts
+++ b/src/measure-element.ts
@@ -31,16 +31,6 @@ type Output = {
 	Element height excluding borders.
 	*/
 	clientHeight: number;
-
-	/**
-	Total width of the element's content, including content not visible due to overflow. Always at least `clientWidth`.
-	*/
-	scrollWidth: number;
-
-	/**
-	Total height of the element's content, including content not visible due to overflow. Always at least `clientHeight`.
-	*/
-	scrollHeight: number;
 };
 
 const emptyOutput: Output = {
@@ -50,17 +40,15 @@ const emptyOutput: Output = {
 	height: 0,
 	clientWidth: 0,
 	clientHeight: 0,
-	scrollWidth: 0,
-	scrollHeight: 0,
 };
 
 /**
 Measure the layout metrics of a particular `<Box>` element.
-Returns an object with `x`, `y`, `width`, `height`, `clientWidth`, `clientHeight`, `scrollWidth` and `scrollHeight` properties.
+Returns an object with `x`, `y`, `width`, `height`, `clientWidth` and `clientHeight` properties.
 
 `x` and `y` are the element's position within the live layout region, computed by walking up the layout tree and accumulating each ancestor's offset. These are layout-tree coordinates, not terminal viewport coordinates. To compare them with mouse events, convert the event coordinates using the live region's viewport position. This is necessary even in alternate-screen mode when output, such as `<Static>` content, appears above the live region.
 
-The remaining properties are useful when your component needs to know the amount of available space it has, or how far its content overflows. You can use them when you need to change the layout based on the length of its content, or to build scrollable views together with the `contentOffsetX`/`contentOffsetY` props.
+`clientWidth` and `clientHeight` are the element's dimensions excluding borders, which is the amount of space its content can occupy. To build a scrollable view, measure the content wrapper separately and clamp the offset with `content.height - viewport.clientHeight`, together with the `contentOffsetX`/`contentOffsetY` props.
 
 Note: `measureElement()` returns zeros for all properties when called during render (before layout is calculated). Call it from post-render code, such as `useEffect`, `useLayoutEffect`, input handlers, or timer callbacks. When content changes, pass the relevant dependency to your effect so it re-measures after each update.
 */
@@ -96,29 +84,6 @@ const measureElement = (node: DOMElement): Output => {
 	const clientHeight =
 		height - borderTop - yogaNode.getComputedBorder(Yoga.EDGE_BOTTOM);
 
-	let contentWidth = 0;
-	let contentHeight = 0;
-
-	for (let index = 0; index < yogaNode.getChildCount(); index++) {
-		const child = yogaNode.getChild(index);
-
-		contentWidth = Math.max(
-			contentWidth,
-			child.getComputedLeft() -
-				borderLeft +
-				child.getComputedWidth() +
-				child.getComputedMargin(Yoga.EDGE_RIGHT),
-		);
-
-		contentHeight = Math.max(
-			contentHeight,
-			child.getComputedTop() -
-				borderTop +
-				child.getComputedHeight() +
-				child.getComputedMargin(Yoga.EDGE_BOTTOM),
-		);
-	}
-
 	return {
 		x,
 		y,
@@ -126,8 +91,6 @@ const measureElement = (node: DOMElement): Output => {
 		height,
 		clientWidth,
 		clientHeight,
-		scrollWidth: Math.max(contentWidth, clientWidth),
-		scrollHeight: Math.max(contentHeight, clientHeight),
 	};
 };
 

--- a/src/measure-element.ts
+++ b/src/measure-element.ts
@@ -46,7 +46,7 @@ const emptyOutput: Output = {
 Measure the layout metrics of a particular `<Box>` element.
 Returns an object with `x`, `y`, `width`, `height`, `clientWidth` and `clientHeight` properties.
 
-`x` and `y` are the element's position within the live layout region, computed by walking up the layout tree and accumulating each ancestor's offset. These are layout-tree coordinates, not terminal viewport coordinates. To compare them with mouse events, convert the event coordinates using the live region's viewport position. This is necessary even in alternate-screen mode when output, such as `<Static>` content, appears above the live region.
+`x` and `y` are the element's position within the live layout region, computed by walking up the layout tree and accumulating each ancestor's offset. These are layout-tree coordinates, not terminal viewport coordinates. To compare them with mouse events, convert the event coordinates using the live region's viewport position. This is necessary even in alternate-screen mode when output, such as `<Static>` content, appears above the live region. These are layout coordinates and do not include any `contentOffsetX`/`contentOffsetY` applied by an ancestor, so hit-testing inside a scrolled container has to subtract those offsets too.
 
 `clientWidth` and `clientHeight` are the element's dimensions excluding borders, which is the amount of space its content can occupy. To build a scrollable view, measure the content wrapper separately and clamp the offset with `content.height - viewport.clientHeight`, together with the `contentOffsetX`/`contentOffsetY` props. That bound assumes an unpadded viewport, since `clientWidth`/`clientHeight` exclude borders but not padding; put padding on the content wrapper instead.
 

--- a/src/measure-element.ts
+++ b/src/measure-element.ts
@@ -1,3 +1,4 @@
+import Yoga from 'yoga-layout';
 import {type DOMElement} from './dom.js';
 
 type Output = {
@@ -20,21 +21,54 @@ type Output = {
 	Element height.
 	*/
 	height: number;
+
+	/**
+	Element width excluding borders.
+	*/
+	clientWidth: number;
+
+	/**
+	Element height excluding borders.
+	*/
+	clientHeight: number;
+
+	/**
+	Total width of the element's content, including content not visible due to overflow. Always at least `clientWidth`.
+	*/
+	scrollWidth: number;
+
+	/**
+	Total height of the element's content, including content not visible due to overflow. Always at least `clientHeight`.
+	*/
+	scrollHeight: number;
+};
+
+const emptyOutput: Output = {
+	x: 0,
+	y: 0,
+	width: 0,
+	height: 0,
+	clientWidth: 0,
+	clientHeight: 0,
+	scrollWidth: 0,
+	scrollHeight: 0,
 };
 
 /**
 Measure the layout metrics of a particular `<Box>` element.
-Returns an object with `x`, `y`, `width`, and `height` properties.
+Returns an object with `x`, `y`, `width`, `height`, `clientWidth`, `clientHeight`, `scrollWidth` and `scrollHeight` properties.
 
 `x` and `y` are the element's position within the live layout region, computed by walking up the layout tree and accumulating each ancestor's offset. These are layout-tree coordinates, not terminal viewport coordinates. To compare them with mouse events, convert the event coordinates using the live region's viewport position. This is necessary even in alternate-screen mode when output, such as `<Static>` content, appears above the live region.
 
-Note: `measureElement()` returns `{x: 0, y: 0, width: 0, height: 0}` when called during render (before layout is calculated). Call it from post-render code, such as `useEffect`, `useLayoutEffect`, input handlers, or timer callbacks. When content changes, pass the relevant dependency to your effect so it re-measures after each update.
+The remaining properties are useful when your component needs to know the amount of available space it has, or how far its content overflows. You can use them when you need to change the layout based on the length of its content, or to build scrollable views together with the `contentOffsetX`/`contentOffsetY` props.
+
+Note: `measureElement()` returns zeros for all properties when called during render (before layout is calculated). Call it from post-render code, such as `useEffect`, `useLayoutEffect`, input handlers, or timer callbacks. When content changes, pass the relevant dependency to your effect so it re-measures after each update.
 */
 const measureElement = (node: DOMElement): Output => {
 	const {yogaNode} = node;
 
 	if (!yogaNode) {
-		return {x: 0, y: 0, width: 0, height: 0};
+		return emptyOutput;
 	}
 
 	let x = yogaNode.getComputedLeft();
@@ -51,11 +85,49 @@ const measureElement = (node: DOMElement): Output => {
 		current = current.parentNode;
 	}
 
+	const width = yogaNode.getComputedWidth();
+	const height = yogaNode.getComputedHeight();
+	const borderLeft = yogaNode.getComputedBorder(Yoga.EDGE_LEFT);
+	const borderTop = yogaNode.getComputedBorder(Yoga.EDGE_TOP);
+
+	const clientWidth =
+		width - borderLeft - yogaNode.getComputedBorder(Yoga.EDGE_RIGHT);
+
+	const clientHeight =
+		height - borderTop - yogaNode.getComputedBorder(Yoga.EDGE_BOTTOM);
+
+	let contentWidth = 0;
+	let contentHeight = 0;
+
+	for (let index = 0; index < yogaNode.getChildCount(); index++) {
+		const child = yogaNode.getChild(index);
+
+		contentWidth = Math.max(
+			contentWidth,
+			child.getComputedLeft() -
+				borderLeft +
+				child.getComputedWidth() +
+				child.getComputedMargin(Yoga.EDGE_RIGHT),
+		);
+
+		contentHeight = Math.max(
+			contentHeight,
+			child.getComputedTop() -
+				borderTop +
+				child.getComputedHeight() +
+				child.getComputedMargin(Yoga.EDGE_BOTTOM),
+		);
+	}
+
 	return {
 		x,
 		y,
-		width: yogaNode.getComputedWidth(),
-		height: yogaNode.getComputedHeight(),
+		width,
+		height,
+		clientWidth,
+		clientHeight,
+		scrollWidth: Math.max(contentWidth, clientWidth),
+		scrollHeight: Math.max(contentHeight, clientHeight),
 	};
 };
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -47,6 +47,36 @@ type UnclipOperation = {
 	type: 'unclip';
 };
 
+// An undefined bound means "unbounded on this edge", so intersecting keeps whichever bound is defined and takes the tighter one when both are.
+const intersectBound = (
+	a: number | undefined,
+	b: number | undefined,
+	tighter: (a: number, b: number) => number,
+): number | undefined => {
+	if (a === undefined) {
+		return b;
+	}
+
+	if (b === undefined) {
+		return a;
+	}
+
+	return tighter(a, b);
+};
+
+const intersectClips = (outer: Clip | undefined, inner: Clip): Clip => {
+	if (!outer) {
+		return inner;
+	}
+
+	return {
+		x1: intersectBound(outer.x1, inner.x1, Math.max),
+		x2: intersectBound(outer.x2, inner.x2, Math.min),
+		y1: intersectBound(outer.y1, inner.y1, Math.max),
+		y2: intersectBound(outer.y2, inner.y2, Math.min),
+	};
+};
+
 class OutputCaches {
 	widths = new Map<string, number>();
 	blockWidths = new Map<string, number>();
@@ -159,7 +189,8 @@ export default class Output {
 
 		for (const operation of this.operations) {
 			if (operation.type === 'clip') {
-				clips.push(operation.clip);
+				// Nested clips must intersect, not replace, otherwise an inner `overflow="hidden"` box lets content escape the outer clip and overwrite surrounding UI.
+				clips.push(intersectClips(clips.at(-1), operation.clip));
 			}
 
 			if (operation.type === 'unclip') {

--- a/src/output.ts
+++ b/src/output.ts
@@ -166,6 +166,23 @@ export default class Output {
 		});
 	}
 
+	// `sliceAnsi` works in terminal columns, but it drops a wide character (e.g. CJK) outright when the slice edge falls between its two halves. The visible half still owns a cell, so without padding it back the rest of the line shifts by a column and one column of content disappears.
+	sliceLineToColumns(line: string, from: number, to: number): string {
+		const slice = sliceAnsi(line, from, to);
+		const lostLeading =
+			from > 0
+				? from - this.caches.getStringWidth(sliceAnsi(line, 0, from))
+				: 0;
+		const lostTrailing =
+			to - from - this.caches.getStringWidth(slice) - lostLeading;
+
+		return (
+			' '.repeat(Math.max(0, lostLeading)) +
+			slice +
+			' '.repeat(Math.max(0, lostTrailing))
+		);
+	}
+
 	get(): {output: string; height: number} {
 		// Initialize output array with a specific set of rows, so that margin/padding at the bottom is preserved
 		const output: StyledChar[][] = [];
@@ -235,7 +252,7 @@ export default class Output {
 							const width = this.caches.getStringWidth(line);
 							const to = x + width > clip.x2! ? clip.x2! - x : width;
 
-							return sliceAnsi(line, from, to);
+							return this.sliceLineToColumns(line, from, to);
 						});
 
 						if (x < clip.x1!) {

--- a/src/output.ts
+++ b/src/output.ts
@@ -64,6 +64,11 @@ const intersectBound = (
 	return tighter(a, b);
 };
 
+// Bounds are half-open: `x2`/`y2` are exclusive, so an axis is empty as soon as its lower bound reaches its upper one.
+const isClipEmpty = (clip: Clip): boolean =>
+	(clip.x1 !== undefined && clip.x2 !== undefined && clip.x1 >= clip.x2) ||
+	(clip.y1 !== undefined && clip.y2 !== undefined && clip.y1 >= clip.y2);
+
 const intersectClips = (outer: Clip | undefined, inner: Clip): Clip => {
 	if (!outer) {
 		return inner;
@@ -222,6 +227,11 @@ export default class Output {
 				const clip = clips.at(-1);
 
 				if (clip) {
+					// Two nested clips can intersect to nothing. Nothing is visible, so bail out before slicing: a `from` past `to` reaches the wide-character padding below, which would manufacture a space and write it at the clip edge, outside both clips.
+					if (isClipEmpty(clip)) {
+						continue;
+					}
+
 					const clipHorizontally =
 						typeof clip?.x1 === 'number' && typeof clip?.x2 === 'number';
 

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -29,6 +29,10 @@ const applyPaddingToText = (node: DOMElement, text: string): string => {
 
 export type OutputTransformer = (s: string, index: number) => string;
 
+// Content offsets end up as terminal cell coordinates, so they have to be whole numbers. Fractions would drop or duplicate cells and non-finite values would erase content entirely.
+const normalizeContentOffset = (value: number | undefined): number =>
+	typeof value === 'number' && Number.isFinite(value) ? Math.trunc(value) : 0;
+
 export const renderNodeToScreenReaderOutput = (
 	node: DOMElement,
 	options: {
@@ -197,8 +201,8 @@ const renderNodeToOutput = (
 		if (node.nodeName === 'ink-root' || node.nodeName === 'ink-box') {
 			for (const childNode of node.childNodes) {
 				renderNodeToOutput(childNode as DOMElement, output, {
-					offsetX: x - (node.style.contentOffsetX ?? 0),
-					offsetY: y - (node.style.contentOffsetY ?? 0),
+					offsetX: x - normalizeContentOffset(node.style.contentOffsetX),
+					offsetY: y - normalizeContentOffset(node.style.contentOffsetY),
 					transformers: newTransformers,
 					skipStaticElements,
 				});

--- a/src/render-node-to-output.ts
+++ b/src/render-node-to-output.ts
@@ -197,8 +197,8 @@ const renderNodeToOutput = (
 		if (node.nodeName === 'ink-root' || node.nodeName === 'ink-box') {
 			for (const childNode of node.childNodes) {
 				renderNodeToOutput(childNode as DOMElement, output, {
-					offsetX: x,
-					offsetY: y,
+					offsetX: x - (node.style.contentOffsetX ?? 0),
+					offsetY: y - (node.style.contentOffsetY ?? 0),
 					transformers: newTransformers,
 					skipStaticElements,
 				});

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -389,6 +389,20 @@ export type Styles = {
 	readonly overflowY?: 'visible' | 'hidden';
 
 	/**
+	Horizontal offset applied to the element's children, in columns. Children are shifted left by this amount. Combine with `overflow="hidden"` to build scrollable views.
+
+	@default 0
+	*/
+	readonly contentOffsetX?: number;
+
+	/**
+	Vertical offset applied to the element's children, in rows. Children are shifted up by this amount. Combine with `overflow="hidden"` to build scrollable views.
+
+	@default 0
+	*/
+	readonly contentOffsetY?: number;
+
+	/**
 	Background color for the element.
 
 	Accepts the same values as `color` in the `<Text>` component.

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -391,12 +391,16 @@ export type Styles = {
 	/**
 	Horizontal offset applied to the element's children, in columns. Children are shifted left by this amount. Combine with `overflow="hidden"` to build scrollable views.
 
+	Offsets are terminal cell coordinates, so fractional values are truncated toward zero and non-finite values are treated as `0`.
+
 	@default 0
 	*/
 	readonly contentOffsetX?: number;
 
 	/**
 	Vertical offset applied to the element's children, in rows. Children are shifted up by this amount. Combine with `overflow="hidden"` to build scrollable views.
+
+	Offsets are terminal cell coordinates, so fractional values are truncated toward zero and non-finite values are treated as `0`.
 
 	@default 0
 	*/

--- a/test/content-offset.tsx
+++ b/test/content-offset.tsx
@@ -345,3 +345,35 @@ test('contentOffsetX/Y - non-finite offsets fall back to zero', t => {
 		t.is(horizontal, 'ABCDEF');
 	}
 });
+
+test('contentOffsetX - preserves columns when offset splits a wide character', t => {
+	const render = (contentOffsetX: number) =>
+		renderToString(
+			<Box width={2} overflowX="hidden" contentOffsetX={contentOffsetX}>
+				<Box width={3} flexShrink={0}>
+					<Text>你A</Text>
+				</Box>
+			</Box>,
+		);
+
+	// The viewport starts on the second half of `你`, which occupies a cell of
+	// its own, so `A` stays in the second column instead of sliding left.
+	t.is(render(1), ' A');
+	t.is(render(2), 'A');
+});
+
+test('contentOffsetX - preserves columns when the right edge splits a wide character', t => {
+	const output = renderToString(
+		<Box>
+			<Box width={2} overflowX="hidden">
+				<Box width={3} flexShrink={0}>
+					<Text>A你</Text>
+				</Box>
+			</Box>
+			<Text>Z</Text>
+		</Box>,
+	);
+
+	// The clipped half of `你` still owns its cell, so `Z` keeps the third column.
+	t.is(output, 'A Z');
+});

--- a/test/content-offset.tsx
+++ b/test/content-offset.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import test from 'ava';
+import boxen from 'boxen';
+import {Box, Text} from '../src/index.js';
+import {renderToString} from './helpers/render-to-string.js';
+
+test('contentOffsetY - scrolls content up', t => {
+	const output = renderToString(
+		<Box
+			height={2}
+			overflowY="hidden"
+			contentOffsetY={1}
+			flexDirection="column"
+		>
+			<Box flexDirection="column" flexShrink={0}>
+				<Text>Line 1</Text>
+				<Text>Line 2</Text>
+				<Text>Line 3</Text>
+			</Box>
+		</Box>,
+	);
+
+	t.is(output, 'Line 2\nLine 3');
+});
+
+test('contentOffsetY - zero offset renders content unchanged', t => {
+	const output = renderToString(
+		<Box
+			height={2}
+			overflowY="hidden"
+			contentOffsetY={0}
+			flexDirection="column"
+		>
+			<Box flexDirection="column" flexShrink={0}>
+				<Text>Line 1</Text>
+				<Text>Line 2</Text>
+				<Text>Line 3</Text>
+			</Box>
+		</Box>,
+	);
+
+	t.is(output, 'Line 1\nLine 2');
+});
+
+test('contentOffsetY - offset beyond content renders empty', t => {
+	const output = renderToString(
+		<Box
+			height={2}
+			overflowY="hidden"
+			contentOffsetY={5}
+			flexDirection="column"
+		>
+			<Box flexDirection="column" flexShrink={0}>
+				<Text>Line 1</Text>
+				<Text>Line 2</Text>
+			</Box>
+		</Box>,
+	);
+
+	t.is(output, '\n');
+});
+
+test('contentOffsetX - scrolls content left', t => {
+	const output = renderToString(
+		<Box width={5} overflowX="hidden" contentOffsetX={6}>
+			<Box width={11} flexShrink={0}>
+				<Text>Hello World</Text>
+			</Box>
+		</Box>,
+	);
+
+	t.is(output, 'World');
+});
+
+test('contentOffsetX and contentOffsetY - scroll both directions', t => {
+	const output = renderToString(
+		<Box
+			width={3}
+			height={2}
+			overflow="hidden"
+			contentOffsetX={2}
+			contentOffsetY={1}
+			flexDirection="column"
+		>
+			<Box flexDirection="column" flexShrink={0} width={5}>
+				<Text>aaaaa</Text>
+				<Text>bbbbb</Text>
+				<Text>ccccc</Text>
+			</Box>
+		</Box>,
+	);
+
+	t.is(output, 'bbb\nccc');
+});
+
+test('contentOffsetY - content stays inside border', t => {
+	const output = renderToString(
+		<Box
+			height={4}
+			width={8}
+			overflowY="hidden"
+			contentOffsetY={1}
+			borderStyle="round"
+			flexDirection="column"
+		>
+			<Box flexDirection="column" flexShrink={0}>
+				<Text>Line 1</Text>
+				<Text>Line 2</Text>
+				<Text>Line 3</Text>
+			</Box>
+		</Box>,
+	);
+
+	t.is(output, boxen('Line 2\nLine 3', {borderStyle: 'round', width: 8}));
+});
+
+test('contentOffsetY - nested offset containers compose', t => {
+	const output = renderToString(
+		<Box
+			height={2}
+			overflowY="hidden"
+			contentOffsetY={1}
+			flexDirection="column"
+		>
+			<Box
+				height={4}
+				overflowY="hidden"
+				contentOffsetY={1}
+				flexDirection="column"
+				flexShrink={0}
+			>
+				<Box flexDirection="column" flexShrink={0}>
+					<Text>Line 1</Text>
+					<Text>Line 2</Text>
+					<Text>Line 3</Text>
+					<Text>Line 4</Text>
+				</Box>
+			</Box>
+		</Box>,
+	);
+
+	// Inner box scrolls to lines 2-4; outer box shows rows 2-3 of that: lines 3-4.
+	t.is(output, 'Line 3\nLine 4');
+});

--- a/test/content-offset.tsx
+++ b/test/content-offset.tsx
@@ -226,6 +226,31 @@ test('disjoint nested clips render nothing', t => {
 	t.is(output, 'HEADER\n');
 });
 
+test('disjoint nested clips do not overwrite content when a wide character straddles the edge', t => {
+	const output = renderToString(
+		<Box flexDirection="column">
+			<Text>XXXXXXXXXX</Text>
+			<Box marginTop={-1} width={5} overflowX="hidden" flexShrink={0}>
+				<Box
+					marginLeft={6}
+					width={5}
+					overflowX="hidden"
+					contentOffsetX={1}
+					flexShrink={0}
+				>
+					<Box flexShrink={0}>
+						<Text>你AAAA</Text>
+					</Box>
+				</Box>
+			</Box>
+		</Box>,
+		{columns: 20},
+	);
+
+	// The clips cover columns 0-5 and 6-11, so the intersection is empty. The offset puts the write one column left of the inner clip, splitting the wide character, and the padding that repairs a split cell used to be emitted even though no column was visible, landing a space on column 6 and blanking a cell outside both clips.
+	t.is(output, 'XXXXXXXXXX\n');
+});
+
 test('contentOffsetY - nested clipped content does not escape the outer viewport', t => {
 	const output = renderToString(
 		<Box flexDirection="column">

--- a/test/content-offset.tsx
+++ b/test/content-offset.tsx
@@ -362,18 +362,37 @@ test('contentOffsetX - preserves columns when offset splits a wide character', t
 	t.is(render(2), 'A');
 });
 
-test('contentOffsetX - preserves columns when the right edge splits a wide character', t => {
+test('contentOffsetX - preserves columns across a line of wide characters', t => {
+	// `你好AB` occupies columns: 你 (0-1), 好 (2-3), A (4), B (5).
+	const expected = ['你好', ' 好A', '好AB', ' AB', 'AB'];
+
+	for (const [contentOffsetX, want] of expected.entries()) {
+		const output = renderToString(
+			<Box width={4} overflowX="hidden" contentOffsetX={contentOffsetX}>
+				<Box width={6} flexShrink={0}>
+					<Text>你好AB</Text>
+				</Box>
+			</Box>,
+		);
+
+		t.is(output, want, `offset ${contentOffsetX}`);
+	}
+});
+
+test('clipping blanks the cell of a wide character split by the right edge', t => {
 	const output = renderToString(
 		<Box>
-			<Box width={2} overflowX="hidden">
+			<Text>XY</Text>
+			<Box position="absolute" width={2} overflowX="hidden">
 				<Box width={3} flexShrink={0}>
 					<Text>A你</Text>
 				</Box>
 			</Box>
-			<Text>Z</Text>
 		</Box>,
 	);
 
-	// The clipped half of `你` still owns its cell, so `Z` keeps the third column.
-	t.is(output, 'A Z');
+	// The clipped half of `你` owns its cell and blanks the `Y` underneath,
+	// rather than leaving a stale character behind. Trailing blanks are trimmed
+	// from the rendered line, so this reads as 'A'.
+	t.is(output, 'A');
 });

--- a/test/content-offset.tsx
+++ b/test/content-offset.tsx
@@ -160,3 +160,188 @@ test('contentOffsetY - nested offset containers compose', t => {
 	// Inner box scrolls to lines 2-4; outer box shows rows 2-3 of that: lines 3-4.
 	t.is(output, 'Line 3\nLine 4');
 });
+
+test('nested clipped content stays inside the outer clip', t => {
+	const output = renderToString(
+		<Box flexDirection="column">
+			<Text>ABOVE</Text>
+			<Box height={2} overflowY="hidden" flexDirection="column">
+				<Box
+					height={4}
+					marginTop={-2}
+					overflowY="hidden"
+					flexDirection="column"
+					flexShrink={0}
+				>
+					<Text>Line 1</Text>
+					<Text>Line 2</Text>
+					<Text>Line 3</Text>
+					<Text>Line 4</Text>
+				</Box>
+			</Box>
+		</Box>,
+	);
+
+	// The inner box starts above the outer viewport, so its own clip alone would let lines 1-2 paint over "ABOVE". Only the intersection of both clips keeps them out. No content offset involved, this is the underlying renderer bug.
+	t.is(output, 'ABOVE\nLine 3\nLine 4');
+});
+
+test('nested clips on different axes both apply', t => {
+	const output = renderToString(
+		<Box flexDirection="column">
+			<Text>HEADER</Text>
+			<Box height={2} overflowY="hidden" flexDirection="column">
+				<Box
+					width={3}
+					overflowX="hidden"
+					marginTop={-1}
+					flexDirection="column"
+					flexShrink={0}
+				>
+					<Text>AAAAAA</Text>
+					<Text>BBBBBB</Text>
+					<Text>CCCCCC</Text>
+				</Box>
+			</Box>
+		</Box>,
+	);
+
+	// The inner box clips only horizontally and the outer only vertically, so the merged clip has to carry both bounds. "AAA" sits a row above the viewport and must not reach "HEADER".
+	t.is(output, 'HEADER\nAAA\nBBB');
+});
+
+test('disjoint nested clips render nothing', t => {
+	const output = renderToString(
+		<Box flexDirection="column">
+			<Text>HEADER</Text>
+			<Box width={5} overflowX="hidden">
+				<Box marginLeft={10} width={10} overflowX="hidden" flexShrink={0}>
+					<Text>XXXXXXXXXX</Text>
+				</Box>
+			</Box>
+		</Box>,
+	);
+
+	// The two clips do not overlap, so the intersection is empty and nothing may be drawn.
+	t.is(output, 'HEADER\n');
+});
+
+test('contentOffsetY - nested clipped content does not escape the outer viewport', t => {
+	const output = renderToString(
+		<Box flexDirection="column">
+			<Text>ABOVE</Text>
+			<Box
+				height={2}
+				overflowY="hidden"
+				contentOffsetY={1}
+				flexDirection="column"
+			>
+				<Box
+					height={4}
+					overflowY="hidden"
+					flexDirection="column"
+					flexShrink={0}
+				>
+					<Text>Line 1</Text>
+					<Text>Line 2</Text>
+					<Text>Line 3</Text>
+					<Text>Line 4</Text>
+				</Box>
+			</Box>
+		</Box>,
+	);
+
+	// Offsetting the outer box must not let the inner box paint over "ABOVE" above it.
+	t.is(output, 'ABOVE\nLine 2\nLine 3');
+});
+
+test('contentOffsetX/Y - fractional offsets are truncated to whole cells', t => {
+	const vertical = renderToString(
+		<Box
+			height={2}
+			overflowY="hidden"
+			contentOffsetY={1.5}
+			flexDirection="column"
+		>
+			<Box flexDirection="column" flexShrink={0}>
+				<Text>Line 1</Text>
+				<Text>Line 2</Text>
+				<Text>Line 3</Text>
+			</Box>
+		</Box>,
+	);
+
+	t.is(vertical, 'Line 2\nLine 3');
+
+	const horizontal = renderToString(
+		<Box width={6} overflowX="hidden" contentOffsetX={1.5}>
+			<Box flexShrink={0}>
+				<Text>ABCDEF</Text>
+			</Box>
+		</Box>,
+	);
+
+	t.is(horizontal, 'BCDEF');
+});
+
+test('contentOffsetX/Y - negative fractional offsets are truncated to whole cells', t => {
+	const vertical = renderToString(
+		<Box
+			height={2}
+			overflowY="hidden"
+			contentOffsetY={-0.5}
+			flexDirection="column"
+		>
+			<Box flexDirection="column" flexShrink={0}>
+				<Text>Line 1</Text>
+				<Text>Line 2</Text>
+			</Box>
+		</Box>,
+	);
+
+	t.is(vertical, 'Line 1\nLine 2');
+
+	const horizontal = renderToString(
+		<Box width={6} overflowX="hidden" contentOffsetX={-0.5}>
+			<Box flexShrink={0}>
+				<Text>ABCDEF</Text>
+			</Box>
+		</Box>,
+	);
+
+	t.is(horizontal, 'ABCDEF');
+});
+
+test('contentOffsetX/Y - non-finite offsets fall back to zero', t => {
+	for (const offset of [
+		Number.NaN,
+		Number.POSITIVE_INFINITY,
+		Number.NEGATIVE_INFINITY,
+	]) {
+		const vertical = renderToString(
+			<Box
+				height={2}
+				overflowY="hidden"
+				contentOffsetY={offset}
+				flexDirection="column"
+			>
+				<Box flexDirection="column" flexShrink={0}>
+					<Text>Line 1</Text>
+					<Text>Line 2</Text>
+				</Box>
+			</Box>,
+		);
+
+		t.is(vertical, 'Line 1\nLine 2');
+
+		const horizontal = renderToString(
+			<Box width={6} overflowX="hidden" contentOffsetX={offset}>
+				<Box flexShrink={0}>
+					<Text>ABCDEF</Text>
+				</Box>
+			</Box>,
+		);
+
+		t.is(horizontal, 'ABCDEF');
+	}
+});

--- a/test/content-offset.tsx
+++ b/test/content-offset.tsx
@@ -60,6 +60,24 @@ test('contentOffsetY - offset beyond content renders empty', t => {
 	t.is(output, '\n');
 });
 
+test('contentOffsetY - negative offset shifts content down', t => {
+	const output = renderToString(
+		<Box
+			height={2}
+			overflowY="hidden"
+			contentOffsetY={-1}
+			flexDirection="column"
+		>
+			<Box flexDirection="column" flexShrink={0}>
+				<Text>Line 1</Text>
+				<Text>Line 2</Text>
+			</Box>
+		</Box>,
+	);
+
+	t.is(output, '\nLine 1');
+});
+
 test('contentOffsetX - scrolls content left', t => {
 	const output = renderToString(
 		<Box width={5} overflowX="hidden" contentOffsetX={6}>

--- a/test/measure-element.tsx
+++ b/test/measure-element.tsx
@@ -397,3 +397,126 @@ test.serial('calculate layout while rendering is throttled', async t => {
 
 	t.is(stripAnsi(lastContentWrite).trim(), 'Width: 100');
 });
+
+test('measure element client and scroll size with overflowing content', async t => {
+	const stdout = createStdout();
+
+	function Test() {
+		const [metrics, setMetrics] = useState('');
+		const ref = useRef<DOMElement>(null);
+
+		useEffect(() => {
+			if (!ref.current) {
+				return;
+			}
+
+			const {clientWidth, clientHeight, scrollWidth, scrollHeight} =
+				measureElement(ref.current);
+
+			setMetrics(
+				`client:${clientWidth}x${clientHeight} scroll:${scrollWidth}x${scrollHeight}`,
+			);
+		}, []);
+
+		return (
+			<Box flexDirection="column">
+				<Box
+					ref={ref}
+					width={12}
+					height={2}
+					overflow="hidden"
+					flexDirection="column"
+				>
+					<Box width={20} height={5} flexShrink={0} flexGrow={0} />
+				</Box>
+				<Text>{metrics}</Text>
+			</Box>
+		);
+	}
+
+	render(<Test />, {stdout, debug: true});
+	await delay(100);
+
+	t.true(
+		stripAnsi((stdout.write as any).lastCall.firstArg as string).includes(
+			'client:12x2 scroll:20x5',
+		),
+	);
+});
+
+test('measure element client size excludes borders', async t => {
+	const stdout = createStdout();
+
+	function Test() {
+		const [metrics, setMetrics] = useState('');
+		const ref = useRef<DOMElement>(null);
+
+		useEffect(() => {
+			if (!ref.current) {
+				return;
+			}
+
+			const {width, height, clientWidth, clientHeight} = measureElement(
+				ref.current,
+			);
+
+			setMetrics(`${width}x${height} client:${clientWidth}x${clientHeight}`);
+		}, []);
+
+		return (
+			<Box flexDirection="column">
+				<Box ref={ref} width={12} height={4} borderStyle="round" />
+				<Text>{metrics}</Text>
+			</Box>
+		);
+	}
+
+	render(<Test />, {stdout, debug: true});
+	await delay(100);
+
+	t.true(
+		stripAnsi((stdout.write as any).lastCall.firstArg as string).includes(
+			'12x4 client:10x2',
+		),
+	);
+});
+
+test('measure element scroll size is at least client size', async t => {
+	const stdout = createStdout();
+
+	function Test() {
+		const [metrics, setMetrics] = useState('');
+		const ref = useRef<DOMElement>(null);
+
+		useEffect(() => {
+			if (!ref.current) {
+				return;
+			}
+
+			const {clientWidth, clientHeight, scrollWidth, scrollHeight} =
+				measureElement(ref.current);
+
+			setMetrics(
+				`client:${clientWidth}x${clientHeight} scroll:${scrollWidth}x${scrollHeight}`,
+			);
+		}, []);
+
+		return (
+			<Box flexDirection="column">
+				<Box ref={ref} width={12} height={4} flexDirection="column">
+					<Text>hi</Text>
+				</Box>
+				<Text>{metrics}</Text>
+			</Box>
+		);
+	}
+
+	render(<Test />, {stdout, debug: true});
+	await delay(100);
+
+	t.true(
+		stripAnsi((stdout.write as any).lastCall.firstArg as string).includes(
+			'client:12x4 scroll:12x4',
+		),
+	);
+});

--- a/test/measure-element.tsx
+++ b/test/measure-element.tsx
@@ -363,8 +363,6 @@ test('measure element returns zeros for node without yoga', t => {
 		height: 0,
 		clientWidth: 0,
 		clientHeight: 0,
-		scrollWidth: 0,
-		scrollHeight: 0,
 	});
 });
 
@@ -407,7 +405,7 @@ test.serial('calculate layout while rendering is throttled', async t => {
 	t.is(stripAnsi(lastContentWrite).trim(), 'Width: 100');
 });
 
-test('measure element client and scroll size with overflowing content', async t => {
+test('measure element client size with overflowing content', async t => {
 	const stdout = createStdout();
 
 	function Test() {
@@ -419,12 +417,9 @@ test('measure element client and scroll size with overflowing content', async t 
 				return;
 			}
 
-			const {clientWidth, clientHeight, scrollWidth, scrollHeight} =
-				measureElement(ref.current);
+			const {clientWidth, clientHeight} = measureElement(ref.current);
 
-			setMetrics(
-				`client:${clientWidth}x${clientHeight} scroll:${scrollWidth}x${scrollHeight}`,
-			);
+			setMetrics(`client:${clientWidth}x${clientHeight}`);
 		}, []);
 
 		return (
@@ -448,7 +443,7 @@ test('measure element client and scroll size with overflowing content', async t 
 
 	t.true(
 		stripAnsi((stdout.write as any).lastCall.firstArg as string).includes(
-			'client:12x2 scroll:20x5',
+			'client:12x2',
 		),
 	);
 });
@@ -486,46 +481,6 @@ test('measure element client size excludes borders', async t => {
 	t.true(
 		stripAnsi((stdout.write as any).lastCall.firstArg as string).includes(
 			'12x4 client:10x2',
-		),
-	);
-});
-
-test('measure element scroll size is at least client size', async t => {
-	const stdout = createStdout();
-
-	function Test() {
-		const [metrics, setMetrics] = useState('');
-		const ref = useRef<DOMElement>(null);
-
-		useEffect(() => {
-			if (!ref.current) {
-				return;
-			}
-
-			const {clientWidth, clientHeight, scrollWidth, scrollHeight} =
-				measureElement(ref.current);
-
-			setMetrics(
-				`client:${clientWidth}x${clientHeight} scroll:${scrollWidth}x${scrollHeight}`,
-			);
-		}, []);
-
-		return (
-			<Box flexDirection="column">
-				<Box ref={ref} width={12} height={4} flexDirection="column">
-					<Text>hi</Text>
-				</Box>
-				<Text>{metrics}</Text>
-			</Box>
-		);
-	}
-
-	render(<Test />, {stdout, debug: true});
-	await delay(100);
-
-	t.true(
-		stripAnsi((stdout.write as any).lastCall.firstArg as string).includes(
-			'client:12x4 scroll:12x4',
 		),
 	);
 });

--- a/test/measure-element.tsx
+++ b/test/measure-element.tsx
@@ -356,7 +356,16 @@ test('measure element returns zeros for node without yoga', t => {
 	} as unknown as DOMElement;
 
 	const metrics = measureElement(node);
-	t.deepEqual(metrics, {x: 0, y: 0, width: 0, height: 0});
+	t.deepEqual(metrics, {
+		x: 0,
+		y: 0,
+		width: 0,
+		height: 0,
+		clientWidth: 0,
+		clientHeight: 0,
+		scrollWidth: 0,
+		scrollHeight: 0,
+	});
 });
 
 test.serial('calculate layout while rendering is throttled', async t => {

--- a/test/use-box-metrics.tsx
+++ b/test/use-box-metrics.tsx
@@ -502,13 +502,14 @@ test('resets metrics when tracked element unmounts', async t => {
 	t.true(stripAnsi(stdout.get()).includes('Metrics: 0,0,0,0,false'));
 });
 
-test('returns client and scroll size for overflowing content', async t => {
+test('returns viewport client size and content size for overflowing content', async t => {
 	const stdout = createStdout(100);
 
 	function Test() {
 		const ref = useRef<DOMElement>(null);
-		const {clientWidth, clientHeight, scrollWidth, scrollHeight} =
-			useBoxMetrics(ref);
+		const contentRef = useRef<DOMElement>(null);
+		const {clientWidth, clientHeight} = useBoxMetrics(ref);
+		const content = useBoxMetrics(contentRef);
 
 		return (
 			<Box flexDirection="column">
@@ -519,11 +520,17 @@ test('returns client and scroll size for overflowing content', async t => {
 					overflow="hidden"
 					flexDirection="column"
 				>
-					<Box width={20} height={5} flexShrink={0} flexGrow={0} />
+					<Box
+						ref={contentRef}
+						width={20}
+						height={5}
+						flexShrink={0}
+						flexGrow={0}
+					/>
 				</Box>
 				<Text>
-					client:{clientWidth}x{clientHeight} scroll:{scrollWidth}x
-					{scrollHeight}
+					client:{clientWidth}x{clientHeight} content:{content.width}x
+					{content.height}
 				</Text>
 			</Box>
 		);
@@ -533,17 +540,17 @@ test('returns client and scroll size for overflowing content', async t => {
 	await waitUntilRenderFlush();
 	await delay(50);
 
-	t.true(stripAnsi(stdout.get()).includes('client:12x2 scroll:20x5'));
+	t.true(stripAnsi(stdout.get()).includes('client:12x2 content:20x5'));
 });
 
-test('scroll size updates when content grows', async t => {
+test('content size updates when content grows', async t => {
 	const stdout = createStdout(100);
 	let addItem!: () => void;
 
 	function Test() {
-		const ref = useRef<DOMElement>(null);
+		const contentRef = useRef<DOMElement>(null);
 		const [items, setItems] = useState(['a', 'b']);
-		const {scrollHeight} = useBoxMetrics(ref);
+		const content = useBoxMetrics(contentRef);
 
 		addItem = () => {
 			setItems(previousItems => [
@@ -554,14 +561,14 @@ test('scroll size updates when content grows', async t => {
 
 		return (
 			<Box flexDirection="column">
-				<Box ref={ref} height={2} overflowY="hidden" flexDirection="column">
-					<Box flexDirection="column" flexShrink={0}>
+				<Box height={2} overflowY="hidden" flexDirection="column">
+					<Box ref={contentRef} flexDirection="column" flexShrink={0}>
 						{items.map(item => (
 							<Text key={item}>{item}</Text>
 						))}
 					</Box>
 				</Box>
-				<Text>scrollHeight:{scrollHeight}</Text>
+				<Text>contentHeight:{content.height}</Text>
 			</Box>
 		);
 	}
@@ -570,10 +577,10 @@ test('scroll size updates when content grows', async t => {
 	await waitUntilRenderFlush();
 	await delay(50);
 
-	t.true(stripAnsi(stdout.get()).includes('scrollHeight:2'));
+	t.true(stripAnsi(stdout.get()).includes('contentHeight:2'));
 
 	addItem();
 	await delay(50);
 
-	t.true(stripAnsi(stdout.get()).includes('scrollHeight:3'));
+	t.true(stripAnsi(stdout.get()).includes('contentHeight:3'));
 });

--- a/test/use-box-metrics.tsx
+++ b/test/use-box-metrics.tsx
@@ -501,3 +501,79 @@ test('resets metrics when tracked element unmounts', async t => {
 
 	t.true(stripAnsi(stdout.get()).includes('Metrics: 0,0,0,0,false'));
 });
+
+test('returns client and scroll size for overflowing content', async t => {
+	const stdout = createStdout(100);
+
+	function Test() {
+		const ref = useRef<DOMElement>(null);
+		const {clientWidth, clientHeight, scrollWidth, scrollHeight} =
+			useBoxMetrics(ref);
+
+		return (
+			<Box flexDirection="column">
+				<Box
+					ref={ref}
+					width={12}
+					height={2}
+					overflow="hidden"
+					flexDirection="column"
+				>
+					<Box width={20} height={5} flexShrink={0} flexGrow={0} />
+				</Box>
+				<Text>
+					client:{clientWidth}x{clientHeight} scroll:{scrollWidth}x
+					{scrollHeight}
+				</Text>
+			</Box>
+		);
+	}
+
+	const {waitUntilRenderFlush} = render(<Test />, {stdout, debug: true});
+	await waitUntilRenderFlush();
+	await delay(50);
+
+	t.true(stripAnsi(stdout.get()).includes('client:12x2 scroll:20x5'));
+});
+
+test('scroll size updates when content grows', async t => {
+	const stdout = createStdout(100);
+	let addItem!: () => void;
+
+	function Test() {
+		const ref = useRef<DOMElement>(null);
+		const [items, setItems] = useState(['a', 'b']);
+		const {scrollHeight} = useBoxMetrics(ref);
+
+		addItem = () => {
+			setItems(previousItems => [
+				...previousItems,
+				`item ${previousItems.length}`,
+			]);
+		};
+
+		return (
+			<Box flexDirection="column">
+				<Box ref={ref} height={2} overflowY="hidden" flexDirection="column">
+					<Box flexDirection="column" flexShrink={0}>
+						{items.map(item => (
+							<Text key={item}>{item}</Text>
+						))}
+					</Box>
+				</Box>
+				<Text>scrollHeight:{scrollHeight}</Text>
+			</Box>
+		);
+	}
+
+	const {waitUntilRenderFlush} = render(<Test />, {stdout, debug: true});
+	await waitUntilRenderFlush();
+	await delay(50);
+
+	t.true(stripAnsi(stdout.get()).includes('scrollHeight:2'));
+
+	addItem();
+	await delay(50);
+
+	t.true(stripAnsi(stdout.get()).includes('scrollHeight:3'));
+});


### PR DESCRIPTION
This implements the scrolling primitives sketched in #765, following the direction there: core primitives only, so a `ScrollView` can be built in userland (example included in the readme).

- `contentOffsetX` / `contentOffsetY` props on `Box`. Children are shifted left/up by the given number of columns/rows at render time. Combined with `overflow="hidden"`, this is the scroll mechanism. Layout is untouched, the offset is applied in `renderNodeToOutput` when recursing into children, so Yoga sees nothing new.
- `measureElement()` now also returns `clientWidth`/`clientHeight` (size excluding borders) and `scrollWidth`/`scrollHeight` (content extent including overflow, computed from child layout extents and clamped to be at least the client size, matching DOM semantics). These extend the `x`/`y`/`width`/`height` shape from #968.
- `useBoxMetrics()` returns the same four new fields, so a userland ScrollView can be fully reactive to content changes via the existing layout listener.
- The readme ScrollView recipe (and the runnable `examples/scroll`) wrap the content in a `flexShrink={0}` container. Without it, Yoga squeezes the children into the fixed-height viewport and there is nothing to scroll; the recipe notes this explicitly since it is the first thing anyone building a ScrollView will hit.

One deliberate divergence from the snippet in #765: child extents are measured relative to the inside of the container's border (parent border offsets are subtracted), so `scrollWidth === clientWidth` when content exactly fits a bordered box. The issue snippet measured against the outer edge, which over-reports the scroll extent by the border width.

Deliberately not included, per the discussion in #765: scrollbars, overflow indicators, an imperative scroll API, and any built-in `ScrollView` component. Offsets are also not clamped to the content extent, clamping policy belongs to the userland component (the readme example clamps via `scrollHeight - clientHeight`).

Tests: rendering tests for vertical/horizontal offsets, offsets inside borders, nested offset containers, offset beyond content, and a zero-offset behavior lock; metric tests for client/scroll sizes with overflowing content, borders, and content that grows after mount. All fail on `master` without the change (except the behavior lock). Verified manually in a real terminal with the included example (both axes, clamping at all edges).

Also relevant to #222.
