### PR TITLE
Fix: clear viewport with home + erase-down instead of `clearTerminal` (preserve scrollback)

### DIFF
--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -123,6 +123,12 @@ const stripKittyQueryResponsesAndTrailingPartial = (
 // pre-7.0 behavior of fully clearing between fullscreen frames there.
 const isWindowsConsole = process.platform === 'win32';
 
+// Full-clear fallback for frames taller than the viewport. `clearTerminal`
+// also emits CSI 3J, which erases the terminal's scrollback, and CSI 2J, which
+// VS Code and Windows Terminal handle by pushing the viewport into scrollback
+// first (#935). Home + erase-down clears only what is visible.
+const clearViewport = ansiEscapes.cursorTo(0, 0) + ansiEscapes.eraseDown;
+
 const shouldClearTerminalForFrame = ({
 	isTty,
 	viewportRows,
@@ -1125,7 +1131,7 @@ export default class Ink {
 			}
 
 			this.options.stdout.write(
-				ansiEscapes.clearTerminal + this.fullStaticOutput + outputToRender,
+				clearViewport + this.fullStaticOutput + outputToRender,
 			);
 			this.lastOutput = output;
 			this.lastOutputToRender = outputToRender;

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -123,7 +123,7 @@ const stripKittyQueryResponsesAndTrailingPartial = (
 // pre-7.0 behavior of fully clearing between fullscreen frames there.
 const isWindowsConsole = process.platform === 'win32';
 
-// Full-clear fallback for frames taller than the viewport. It must clear only
+// Full-clear path (see `shouldClearTerminalForFrame`). It must clear only
 // what is visible: `ansiEscapes.clearTerminal` emits CSI 3J, which erases the
 // terminal's scrollback, and both it and `ansiEscapes.clearViewport` emit
 // CSI 2J, which VS Code and Windows Terminal handle by pushing the viewport

--- a/src/ink.tsx
+++ b/src/ink.tsx
@@ -123,11 +123,14 @@ const stripKittyQueryResponsesAndTrailingPartial = (
 // pre-7.0 behavior of fully clearing between fullscreen frames there.
 const isWindowsConsole = process.platform === 'win32';
 
-// Full-clear fallback for frames taller than the viewport. `clearTerminal`
-// also emits CSI 3J, which erases the terminal's scrollback, and CSI 2J, which
-// VS Code and Windows Terminal handle by pushing the viewport into scrollback
-// first (#935). Home + erase-down clears only what is visible.
-const clearViewport = ansiEscapes.cursorTo(0, 0) + ansiEscapes.eraseDown;
+// Full-clear fallback for frames taller than the viewport. It must clear only
+// what is visible: `ansiEscapes.clearTerminal` emits CSI 3J, which erases the
+// terminal's scrollback, and both it and `ansiEscapes.clearViewport` emit
+// CSI 2J, which VS Code and Windows Terminal handle by pushing the viewport
+// into scrollback first (#935). Exported so tests assert against the real
+// sequence rather than a copy.
+export const homeAndEraseDown =
+	ansiEscapes.cursorTo(0, 0) + ansiEscapes.eraseDown;
 
 const shouldClearTerminalForFrame = ({
 	isTty,
@@ -1131,7 +1134,7 @@ export default class Ink {
 			}
 
 			this.options.stdout.write(
-				clearViewport + this.fullStaticOutput + outputToRender,
+				homeAndEraseDown + this.fullStaticOutput + outputToRender,
 			);
 			this.lastOutput = output;
 			this.lastOutputToRender = outputToRender;

--- a/test/cursor.tsx
+++ b/test/cursor.tsx
@@ -11,10 +11,10 @@ import {
 	useStdout,
 	useStderr,
 } from '../src/index.js';
+import {homeAndEraseDown} from '../src/ink.js';
 import {createStdin, emitReadable} from './helpers/create-stdin.js';
 import createStdout from './helpers/create-stdout.js';
 
-const clearViewport = ansiEscapes.cursorTo(0, 0) + ansiEscapes.eraseDown;
 const showCursorEscape = '\u001B[?25h';
 const hideCursorEscape = '\u001B[?25l';
 
@@ -784,7 +784,7 @@ for (const {name, incremental} of inkRenderingModes) {
 			await waitUntilRenderFlush();
 
 			const synced = getWriteCalls(stdout).slice(writesBeforeRerender).join('');
-			t.true(synced.includes(clearViewport), 'took the sync path');
+			t.true(synced.includes(homeAndEraseDown), 'took the sync path');
 			// 6 lines with no trailing newline: the cursor is left on row 5, so y=2
 			// is cursorUp(3), not the cursorUp(4) a visible-line-count basis gives.
 			t.true(

--- a/test/cursor.tsx
+++ b/test/cursor.tsx
@@ -14,6 +14,7 @@ import {
 import {createStdin, emitReadable} from './helpers/create-stdin.js';
 import createStdout from './helpers/create-stdout.js';
 
+const clearViewport = ansiEscapes.cursorTo(0, 0) + ansiEscapes.eraseDown;
 const showCursorEscape = '\u001B[?25h';
 const hideCursorEscape = '\u001B[?25l';
 
@@ -783,7 +784,7 @@ for (const {name, incremental} of inkRenderingModes) {
 			await waitUntilRenderFlush();
 
 			const synced = getWriteCalls(stdout).slice(writesBeforeRerender).join('');
-			t.true(synced.includes(ansiEscapes.clearTerminal), 'took the sync path');
+			t.true(synced.includes(clearViewport), 'took the sync path');
 			// 6 lines with no trailing newline: the cursor is left on row 5, so y=2
 			// is cursorUp(3), not the cursorUp(4) a visible-line-count basis gives.
 			t.true(

--- a/test/fixtures/issue-450-fixture-helpers.tsx
+++ b/test/fixtures/issue-450-fixture-helpers.tsx
@@ -8,19 +8,24 @@ type RerenderFixtureOptions = {
 	readonly includeStaticLine?: boolean;
 	readonly rowsFallback?: number;
 	readonly heightForFrame: (rows: number, frameCount: number) => number;
+	readonly labelForFrame?: (frameCount: number) => string;
 };
+
+const defaultLabelForFrame = (frameCount: number) => `frame ${frameCount}`;
 
 function Issue450RerenderFixtureComponent({
 	completionMarker,
 	frameLimit,
 	includeStaticLine,
 	heightForFrame,
+	labelForFrame,
 	rows,
 }: {
 	readonly completionMarker?: string;
 	readonly frameLimit: number;
 	readonly includeStaticLine: boolean;
 	readonly heightForFrame: (rows: number, frameCount: number) => number;
+	readonly labelForFrame: (frameCount: number) => string;
 	readonly rows: number;
 }) {
 	const {exit} = useApp();
@@ -61,7 +66,7 @@ function Issue450RerenderFixtureComponent({
 			<Box height={targetHeight} flexDirection="column">
 				<Text>#450 top</Text>
 				<Box flexGrow={1}>
-					<Text>{`frame ${frameCount}`}</Text>
+					<Text>{labelForFrame(frameCount)}</Text>
 				</Box>
 				<Text>#450 bottom</Text>
 			</Box>
@@ -75,6 +80,7 @@ export const runIssue450RerenderFixture = ({
 	includeStaticLine = false,
 	rowsFallback = 6,
 	heightForFrame,
+	labelForFrame = defaultLabelForFrame,
 }: RerenderFixtureOptions): void => {
 	const rows = Number(process.argv[2]) || rowsFallback;
 	process.stdout.rows = rows;
@@ -85,6 +91,7 @@ export const runIssue450RerenderFixture = ({
 			frameLimit={frameLimit}
 			includeStaticLine={includeStaticLine}
 			heightForFrame={heightForFrame}
+			labelForFrame={labelForFrame}
 			rows={rows}
 		/>,
 	);

--- a/test/fixtures/issue-935-overflow-rerender.tsx
+++ b/test/fixtures/issue-935-overflow-rerender.tsx
@@ -9,4 +9,8 @@ for (let index = 0; index < rows; index++) {
 
 runIssue450RerenderFixture({
 	heightForFrame: rows => rows + 1,
+	// The last frame is shorter than the one before it, so an incomplete clear
+	// leaves the tail of the previous frame's row behind (`frame 8 STALE-ROW`).
+	labelForFrame: frameCount =>
+		frameCount === 7 ? 'frame 7 STALE-ROW' : `frame ${frameCount}`,
 });

--- a/test/fixtures/issue-935-overflow-rerender.tsx
+++ b/test/fixtures/issue-935-overflow-rerender.tsx
@@ -8,6 +8,9 @@ for (let index = 0; index < rows; index++) {
 }
 
 runIssue450RerenderFixture({
+	// Overflow by exactly one row: only the top row scrolls into scrollback per
+	// frame, so the label row below it stays in the viewport, where a full clear
+	// erases it before the next frame is written.
 	heightForFrame: rows => rows + 1,
 	// One frame's label is longer than the others, so an incomplete clear leaves
 	// its tail behind (`#450 topSTALE-ROW`) instead of being overwritten.

--- a/test/fixtures/issue-935-overflow-rerender.tsx
+++ b/test/fixtures/issue-935-overflow-rerender.tsx
@@ -9,8 +9,8 @@ for (let index = 0; index < rows; index++) {
 
 runIssue450RerenderFixture({
 	heightForFrame: rows => rows + 1,
-	// The last frame is shorter than the one before it, so an incomplete clear
-	// leaves the tail of the previous frame's row behind (`frame 8 STALE-ROW`).
+	// One frame's label is longer than the others, so an incomplete clear leaves
+	// its tail behind (`#450 topSTALE-ROW`) instead of being overwritten.
 	labelForFrame: frameCount =>
 		frameCount === 7 ? 'frame 7 STALE-ROW' : `frame ${frameCount}`,
 });

--- a/test/fixtures/issue-935-overflow-rerender.tsx
+++ b/test/fixtures/issue-935-overflow-rerender.tsx
@@ -1,0 +1,12 @@
+import process from 'node:process';
+import {runIssue450RerenderFixture} from './issue-450-fixture-helpers.js';
+
+// Pre-existing terminal output that must survive Ink's full-clear fallback.
+const rows = Number(process.argv[2]) || 6;
+for (let index = 0; index < rows; index++) {
+	process.stdout.write(`#935 scrollback ${index}\n`);
+}
+
+runIssue450RerenderFixture({
+	heightForFrame: rows => rows + 1,
+});

--- a/test/log-update.tsx
+++ b/test/log-update.tsx
@@ -439,7 +439,7 @@ for (const {name, incremental} of renderingModes) {
 		render.setCursorPosition({x: 5, y: 0});
 		render('Line 1\nLine 2\nLine 3\n');
 
-		// Sync() simulates clearTerminal path: screen is fully reset
+		// Sync() simulates Ink's full-clear (home + erase-down) path: screen is fully reset
 		render.sync('Fresh output\n');
 
 		// Next render should NOT include hideCursor + cursorDown (return-to-bottom prefix)

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -29,7 +29,7 @@ import {
 	useInput,
 	useStdin,
 } from '../src/index.js';
-import {type RenderMetrics} from '../src/ink.js';
+import {type RenderMetrics, homeAndEraseDown} from '../src/ink.js';
 import {bsu, esu} from '../src/write-synchronized.js';
 import {createStdin, emitReadable} from './helpers/create-stdin.js';
 import createStdout from './helpers/create-stdout.js';
@@ -240,10 +240,6 @@ const countOccurrences = (text: string, searchValue: string): number => {
 	return text.split(searchValue).length - 1;
 };
 
-// Ink's full-clear fallback for oversized frames: home + erase-down. It must
-// never be `clearTerminal`, whose CSI 3J wipes the terminal scrollback (#935).
-const clearViewport = ansiEscapes.cursorTo(0, 0) + ansiEscapes.eraseDown;
-
 const isWriteBarrierChunk = (chunk: string | Uint8Array): boolean =>
 	(typeof chunk === 'string' && chunk === '') ||
 	(chunk instanceof Uint8Array && chunk.length === 0);
@@ -383,7 +379,7 @@ type Issue450FixtureResult = {
 };
 
 const getIssue450ControlSequenceCounts = (output: string) => ({
-	fullClearCount: countOccurrences(output, clearViewport),
+	fullClearCount: countOccurrences(output, homeAndEraseDown),
 	eraseLineCount: countOccurrences(output, ansiEscapes.eraseLines(1)),
 });
 
@@ -479,7 +475,7 @@ function ThrowingComponentWithBoundary() {
 test.serial('do not erase screen', async t => {
 	const ps = term('erase', ['4']);
 	await ps.waitForExit();
-	t.false(ps.output.includes(clearViewport));
+	t.false(ps.output.includes(homeAndEraseDown));
 
 	for (const letter of ['A', 'B', 'C']) {
 		t.true(ps.output.includes(letter));
@@ -492,7 +488,7 @@ test.serial(
 		const ps = term('erase-with-static', ['4']);
 
 		await ps.waitForExit();
-		t.false(ps.output.includes(clearViewport));
+		t.false(ps.output.includes(homeAndEraseDown));
 
 		for (const letter of ['A', 'B', 'C', 'D', 'E', 'F']) {
 			t.true(ps.output.includes(letter));
@@ -536,13 +532,13 @@ test.serial(
 			'Expected the inflate phase to have rendered as its own frame',
 		);
 		t.true(
-			ps.output.includes(clearViewport),
+			ps.output.includes(homeAndEraseDown),
 			'Expected the overflow to have routed a frame through the full-clear path',
 		);
 
 		// The shrink frame's full clear is the last one; the lowercase "live-0"
 		// after it proves shrink and nudge rendered as separate frames.
-		const lastClearIndex = ps.output.lastIndexOf(clearViewport);
+		const lastClearIndex = ps.output.lastIndexOf(homeAndEraseDown);
 		t.false(
 			ps.output.includes('live-4', lastClearIndex),
 			'Expected the last full clear to be the shrink frame, not the inflate frame',
@@ -565,7 +561,7 @@ test.serial(
 test.serial('erase screen', async t => {
 	const ps = term('erase', ['3']);
 	await ps.waitForExit();
-	t.true(ps.output.includes(clearViewport));
+	t.true(ps.output.includes(homeAndEraseDown));
 
 	for (const letter of ['A', 'B', 'C']) {
 		t.true(ps.output.includes(letter));
@@ -577,7 +573,7 @@ test.serial(
 	async t => {
 		const ps = term('erase', ['3']);
 		await ps.waitForExit();
-		t.true(ps.output.includes(clearViewport));
+		t.true(ps.output.includes(homeAndEraseDown));
 
 		for (const letter of ['A', 'B', 'C']) {
 			t.true(ps.output.includes(letter));
@@ -618,7 +614,7 @@ test.serial('erase screen where state changes in small viewport', async t => {
 	const ps = term('erase-with-state-change', ['3']);
 	await ps.waitForExit();
 
-	const frames = ps.output.split(clearViewport);
+	const frames = ps.output.split(homeAndEraseDown);
 	const lastFrame = frames.at(-1);
 
 	for (const letter of ['A', 'B', 'C']) {
@@ -634,7 +630,7 @@ test.serial(
 
 		t.true(ps.output.includes('Bottom line'));
 
-		const lastFrame = ps.output.split(clearViewport).at(-1) ?? '';
+		const lastFrame = ps.output.split(homeAndEraseDown).at(-1) ?? '';
 
 		// Check that the bottom line is at the end without extra newlines
 		// In a 5-line terminal:
@@ -659,7 +655,7 @@ test.serial(
 		const ps = term('issue-442-full-height', [String(rows)]);
 		await ps.waitForExit();
 
-		const lastFrame = ps.output.split(clearViewport).at(-1) ?? '';
+		const lastFrame = ps.output.split(homeAndEraseDown).at(-1) ?? '';
 		const lastFrameContent = stripAnsi(lastFrame);
 		const lines = lastFrameContent.split('\n');
 
@@ -705,7 +701,7 @@ test.serial(
 		// Windows consoles scroll when the bottom-right cell is written, which
 		// breaks incremental erase for fullscreen frames. Each rerender must fall
 		// back to a full clear there.
-		const fullClearCount = countOccurrences(output, clearViewport);
+		const fullClearCount = countOccurrences(output, homeAndEraseDown);
 		t.true(
 			fullClearCount >= 2,
 			`Expected a full clear per fullscreen rerender, received ${fullClearCount}`,
@@ -725,7 +721,7 @@ test.serial(
 		);
 
 		t.false(
-			outputBeforeMarker.includes(clearViewport),
+			outputBeforeMarker.includes(homeAndEraseDown),
 			'Initial overflowing render should not clear terminal',
 		);
 	},
@@ -743,7 +739,7 @@ test.serial(
 		);
 
 		t.false(
-			outputBeforeMarker.includes(clearViewport),
+			outputBeforeMarker.includes(homeAndEraseDown),
 			'Initial full-height render should not clear terminal',
 		);
 	},
@@ -990,7 +986,7 @@ test.serial(
 			'issue-450-grow-to-overflow-rerender',
 			['3'],
 		);
-		t.false(output.includes(clearViewport));
+		t.false(output.includes(homeAndEraseDown));
 	},
 );
 

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -685,7 +685,7 @@ test.serial(
 		assertIssue450DynamicFrameOutput(t, output);
 		t.true(
 			fullClearCount <= 1,
-			`Expected at most one clearTerminal sequence, received ${fullClearCount}`,
+			`Expected at most one full-clear sequence, received ${fullClearCount}`,
 		);
 		t.true(
 			eraseLineCount > 0,
@@ -750,7 +750,7 @@ test.serial(
 );
 
 test.serial(
-	'#450 control: rows - 1 rerenders should avoid clearTerminal',
+	'#450 control: rows - 1 rerenders should avoid a full clear',
 	async t => {
 		const {output, fullClearCount, eraseLineCount} =
 			await runIssue450FixtureWithCounts('issue-450-height-minus-one-rerender');
@@ -795,10 +795,11 @@ test.serial(
 			);
 		}
 
-		// The final viewport shows the last frame only, without stale rows.
+		// The final viewport shows the last frame only. Frame 7's label is longer
+		// than frame 8's, so a missing or partial clear leaves `STALE-ROW` behind.
 		const viewport = visibleLines.slice(-rows);
 		t.true(viewport.some(line => line.includes('frame 8')));
-		t.false(viewport.some(line => line.includes('frame 7')));
+		t.false(viewport.some(line => line.includes('STALE-ROW')));
 	},
 );
 
@@ -1032,7 +1033,7 @@ test.serial(
 		assertIssue450DynamicFrameOutput(t, output);
 		t.true(
 			fullClearCount <= 1,
-			`Expected at most one clearTerminal sequence, received ${fullClearCount}`,
+			`Expected at most one full-clear sequence, received ${fullClearCount}`,
 		);
 		t.true(
 			eraseLineCount > 0,

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -240,6 +240,10 @@ const countOccurrences = (text: string, searchValue: string): number => {
 	return text.split(searchValue).length - 1;
 };
 
+// Ink's full-clear fallback for oversized frames: home + erase-down. It must
+// never be `clearTerminal`, whose CSI 3J wipes the terminal scrollback (#935).
+const clearViewport = ansiEscapes.cursorTo(0, 0) + ansiEscapes.eraseDown;
+
 const isWriteBarrierChunk = (chunk: string | Uint8Array): boolean =>
 	(typeof chunk === 'string' && chunk === '') ||
 	(chunk instanceof Uint8Array && chunk.length === 0);
@@ -308,7 +312,8 @@ type Issue450Fixture =
 	| 'issue-450-shrink-from-fullscreen-rerender'
 	| 'issue-450-shrink-from-overflow-rerender'
 	| 'issue-450-static-shrink-from-fullscreen-rerender'
-	| 'issue-969-windows-full-height-rerender';
+	| 'issue-969-windows-full-height-rerender'
+	| 'issue-935-overflow-rerender';
 
 const runIssue450Fixture = async (
 	fixture: Issue450Fixture,
@@ -373,12 +378,12 @@ const runNonTtyFixture = async (
 
 type Issue450FixtureResult = {
 	output: string;
-	clearTerminalCount: number;
+	fullClearCount: number;
 	eraseLineCount: number;
 };
 
 const getIssue450ControlSequenceCounts = (output: string) => ({
-	clearTerminalCount: countOccurrences(output, ansiEscapes.clearTerminal),
+	fullClearCount: countOccurrences(output, clearViewport),
 	eraseLineCount: countOccurrences(output, ansiEscapes.eraseLines(1)),
 });
 
@@ -387,12 +392,12 @@ const runIssue450FixtureWithCounts = async (
 	rows = 6,
 ): Promise<Issue450FixtureResult> => {
 	const output = await runIssue450Fixture(fixture, rows);
-	const {clearTerminalCount, eraseLineCount} =
+	const {fullClearCount, eraseLineCount} =
 		getIssue450ControlSequenceCounts(output);
 
 	return {
 		output,
-		clearTerminalCount,
+		fullClearCount,
 		eraseLineCount,
 	};
 };
@@ -474,7 +479,7 @@ function ThrowingComponentWithBoundary() {
 test.serial('do not erase screen', async t => {
 	const ps = term('erase', ['4']);
 	await ps.waitForExit();
-	t.false(ps.output.includes(ansiEscapes.clearTerminal));
+	t.false(ps.output.includes(clearViewport));
 
 	for (const letter of ['A', 'B', 'C']) {
 		t.true(ps.output.includes(letter));
@@ -487,7 +492,7 @@ test.serial(
 		const ps = term('erase-with-static', ['4']);
 
 		await ps.waitForExit();
-		t.false(ps.output.includes(ansiEscapes.clearTerminal));
+		t.false(ps.output.includes(clearViewport));
 
 		for (const letter of ['A', 'B', 'C', 'D', 'E', 'F']) {
 			t.true(ps.output.includes(letter));
@@ -531,13 +536,13 @@ test.serial(
 			'Expected the inflate phase to have rendered as its own frame',
 		);
 		t.true(
-			ps.output.includes(ansiEscapes.clearTerminal),
+			ps.output.includes(clearViewport),
 			'Expected the overflow to have routed a frame through the full-clear path',
 		);
 
 		// The shrink frame's full clear is the last one; the lowercase "live-0"
 		// after it proves shrink and nudge rendered as separate frames.
-		const lastClearIndex = ps.output.lastIndexOf(ansiEscapes.clearTerminal);
+		const lastClearIndex = ps.output.lastIndexOf(clearViewport);
 		t.false(
 			ps.output.includes('live-4', lastClearIndex),
 			'Expected the last full clear to be the shrink frame, not the inflate frame',
@@ -560,7 +565,7 @@ test.serial(
 test.serial('erase screen', async t => {
 	const ps = term('erase', ['3']);
 	await ps.waitForExit();
-	t.true(ps.output.includes(ansiEscapes.clearTerminal));
+	t.true(ps.output.includes(clearViewport));
 
 	for (const letter of ['A', 'B', 'C']) {
 		t.true(ps.output.includes(letter));
@@ -572,7 +577,7 @@ test.serial(
 	async t => {
 		const ps = term('erase', ['3']);
 		await ps.waitForExit();
-		t.true(ps.output.includes(ansiEscapes.clearTerminal));
+		t.true(ps.output.includes(clearViewport));
 
 		for (const letter of ['A', 'B', 'C']) {
 			t.true(ps.output.includes(letter));
@@ -613,7 +618,7 @@ test.serial('erase screen where state changes in small viewport', async t => {
 	const ps = term('erase-with-state-change', ['3']);
 	await ps.waitForExit();
 
-	const frames = ps.output.split(ansiEscapes.clearTerminal);
+	const frames = ps.output.split(clearViewport);
 	const lastFrame = frames.at(-1);
 
 	for (const letter of ['A', 'B', 'C']) {
@@ -629,7 +634,7 @@ test.serial(
 
 		t.true(ps.output.includes('Bottom line'));
 
-		const lastFrame = ps.output.split(ansiEscapes.clearTerminal).at(-1) ?? '';
+		const lastFrame = ps.output.split(clearViewport).at(-1) ?? '';
 
 		// Check that the bottom line is at the end without extra newlines
 		// In a 5-line terminal:
@@ -654,7 +659,7 @@ test.serial(
 		const ps = term('issue-442-full-height', [String(rows)]);
 		await ps.waitForExit();
 
-		const lastFrame = ps.output.split(ansiEscapes.clearTerminal).at(-1) ?? '';
+		const lastFrame = ps.output.split(clearViewport).at(-1) ?? '';
 		const lastFrameContent = stripAnsi(lastFrame);
 		const lines = lastFrameContent.split('\n');
 
@@ -674,13 +679,13 @@ test.serial(
 test.serial(
 	'#450: full-height rerenders should not repeatedly clear terminal',
 	async t => {
-		const {output, clearTerminalCount, eraseLineCount} =
+		const {output, fullClearCount, eraseLineCount} =
 			await runIssue450FixtureWithCounts('issue-450-full-height-rerender');
 
 		assertIssue450DynamicFrameOutput(t, output);
 		t.true(
-			clearTerminalCount <= 1,
-			`Expected at most one clearTerminal sequence, received ${clearTerminalCount}`,
+			fullClearCount <= 1,
+			`Expected at most one clearTerminal sequence, received ${fullClearCount}`,
 		);
 		t.true(
 			eraseLineCount > 0,
@@ -699,11 +704,8 @@ test.serial(
 		assertIssue450DynamicFrameOutput(t, output);
 		// Windows consoles scroll when the bottom-right cell is written, which
 		// breaks incremental erase for fullscreen frames. Each rerender must fall
-		// back to a full clear there. The fixture process believes it is on
-		// Windows, so ansi-escapes may emit its legacy clearTerminal variant
-		// there (the host's os.release() decides), while this process resolves
-		// the modern one. Count the eraseScreen prefix shared by both variants.
-		const fullClearCount = countOccurrences(output, ansiEscapes.eraseScreen);
+		// back to a full clear there.
+		const fullClearCount = countOccurrences(output, clearViewport);
 		t.true(
 			fullClearCount >= 2,
 			`Expected a full clear per fullscreen rerender, received ${fullClearCount}`,
@@ -723,7 +725,7 @@ test.serial(
 		);
 
 		t.false(
-			outputBeforeMarker.includes(ansiEscapes.clearTerminal),
+			outputBeforeMarker.includes(clearViewport),
 			'Initial overflowing render should not clear terminal',
 		);
 	},
@@ -741,7 +743,7 @@ test.serial(
 		);
 
 		t.false(
-			outputBeforeMarker.includes(ansiEscapes.clearTerminal),
+			outputBeforeMarker.includes(clearViewport),
 			'Initial full-height render should not clear terminal',
 		);
 	},
@@ -750,15 +752,53 @@ test.serial(
 test.serial(
 	'#450 control: rows - 1 rerenders should avoid clearTerminal',
 	async t => {
-		const {output, clearTerminalCount, eraseLineCount} =
+		const {output, fullClearCount, eraseLineCount} =
 			await runIssue450FixtureWithCounts('issue-450-height-minus-one-rerender');
 
 		assertIssue450DynamicFrameOutput(t, output);
-		t.is(clearTerminalCount, 0);
+		t.is(fullClearCount, 0);
 		t.true(
 			eraseLineCount > 0,
 			'Expected incremental erase sequences for non-fullscreen rerenders',
 		);
+	},
+);
+
+test.serial(
+	'#935: overflowing rerenders must not erase terminal scrollback',
+	async t => {
+		const rows = 6;
+		const output = await runIssue450Fixture(
+			'issue-935-overflow-rerender',
+			rows,
+		);
+		const {fullClearCount} = getIssue450ControlSequenceCounts(output);
+
+		assertIssue450DynamicFrameOutput(t, output);
+		t.true(
+			fullClearCount >= 2,
+			`Expected a full clear per overflowing rerender, received ${fullClearCount}`,
+		);
+
+		// The fallback may only clear the viewport. CSI 3J erases the terminal's
+		// scrollback and CSI 2J makes VS Code / Windows Terminal push the viewport
+		// into scrollback before clearing, churning bounded history on every frame.
+		t.false(output.includes('\u001B[3J'), 'Must not emit CSI 3J');
+		t.false(output.includes(ansiEscapes.eraseScreen), 'Must not emit CSI 2J');
+		t.false(output.includes(ansiEscapes.clearTerminal));
+
+		const visibleLines = reconstructTerminalLines(output, rows);
+		for (let index = 0; index < rows; index++) {
+			t.true(
+				visibleLines.includes(`#935 scrollback ${index}`),
+				`Pre-existing scrollback line ${index} must survive rerenders`,
+			);
+		}
+
+		// The final viewport shows the last frame only, without stale rows.
+		const viewport = visibleLines.slice(-rows);
+		t.true(viewport.some(line => line.includes('frame 8')));
+		t.false(viewport.some(line => line.includes('frame 7')));
 	},
 );
 
@@ -771,11 +811,11 @@ test.serial(
 			'issue-450-full-height-rerender-with-marker',
 			renderedMarker,
 		);
-		const {clearTerminalCount} =
+		const {fullClearCount} =
 			getIssue450ControlSequenceCounts(outputBeforeMarker);
 
 		assertIssue450DynamicFrameOutput(t, outputBeforeMarker);
-		t.is(clearTerminalCount, 0);
+		t.is(fullClearCount, 0);
 	},
 );
 
@@ -788,48 +828,48 @@ test.serial(
 			'issue-450-grow-to-fullscreen-rerender',
 			renderedMarker,
 		);
-		const {clearTerminalCount} =
+		const {fullClearCount} =
 			getIssue450ControlSequenceCounts(outputBeforeMarker);
 
 		assertIssue450DynamicFrameOutput(t, outputBeforeMarker);
-		t.is(clearTerminalCount, 0);
+		t.is(fullClearCount, 0);
 	},
 );
 
 test.serial(
 	'#450: shrink from full-height to rows - 1 should clear exactly once',
 	async t => {
-		const {output, clearTerminalCount} = await runIssue450FixtureWithCounts(
+		const {output, fullClearCount} = await runIssue450FixtureWithCounts(
 			'issue-450-shrink-from-fullscreen-rerender',
 		);
 
 		assertIssue450DynamicFrameOutput(t, output);
-		t.is(clearTerminalCount, 1);
+		t.is(fullClearCount, 1);
 	},
 );
 
 test.serial(
 	'#450: shrink from overflow to rows - 1 should clear exactly once',
 	async t => {
-		const {output, clearTerminalCount} = await runIssue450FixtureWithCounts(
+		const {output, fullClearCount} = await runIssue450FixtureWithCounts(
 			'issue-450-shrink-from-overflow-rerender',
 		);
 
 		assertIssue450DynamicFrameOutput(t, output);
-		t.is(clearTerminalCount, 1);
+		t.is(fullClearCount, 1);
 	},
 );
 
 test.serial(
 	'#450: <Static> with shrink from full-height should clear exactly once',
 	async t => {
-		const {output, clearTerminalCount} = await runIssue450FixtureWithCounts(
+		const {output, fullClearCount} = await runIssue450FixtureWithCounts(
 			'issue-450-static-shrink-from-fullscreen-rerender',
 		);
 
 		t.true(output.includes('#450 static line'));
 		assertIssue450DynamicFrameOutput(t, output);
-		t.is(clearTerminalCount, 1);
+		t.is(fullClearCount, 1);
 	},
 );
 
@@ -865,10 +905,8 @@ test.serial(
 		rerender(<NonTtyRerenderTestComponent frameCount={1} />);
 		rerender(<NonTtyRerenderTestComponent frameCount={2} />);
 
-		const {clearTerminalCount} = getIssue450ControlSequenceCounts(
-			writes.join(''),
-		);
-		t.is(clearTerminalCount, 0);
+		const {fullClearCount} = getIssue450ControlSequenceCounts(writes.join(''));
+		t.is(fullClearCount, 0);
 
 		unmount();
 	},
@@ -902,10 +940,8 @@ test.serial(
 
 		rerender(<NonTtyOverflowTransitionTestComponent lineCount={4} />);
 
-		const {clearTerminalCount} = getIssue450ControlSequenceCounts(
-			writes.join(''),
-		);
-		t.is(clearTerminalCount, 0);
+		const {fullClearCount} = getIssue450ControlSequenceCounts(writes.join(''));
+		t.is(fullClearCount, 0);
 
 		unmount();
 	},
@@ -938,10 +974,8 @@ test.serial(
 		stdout.emit('resize');
 		await delay(0);
 
-		const {clearTerminalCount} = getIssue450ControlSequenceCounts(
-			writes.join(''),
-		);
-		t.is(clearTerminalCount, 1);
+		const {fullClearCount} = getIssue450ControlSequenceCounts(writes.join(''));
+		t.is(fullClearCount, 1);
 
 		unmount();
 	},
@@ -954,7 +988,7 @@ test.serial(
 			'issue-450-grow-to-overflow-rerender',
 			['3'],
 		);
-		t.false(output.includes(ansiEscapes.clearTerminal));
+		t.false(output.includes(clearViewport));
 	},
 );
 
@@ -986,7 +1020,7 @@ test.serial(
 test.serial(
 	'#450: full-height rerenders with <Static> should not repeatedly clear terminal',
 	async t => {
-		const {output, clearTerminalCount, eraseLineCount} =
+		const {output, fullClearCount, eraseLineCount} =
 			await runIssue450FixtureWithCounts(
 				'issue-450-full-height-with-static-rerender',
 			);
@@ -997,8 +1031,8 @@ test.serial(
 		);
 		assertIssue450DynamicFrameOutput(t, output);
 		t.true(
-			clearTerminalCount <= 1,
-			`Expected at most one clearTerminal sequence, received ${clearTerminalCount}`,
+			fullClearCount <= 1,
+			`Expected at most one clearTerminal sequence, received ${fullClearCount}`,
 		);
 		t.true(
 			eraseLineCount > 0,

--- a/test/render.tsx
+++ b/test/render.tsx
@@ -795,11 +795,12 @@ test.serial(
 			);
 		}
 
-		// The final viewport shows the last frame only. Frame 7's label is longer
-		// than frame 8's, so a missing or partial clear leaves `STALE-ROW` behind.
+		// The final viewport shows the last frame, and no stale row survives
+		// anywhere the user can see: frame 7's label is longer than every other
+		// frame's, so a missing or partial clear leaves `STALE-ROW` behind.
 		const viewport = visibleLines.slice(-rows);
 		t.true(viewport.some(line => line.includes('frame 8')));
-		t.false(viewport.some(line => line.includes('STALE-ROW')));
+		t.false(visibleLines.some(line => line.includes('STALE-ROW')));
 	},
 );
 


### PR DESCRIPTION
## Summary

Frames taller than the viewport fall back to a full clear on every re-render, and `ansiEscapes.clearTerminal` emits `CSI 3J`, which erases the terminal's scrollback. A ticking overflowing app, or a single resize, wipes the user's shell history (#935, #990).

This replaces the sequence with `ansiEscapes.cursorTo(0, 0) + ansiEscapes.eraseDown` (`CSI 1;1H CSI J`), as suggested in the #936 review. `eraseScreen` (`CSI 2J`) is not a safe replacement on its own: VS Code and Windows Terminal push the viewport into scrollback before clearing, so repeated redraws churn bounded history. Home + erase-down clears only what is visible.

Builds on #936 by moeritze and the terminal-matrix measurements razchiriac posted on #935, which confirmed home + erase-down preserves history with no model-dependent churn.

## Changes

- `src/ink.tsx`: full-clear path writes `homeAndEraseDown` (`cursorTo(0, 0) + eraseDown`) instead of `clearTerminal`. Exported so tests assert against the real sequence; deliberately not named `clearViewport`, which ansi-escapes already exports as `CSI 2J + CSI H`. Applies to the `#969` Windows path too: that path needs a full viewport clear per fullscreen frame, and home + erase-down provides one without `3J`.
- New fixture `issue-935-overflow-rerender`: prints scrollback lines, then renders a `rows + 1` frame eight times, with frame 7 carrying a longer `STALE-ROW` label so a missing or partial clear leaves residue behind.
- New test `#935: overflowing rerenders must not erase terminal scrollback`: asserts a full clear happens per rerender, `CSI 3J` / `CSI 2J` / `clearTerminal` are absent from the raw PTY output, the pre-existing scrollback lines survive when replayed through the existing `reconstructTerminalLines` reducer, the final viewport shows the last frame, and `STALE-ROW` is absent from the whole reconstructed buffer. Fails on master; also fails against `cursorTo(0, 0)` alone (no erase) and against `eraseScreen + home`.
- Existing byte-level assertions (`clearTerminalCount`, `split(clearTerminal)`, cursor sync-path check) updated to the new sequence and renamed `fullClearCount`.

## Verification

- `npm test`: 1063 passed, same 4 pre-existing known failures as master.
- Live tmux repro from #990 (80x24, 100 lines of shell history, 40-row app, one resize to 64 cols): master keeps 0 history lines after the resize, this branch keeps all 102.
- Ticking variant (40-row app re-rendering 3x/s for 4 s, then a resize), raw PTY bytes via `tmux pipe-pane`: ink@7.1.1 emits 18x `CSI 2J CSI 3J` and keeps 0 history lines; this branch emits 17x `CSI 1;1H CSI J`, no 2J/3J, keeps all 102.
- Same captures replayed through `@xterm/headless` 6.1.0-beta.301 with `scrollOnEraseInDisplay` off and on: published keeps 0/100 history lines in both; this branch keeps 100/100 with an identical 414-line buffer in both models. Swapping the sequence for `2J + home` in the same capture keeps history too but grows the buffer to 798 lines with `scrollOnEraseInDisplay` on, matching the #936 review's concern.
- Eyeballed side by side in Terminal.app on macOS 14: with this branch, scrolling up and resizing while the app ticks leaves the shell history intact; with ink@7.1.1 it is gone after the first redraw.

As noted in the #936 review, an oversized dynamic frame still consumes scrollback simply by being written, so this is best-effort preservation. Concretely: each full clear re-emits `fullStaticOutput` plus the frame from home, and the rows that scroll off the top now stay in history instead of being erased by `3J`, so a long-running overflowing render leaves duplicate copies of its top rows (including `<Static>` lines) in scrollback. That churn existed before too, `3J` just hid it by deleting everything. Apps with taller-than-viewport UI should still use the alternate screen or `<Static>`. This just stops Ink from actively destroying history.

Fixes #935
Fixes #990
Closes #936
